### PR TITLE
CC-924 : Add Analytics event call for revealed autofix diff.

### DIFF
--- a/app/components/course-page/test-results-bar/autofix-section/autofix-result.hbs
+++ b/app/components/course-page/test-results-bar/autofix-section/autofix-result.hbs
@@ -75,7 +75,7 @@
           >Learn more</a>.
         </div>
 
-        <BlurredOverlay @isBlurred={{this.diffIsBlurred}} @onUnblur={{fn (mut this.diffIsBlurred) false}}>
+        <BlurredOverlay @isBlurred={{this.diffIsBlurred}} @onUnblur={{this.toggleBlur}}>
           {{#each @autofixRequest.changedFiles key="filename" as |changedFile|}}
             <FileDiffCard
               class="mt-6"

--- a/app/components/course-page/test-results-bar/autofix-section/autofix-result.ts
+++ b/app/components/course-page/test-results-bar/autofix-section/autofix-result.ts
@@ -1,3 +1,4 @@
+import AnalyticsEventTrackerService from 'codecrafters-frontend/services/analytics-event-tracker';
 import type Store from '@ember-data/store';
 import { action } from '@ember/object';
 import { service } from '@ember/service';
@@ -18,6 +19,7 @@ type Signature = {
 export default class AutofixResultComponent extends Component<Signature> {
   @service declare store: Store;
   @service declare actionCableConsumer: ActionCableConsumerService;
+  @service declare analyticsEventTracker: AnalyticsEventTrackerService;
 
   @tracked logstream: Logstream | null = null;
   @tracked shouldShowFullLog = false;
@@ -47,6 +49,15 @@ export default class AutofixResultComponent extends Component<Signature> {
     if (this.logstream) {
       this.logstream.unsubscribe();
     }
+  }
+
+  @action
+  toggleBlur() {
+    if (this.diffIsBlurred) {
+      this.analyticsEventTracker.track('revealed_autofix_request_diff', { autofix_request_id: this.args.autofixRequest.id });
+    }
+
+    this.diffIsBlurred = !this.diffIsBlurred;
   }
 }
 


### PR DESCRIPTION
**Checklist**:

- [X] I've thoroughly self-reviewed my changes
- [ ] I've added tests for my changes, unless they affect admin-only areas (or are otherwise not worth testing)
- [ ] I've verified any visual changes using Percy (add a commit with `[percy]` in the message to trigger)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced the user interaction with blurred content, allowing for a toggle feature within the course results page.
  
- **Improvements**
	- Integrated analytics tracking to monitor user engagement when revealing test result details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->