### PR TITLE
Contextual back<>next switching

### DIFF
--- a/app/components/course-page/step-switcher-container.hbs
+++ b/app/components/course-page/step-switcher-container.hbs
@@ -2,8 +2,8 @@
 <div class="inline-flex rounded items-stretch shadow-sm select-none" ...attributes>
   {{#if this.previousStep}}
     <LinkTo
-      @route={{this.previousStep.routeParams.route}}
-      @models={{this.previousStep.routeParams.models}}
+      @route={{this.previousStepRouteParams.route}}
+      @models={{this.previousStepRouteParams.models}}
       @replace={{true}}
       class="rounded-l border-r-0 flex items-center border border-gray-300 transition-colors duration-75 pl-1 pr-2 py-1.5 text-gray-500 bg-white hover:bg-gray-50 hover:text-gray-500"
       data-test-previous-stage-button
@@ -25,8 +25,8 @@
 
   {{#if this.nextStep}}
     <LinkTo
-      @route={{this.nextStep.routeParams.route}}
-      @models={{this.nextStep.routeParams.models}}
+      @route={{this.nextStepRouteParams.route}}
+      @models={{this.nextStepRouteParams.models}}
       @replace={{true}}
       class="rounded-r border-l-0 flex items-center border border-gray-300 transition-colors duration-75 pr-1 pl-2 py-1.5 text-gray-500 bg-white hover:bg-gray-50 hover:text-gray-500"
       data-test-next-stage-button

--- a/app/components/course-page/step-switcher-container.ts
+++ b/app/components/course-page/step-switcher-container.ts
@@ -1,5 +1,7 @@
 import Component from '@glimmer/component';
+import RouterService from '@ember/routing/router-service';
 import { Step, StepList } from 'codecrafters-frontend/lib/course-page-step-list';
+import { service } from '@ember/service';
 
 type Signature = {
   Element: HTMLDivElement;
@@ -11,12 +13,22 @@ type Signature = {
 };
 
 export default class StepSwitcherComponent extends Component<Signature> {
+  @service router!: RouterService;
+
   get nextStep() {
     return this.args.stepList.nextVisibleStepFor(this.args.currentStep);
   }
 
+  get nextStepRouteParams() {
+    return this.nextStep?.contextualRouteParamsFor(this.router.currentRouteName);
+  }
+
   get previousStep() {
     return this.args.stepList.previousVisibleStepFor(this.args.currentStep);
+  }
+
+  get previousStepRouteParams() {
+    return this.previousStep?.contextualRouteParamsFor(this.router.currentRouteName);
   }
 }
 

--- a/app/lib/course-page-step-list/course-stage-step.ts
+++ b/app/lib/course-page-step-list/course-stage-step.ts
@@ -28,6 +28,18 @@ export default class CourseStageStep extends Step {
     return this.completedAt && isYesterday(this.completedAt);
   }
 
+  // If a user is on course.stage.concepts, we want to redirect them to course.stage.concepts
+  contextualRouteParamsFor(route: string) {
+    if (route.startsWith('course.stage')) {
+      return {
+        ...this.routeParams,
+        route: route,
+      };
+    } else {
+      return this.routeParams;
+    }
+  }
+
   get progressIndicator(): ProgressIndicator | null {
     if (this.testsStatus === 'evaluating') {
       return {
@@ -113,7 +125,11 @@ export default class CourseStageStep extends Step {
     if (this.lastFailedSubmissionWasWithinLast10Minutes) {
       return 'Tests failed.';
     } else if (this.lastFailedSubmissionCreatedAt) {
-      return `Last attempt ${formatDistanceStrictWithOptions({ addSuffix: true }, new Date(), this.lastFailedSubmissionCreatedAt || new Date())}. Try again?`;
+      return `Last attempt ${formatDistanceStrictWithOptions(
+        { addSuffix: true },
+        new Date(),
+        this.lastFailedSubmissionCreatedAt || new Date(),
+      )}. Try again?`;
     } else {
       return 'Last attempt failed. Try again?';
     }

--- a/app/lib/course-page-step-list/step.ts
+++ b/app/lib/course-page-step-list/step.ts
@@ -7,6 +7,11 @@ export default class Step {
     this.position = position;
   }
 
+  // Allows steps to redirect to nested routes if they choose to
+  contextualRouteParamsFor(_route: string): { route: string; models: string[] } {
+    return this.routeParams;
+  }
+
   get routeParams(): { route: string; models: string[] } {
     throw new Error('Subclasses of Step must implement a routeParams getter');
   }


### PR DESCRIPTION
The step switcher container component in the course page was using incorrect route parameters for the previous and next steps. This was causing issues with navigation. The fix updates the route parameters to use the correct properties. Additionally, the step and course stage step classes were updated to include a contextualRouteParamsFor method, allowing steps to redirect to nested routes if needed.
