### PR TITLE
Update autofix result template and autofix request model

### DIFF
--- a/app/components/course-page/test-results-bar/autofix-section/autofix-result.hbs
+++ b/app/components/course-page/test-results-bar/autofix-section/autofix-result.hbs
@@ -4,22 +4,33 @@
       {{#if (eq @autofixRequest.status "in_progress")}}
         <BlinkingDot @color="yellow" />
         <span class="font-mono text-xs text-white">Autofix in progress... (the logs below will be verbose, we'll summarize them once completed)</span>
-      {{else}}
+      {{else if (eq @autofixRequest.status "failure")}}
+        <StaticDot @color="red" />
+        <span class="font-mono text-xs text-white">Autofix failed</span>
+      {{else if (eq @autofixRequest.status "error")}}
+        <StaticDot @color="red" />
+        <span class="font-mono text-xs text-white">Internal error (Our engineers have been notified of this!)</span>
+      {{else if (eq @autofixRequest.status "cancelled")}}
+        <StaticDot @color="gray" />
+        <span class="font-mono text-xs text-white">Autofix cancelled</span>
+      {{else if (eq @autofixRequest.status "success")}}
         <StaticDot @color="green" />
         <span class="font-mono text-xs text-white">Autofix success</span>
       {{/if}}
     </div>
-    <div
-      class="text-gray-400 underline text-xs px-3 py-2 inline-flex hover:text-gray-300"
-      {{on "click" (fn (mut this.shouldShowFullLog) (not this.shouldShowFullLog))}}
-      role="button"
-    >
-      {{#if this.shouldShowFullLog}}
-        Show summary
-      {{else}}
-        Show Full Log
-      {{/if}}
-    </div>
+    {{#unless (eq @autofixRequest.status "in_progress")}}
+      <div
+        class="text-gray-400 underline text-xs px-3 py-2 inline-flex hover:text-gray-300"
+        {{on "click" (fn (mut this.shouldShowFullLog) (not this.shouldShowFullLog))}}
+        role="button"
+      >
+        {{#if this.shouldShowFullLog}}
+          Show summary
+        {{else}}
+          Show Full Log
+        {{/if}}
+      </div>
+    {{/unless}}
   </div>
 
   {{#if (eq @autofixRequest.status "in_progress")}}
@@ -42,7 +53,7 @@
           <pre class="font-mono text-xs text-white whitespace-pre-wrap"><code>{{ansi-to-html @autofixRequest.logs}}</code></pre>
         </div>
       </div>
-    {{else}}
+    {{else if (eq @autofixRequest.status "success")}}
       <div class="flex-grow overflow-y-auto">
         <div class="prose prose-sm dark:prose-invert">
           {{!-- {{markdown-to-html @autofixRequest.explanationMarkdown}} --}}
@@ -61,6 +72,30 @@
             @language={{@autofixRequest.submission.repository.language.slug}}
           />
         {{/each}}
+      </div>
+    {{else if (eq @autofixRequest.status "failure")}}
+      <div class="flex-grow overflow-y-auto">
+        <div class="prose prose-sm dark:prose-invert">
+          <p>
+            We failed to generate an autofix for your submission. You can click on "Show Full Log" to see what we tried.
+          </p>
+        </div>
+      </div>
+    {{else if (eq @autofixRequest.status "error")}}
+      <div class="flex-grow overflow-y-auto">
+        <div class="prose prose-sm dark:prose-invert">
+          <p>
+            We encountered an internal error while generating an autofix for your submission. Our engineers have been notified of this!
+          </p>
+        </div>
+      </div>
+    {{else if (eq @autofixRequest.status "cancelled")}}
+      <div class="flex-grow overflow-y-auto">
+        <div class="prose prose-sm dark:prose-invert">
+          <p>
+            This autofix was cancelled.
+          </p>
+        </div>
       </div>
     {{/if}}
   {{/if}}

--- a/app/models/autofix-request.ts
+++ b/app/models/autofix-request.ts
@@ -12,7 +12,7 @@ export default class AutofixRequestModel extends Model {
   @attr('string') declare explanationMarkdown: string;
   @attr('string') declare logstreamId: string; // For streaming logs when status is in_progress
   @attr('string') declare logsBase64: string; // Base64-encoded logs
-  @attr('string') declare status: string; // 'in_progress' | 'success' | 'failure' | 'internal_error'
+  @attr('string') declare status: string; // 'in_progress' | 'success' | 'failure' | 'error'
 
   get logs(): string {
     return atob(this.logsBase64);


### PR DESCRIPTION
The changes in this commit update the autofix result template and the autofix request model.

In the autofix result template, the changes include:
- Adding conditions to display different messages based on the autofix request status (in_progress, failure, error, cancelled, success)
- Adding a button to show or hide the full log
- Adding different sections to display different messages and content based on the autofix request status

In the autofix request model, the changes include:
- Updating the status attribute to include 'error' instead of 'internal_error'

These changes improve the display and handling of autofix results in the application.
