### PR TITLE
Replace remaining usages of `firstObject` with `objectAt(0)`

### DIFF
--- a/app/components/referral-link-page/accept-referral-container.ts
+++ b/app/components/referral-link-page/accept-referral-container.ts
@@ -84,7 +84,7 @@ export default class AcceptReferralContainerComponent extends Component<Signatur
         user_id: this.currentUser?.id,
       });
 
-      this.freeUsageGrantExpiresAt = format(freeUsageGrant.firstObject?.expiresAt, 'dd MMM yyyy');
+      this.freeUsageGrantExpiresAt = format(freeUsageGrant.objectAt(0)?.expiresAt, 'dd MMM yyyy');
       this.isAccepted = true;
     }
   }

--- a/app/routes/perk.ts
+++ b/app/routes/perk.ts
@@ -12,6 +12,6 @@ export default class PerkRoute extends BaseRoute {
   async model(params: { slug: string }) {
     const perk = await this.store.query('perk', { slug: params.slug });
 
-    return perk.firstObject;
+    return perk.objectAt(0);
   }
 }

--- a/app/routes/referral-link.ts
+++ b/app/routes/referral-link.ts
@@ -38,11 +38,11 @@ export default class ReferralLinkRoute extends BaseRoute {
         user_id: this.authenticator.currentUser?.id,
       });
 
-      acceptedReferralOfferFreeUsageGrant = acceptedReferralOfferFreeUsageGrants.firstObject;
+      acceptedReferralOfferFreeUsageGrant = acceptedReferralOfferFreeUsageGrants.objectAt(0);
     }
 
     return {
-      referralLink: referralLinks.firstObject,
+      referralLink: referralLinks.objectAt(0),
       acceptedReferralOfferFreeUsageGrant: acceptedReferralOfferFreeUsageGrant,
     };
   }


### PR DESCRIPTION
Related to #993 

### Brief

This replaces all remaining usages of `firstObject`, previously conflicting with TypeScript types, to `objectAt(0)`. TypeScript is happy, and this brings down the number of failing tests in the [Ember 5 Branch](https://github.com/codecrafters-io/frontend/pull/1161) from 10 to 0 🎉 .

### Details

* Replaced all remaining usages of `.firstObject` with `.objectAt(0)`
* Did NOT replace remaining usages of `.lastObject` — it's a bit less trivial, and tests are already passing without this

### Checklist

- [x] I've thoroughly self-reviewed my changes
- [x] I've added tests for my changes, unless they affect admin-only areas (or are otherwise not worth testing)
- [x] I've verified any visual changes using Percy (add a commit with `[percy]` in the message to trigger)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Updated access to array elements for improved code consistency and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->