### PR TITLE
CC-678 removed extensive wrapping for upgrade prompt copy

### DIFF
--- a/app/components/course-page/course-stage-step/upgrade-prompt.hbs
+++ b/app/components/course-page/course-stage-step/upgrade-prompt.hbs
@@ -8,11 +8,10 @@
   <div class="flex justify-between {{if this.isLarge 'flex-row items-center' 'flex-col'}}">
     <div>
       <div class="font-bold text-slate-600 {{if this.isLarge 'text-2xl' 'text-xl'}}">
-        This stage requires a<br />
-        CodeCrafters Membership.
+        This stage requires a CodeCrafters Membership.
       </div>
 
-      <div class="pt-3 pb-6 max-w-sm text-slate-700 {{if this.isLarge 'text-base' 'text-sm'}}" data-test-upgrade-prompt-secondary-copy>
+      <div class="pt-3 pb-6 text-slate-700 {{if this.isLarge 'text-base' 'text-sm'}}" data-test-upgrade-prompt-secondary-copy>
         {{#if this.isLoadingRegionalDiscount}}
           Plans start at $30/mo.
         {{else}}
@@ -27,12 +26,12 @@
       </PrimaryButton>
     </div>
 
-    <div class="flex flex-col gap-2 {{if this.isLarge 'mt-0' 'mt-10'}}">
+    <div class="flex flex-col gap-2 ml-4 grow-0 shrink-0 {{if this.isLarge 'mt-0' 'mt-10'}}">
       {{#each this.featureList as |feature|}}
         <div class="flex gap-4">
-          {{svg-jar "check" class="w-8 h-8 p-1 fill-current rounded bg-teal-500 text-white"}}
+          {{svg-jar "check" class="w-8 h-8 p-1 fill-current rounded bg-teal-500 text-white grow-0 shrink-0"}}
 
-          <div class="rounded bg-white border border-slate-200 px-4 text-slate-600 flex items-center">
+          <div class="rounded bg-white border border-slate-200 px-4 text-slate-600 flex items-center w-fit grow-0 shrink-0">
             {{feature}}
           </div>
         </div>


### PR DESCRIPTION
**Checklist**:

- [x] I've thoroughly self-reviewed my changes
- [x] I've added tests for my changes, unless they affect admin-only areas (or are otherwise not worth testing)
- [x] I've verified any visual changes using Percy (add a commit with `[percy]` in the message to trigger)
