### PR TITLE
chore: remove deprecated network protocol link

### DIFF
--- a/app/models/course-stage.ts
+++ b/app/models/course-stage.ts
@@ -118,7 +118,6 @@ Before attempting this stage, we recommend familiarizing yourself with:
 
 Our interactive concepts can help with this:
 
-- [Network Protocols](https://app.codecrafters.io/concepts/network-protocols) — Learn about various network protocols and the TCP/IP model.
 - [TCP: An Overview](https://app.codecrafters.io/concepts/tcp-overview) — Learn about the TCP protocol and how it works
 {{#lang_is_go}}- [TCP Servers in Go](https://app.codecrafters.io/concepts/go-tcp-server) — Learn how to write TCP servers using Go's net package{{/lang_is_go}}{{#lang_is_rust}}- [TCP Servers in Rust](https://app.codecrafters.io/concepts/rust-tcp-server) — Learn how to write TCP servers using Rust's std::net module{{/lang_is_rust}}
       `;


### PR DESCRIPTION
**Checklist**:

- [ ] I've thoroughly self-reviewed my changes
- [ ] I've added tests for my changes, unless they affect admin-only areas (or are otherwise not worth testing)
- [ ] I've verified any visual changes using Percy (add a commit with `[percy]` in the message to trigger)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Updated the course content structure, including the removal of "Network Protocols" reference and link adjustments for interactive concepts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->