### PR TITLE
Fix tests that fail because of wrong Port being checked

### DIFF
--- a/tests/acceptance/pay-test.js
+++ b/tests/acceptance/pay-test.js
@@ -7,7 +7,7 @@ import { signIn } from 'codecrafters-frontend/tests/support/authentication-helpe
 import payPage from 'codecrafters-frontend/tests/pages/pay-page';
 import percySnapshot from '@percy/ember';
 import testScenario from 'codecrafters-frontend/mirage/scenarios/test';
-import window from 'ember-window-mock';
+import windowMock from 'ember-window-mock';
 
 module('Acceptance | pay-test', function (hooks) {
   setupApplicationTest(hooks);
@@ -26,8 +26,8 @@ module('Acceptance | pay-test', function (hooks) {
     }
 
     assert.strictEqual(
-      window.location.href,
-      `${window.location.origin}/login?next=http%3A%2F%2Flocalhost%3A7357%2Fpay`,
+      windowMock.location.href,
+      `${windowMock.location.origin}/login?next=http%3A%2F%2Flocalhost%3A${window.location.port}%2Fpay`,
       'should redirect to login URL',
     );
   });

--- a/tests/acceptance/referral-link-page/accept-referral-offer-test.js
+++ b/tests/acceptance/referral-link-page/accept-referral-offer-test.js
@@ -8,7 +8,7 @@ import { setupMirage } from 'ember-cli-mirage/test-support';
 import { setupWindowMock } from 'ember-window-mock/test-support';
 import { signIn } from 'codecrafters-frontend/tests/support/authentication-helpers';
 import percySnapshot from '@percy/ember';
-import window from 'ember-window-mock';
+import windowMock from 'ember-window-mock';
 
 module('Acceptance | referral-link-page | accept-referral-offer', function (hooks) {
   setupApplicationTest(hooks);
@@ -25,8 +25,8 @@ module('Acceptance | referral-link-page | accept-referral-offer', function (hook
     await referralLinkPage.acceptReferralButton.click();
 
     assert.strictEqual(
-      window.location.href,
-      `${window.location.origin}/login?next=http%3A%2F%2Flocalhost%3A7357%2Fjoin%3Fvia%3Dreferral1`,
+      windowMock.location.href,
+      `${windowMock.location.origin}/login?next=http%3A%2F%2Flocalhost%3A${window.location.port}%2Fjoin%3Fvia%3Dreferral1`,
       'should redirect to login URL',
     );
   });


### PR DESCRIPTION
### Brief

Two tests were failing locally because they expected `window.location.port` to be `7357`, a hard-coded value. This fixes them.

### Details

Looks like `ember-window-mock` does not proxy `window.location.port` correctly. By using original `window` instead of mocked, the tests are fixed.

**Checklist**:

- [x] I've thoroughly self-reviewed my changes
- [x] I've added tests for my changes, unless they affect admin-only areas (or are otherwise not worth testing)