### PR TITLE
Fix a flood warning about unsafe `style` binding during tests

### DIFF
--- a/app/components/course-stage-difficulty-label.hbs
+++ b/app/components/course-stage-difficulty-label.hbs
@@ -6,7 +6,7 @@
       {{! template-lint-disable no-inline-styles }}
       <div
         class="{{if (gte this.numberOfBars currentBarNumber) this.barColorClass 'bg-gray-300'}}"
-        style="width: 4px; height: {{add 0.5 (mult 0.2 currentBarNumber)}}em; margin-right: 2px; border-radius: 1px;"
+        style={{html-safe (concat "width: 4px; margin-right: 2px; border-radius: 1px; height: " (add 0.5 (mult 0.2 currentBarNumber)) "em;")}}
       ></div>
     {{/each}}
   </div>


### PR DESCRIPTION
### Brief

Our `CourseStageDifficultyLabelComponent` is currently using an unsafe way to bind the `style` attribute dynamically to assign a calculated `height` to an element.

This generates a flood of warnings, to an extent that when visiting `localhost:4200/tests` with browser console open — the console freezes within half a minute, due to an enormous amount of output.

<img width="860" alt="Знімок екрана 2024-01-14 о 15 23 19" src="https://github.com/codecrafters-io/frontend/assets/493875/93235ebf-0b19-45f7-9b71-f11768d80bb3">

### Details

This wraps the dynamically-bound `style` into an `html-safe` helper, and together with `concat` — builds the correct style, without warnings.

### Checklist

- [x] I've thoroughly self-reviewed my changes
- [x] I've added tests for my changes, unless they affect admin-only areas (or are otherwise not worth testing)
- [x] I've verified any visual changes using Percy (add a commit with `[percy]` in the message to trigger)
