### PR TITLE
CC-668 use created_at to sort tester versions

### DIFF
--- a/app/controllers/course-admin/tester-versions.ts
+++ b/app/controllers/course-admin/tester-versions.ts
@@ -36,6 +36,6 @@ export default class CourseTesterVersionsController extends Controller {
 
 
   get sortedTesterVersions() {
-    return this.model.course.testerVersions.sortBy('lastSyncedAt').reverse();
+    return this.model.course.testerVersions.sortBy('createdAt').reverse();
   }
 }


### PR DESCRIPTION
**Checklist**:

- [x] I've thoroughly self-reviewed my changes
- [x] I've added tests for my changes, unless they affect admin-only areas (or are otherwise not worth testing)
- [x] I've verified any visual changes using Percy (add a commit with `[percy]` in the message to trigger)
