### PR TITLE
Replace `kategengler/ember-cli-code-coverage` with `ember-cli-code-co…

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -89,7 +89,7 @@
         "ember-cli-app-version": "^6.0.1",
         "ember-cli-babel": "^8.0.0",
         "ember-cli-bundle-analyzer": "^1.0.0",
-        "ember-cli-code-coverage": "https://gitpkg.now.sh/kategengler/ember-cli-code-coverage/packages/ember-cli-code-coverage?master",
+        "ember-cli-code-coverage": "https://gitpkg.now.sh/ember-cli-code-coverage/ember-cli-code-coverage/packages/ember-cli-code-coverage?master",
         "ember-cli-dependency-checker": "^3.3.2",
         "ember-cli-deprecation-workflow": "^2.0.0",
         "ember-cli-fastboot": "^4.1.1",
@@ -22661,8 +22661,8 @@
     },
     "node_modules/ember-cli-code-coverage": {
       "version": "2.0.0",
-      "resolved": "https://gitpkg.now.sh/kategengler/ember-cli-code-coverage/packages/ember-cli-code-coverage?master",
-      "integrity": "sha512-qFE2XMRcHKllSecHtGm5h89oqss0KMTi4GHt/GTJHWdcix1qoFJrnj9nLEtct2EFLE6jerR13W+kio9AIdcVpA==",
+      "resolved": "https://gitpkg.now.sh/ember-cli-code-coverage/ember-cli-code-coverage/packages/ember-cli-code-coverage?master",
+      "integrity": "sha512-Q33vk0/hRsuwQJDlEKFMpMM2Rhhht9Kv4ibY4YfTQVvnFpaIIeP9PTEfD+Y4AVetYVUGqBvJQJkR/xyF8cXy1g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -73109,8 +73109,8 @@
       }
     },
     "ember-cli-code-coverage": {
-      "version": "https://gitpkg.now.sh/kategengler/ember-cli-code-coverage/packages/ember-cli-code-coverage?master",
-      "integrity": "sha512-qFE2XMRcHKllSecHtGm5h89oqss0KMTi4GHt/GTJHWdcix1qoFJrnj9nLEtct2EFLE6jerR13W+kio9AIdcVpA==",
+      "version": "https://gitpkg.now.sh/ember-cli-code-coverage/ember-cli-code-coverage/packages/ember-cli-code-coverage?master",
+      "integrity": "sha512-Q33vk0/hRsuwQJDlEKFMpMM2Rhhht9Kv4ibY4YfTQVvnFpaIIeP9PTEfD+Y4AVetYVUGqBvJQJkR/xyF8cXy1g==",
       "dev": true,
       "requires": {
         "babel-plugin-istanbul": "^6.0.0",

--- a/package.json
+++ b/package.json
@@ -94,7 +94,7 @@
     "ember-cli-app-version": "^6.0.1",
     "ember-cli-babel": "^8.0.0",
     "ember-cli-bundle-analyzer": "^1.0.0",
-    "ember-cli-code-coverage": "https://gitpkg.now.sh/kategengler/ember-cli-code-coverage/packages/ember-cli-code-coverage?master",
+    "ember-cli-code-coverage": "https://gitpkg.now.sh/ember-cli-code-coverage/ember-cli-code-coverage/packages/ember-cli-code-coverage?master",
     "ember-cli-dependency-checker": "^3.3.2",
     "ember-cli-deprecation-workflow": "^2.0.0",
     "ember-cli-fastboot": "^4.1.1",


### PR DESCRIPTION
### Brief

After wiping out `node_modules` and running `npm install`, an error started occuring due to a sha checksum mismatch.

### Details

Replacing `kategengler/ember-cli-code-coverage` with `ember-cli-code-coverage/ember-cli-code-coverage` fixes the problem.

**Checklist**:

- [x] I've thoroughly self-reviewed my changes
- [x] I've added tests for my changes, unless they affect admin-only areas (or are otherwise not worth testing)
- [x] I've verified any visual changes using Percy (add a commit with `[percy]` in the message to trigger)
