### PR TITLE
Report `utm_id` and `url` globally in `AnalyticsEventTracker` service

### DIFF
--- a/app/services/analytics-event-tracker.ts
+++ b/app/services/analytics-event-tracker.ts
@@ -1,14 +1,27 @@
 import Service, { service } from '@ember/service';
+import RouterService from '@ember/routing/router-service';
 import Store from '@ember-data/store';
 
 export default class AnalyticsEventTrackerService extends Service {
   @service declare store: Store;
+  @service declare router: RouterService;
+  @service utmCampaignIdTracker: unknown;
 
   track(eventName: string, eventProperties: Record<string, unknown>) {
+    const baseURL = `${window.location.protocol}//${window.location.host}`; // 'https://app.codecrafters.io
+
+    const defaultProperties = {
+      // @ts-ignore
+      utm_id: this.utmCampaignIdTracker.firstSeenCampaignId,
+      url: `${baseURL}${this.router.currentURL}`,
+    };
+
+    const mergedProperties = Object.assign(defaultProperties,  eventProperties);
+
     this.store
       .createRecord('analytics-event', {
         name: eventName,
-        properties: eventProperties,
+        properties: mergedProperties,
       })
       .save();
   }

--- a/app/services/page-view-tracker.js
+++ b/app/services/page-view-tracker.js
@@ -5,7 +5,6 @@ import { action } from '@ember/object';
 export default class PageViewTracker extends Service {
   @service analyticsEventTracker;
   @service router;
-  @service utmCampaignIdTracker;
 
   @action
   handleRouteChange(transition) {
@@ -13,12 +12,7 @@ export default class PageViewTracker extends Service {
       return;
     }
 
-    let baseURL = `${window.location.protocol}//${window.location.host}`; // 'https://app.codecrafters.io
-
-    this.analyticsEventTracker.track('viewed_page', {
-      utm_id: this.utmCampaignIdTracker.firstSeenCampaignId,
-      url: `${baseURL}${this.router.currentURL}`,
-    });
+    this.analyticsEventTracker.track('viewed_page');
   }
 
   setupListener() {


### PR DESCRIPTION
### Brief

In preparation for the [FastBoot PR](https://github.com/codecrafters-io/frontend/pull/542), this makes `AnalyticsEventTrackerService.track` method pass `utm_id` and `url` parameters for **all analytics events globally**, instead of just `PageViewTrackerService.handleRouteChange`.

### Details

This way, all analytics reporting can be _sent to void_ during a FastBoot run, and no explicit checks are required in other locations.

In addition, `PageViewTracker` doesn't require an explicit FastBoot check, as it doesn't need to access `window.location` for generating event parameters.