### PR TITLE
CC-678 allowed upgrade prompt to expand instead of being at a fixed w…

### DIFF
--- a/app/components/course-page/course-stage-step/upgrade-prompt.hbs
+++ b/app/components/course-page/course-stage-step/upgrade-prompt.hbs
@@ -5,7 +5,7 @@
   data-test-upgrade-prompt
   ...attributes
 >
-  <div class="max-w-3xl flex justify-between {{if this.isLarge 'mx-auto flex-row items-center' 'flex-col'}}">
+  <div class="flex justify-between {{if this.isLarge 'flex-row items-center' 'flex-col'}}">
     <div>
       <div class="font-bold text-slate-600 {{if this.isLarge 'text-2xl' 'text-xl'}}">
         This stage requires a<br />


### PR DESCRIPTION
…idth and centered

**Checklist**:

- [x] I've thoroughly self-reviewed my changes
- [x] I've added tests for my changes, unless they affect admin-only areas (or are otherwise not worth testing)
- [x] I've verified any visual changes using Percy (add a commit with `[percy]` in the message to trigger)
