### PR TITLE
Use proper `href`, `origin`, and `port` in View Screencasts tests

### DIFF
--- a/tests/acceptance/course-page/view-screencasts-test.js
+++ b/tests/acceptance/course-page/view-screencasts-test.js
@@ -2,12 +2,12 @@
 import catalogPage from 'codecrafters-frontend/tests/pages/catalog-page';
 import coursePage from 'codecrafters-frontend/tests/pages/course-page';
 import testScenario from 'codecrafters-frontend/mirage/scenarios/test';
-import window from 'ember-window-mock';
 import { module, test } from 'qunit';
 import { setupAnimationTest } from 'ember-animated/test-support';
 import { setupApplicationTest } from 'ember-qunit';
 import { setupMirage } from 'ember-cli-mirage/test-support';
 import { setupWindowMock } from 'ember-window-mock/test-support';
+import windowMock from 'ember-window-mock';
 import { signInAsStaff } from 'codecrafters-frontend/tests/support/authentication-helpers';
 import { visit } from '@ember/test-helpers';
 
@@ -29,8 +29,8 @@ module('Acceptance | course-page | view-screencasts-test', function (hooks) {
     }
 
     assert.strictEqual(
-      window.location.href,
-      `${window.location.origin}/login?next=http%3A%2F%2Flocalhost%3A7357%2Fcourses%2Fredis%2Fstages%2F2%2Fscreencasts`,
+      windowMock.location.href,
+      `${windowMock.location.origin}/login?next=http%3A%2F%2Flocalhost%3A${window.location.port}%2Fcourses%2Fredis%2Fstages%2F2%2Fscreencasts`,
       'should redirect to login URL',
     );
   });


### PR DESCRIPTION
### Brief

When running tests locally on port other than `7357`, for example on default port `4200`, View Screencasts tests are failing.

### Details

This fixes the tests by using `window` (original) and `windowMock` (from `ember-window-mock`) appropriately in the assertions. For some reason `location.port` in empty in `windowMock`.

**Checklist**:

- [x] I've thoroughly self-reviewed my changes
- [x] I've added tests for my changes, unless they affect admin-only areas (or are otherwise not worth testing)
- [x] I've verified any visual changes using Percy (add a commit with `[percy]` in the message to trigger)
