### PR TITLE
Package `@ember/error` is deprecated, native `Error` should be used

### DIFF
--- a/app/components/concept-admin/blocks-page.ts
+++ b/app/components/concept-admin/blocks-page.ts
@@ -2,7 +2,6 @@ import Component from '@glimmer/component';
 import ConceptModel, { type Block } from 'codecrafters-frontend/models/concept';
 import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
-import Error from '@ember/error';
 import type Transition from '@ember/routing/transition';
 
 type Signature = {


### PR DESCRIPTION
Related to #993 

### Brief

Package `@ember/error` is deprecated, native `Error` should be used. This brings the number of failing tests in the [Ember 5 branch](https://github.com/codecrafters-io/frontend/pull/1161) down from 15 to 10.

### Details

This package is no longer present in Ember 5, and [it is suggested](https://deprecations.emberjs.com/v4.x/#toc_deprecate-ember-error) to replace it with native `Error` usages:

<img width="588" alt="Знімок екрана 2024-01-19 о 13 06 44" src="https://github.com/codecrafters-io/frontend/assets/493875/ac21cfef-168f-4752-8294-abb9321f32f0">


### Checklist

- [x] I've thoroughly self-reviewed my changes
- [x] I've added tests for my changes, unless they affect admin-only areas (or are otherwise not worth testing)
- [x] I've verified any visual changes using Percy (add a commit with `[percy]` in the message to trigger)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Removed the `Error` import from the list of imports in the `blocks-page.ts` file.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->