### PR TITLE
Fix warnings in test "Acceptance | contests-test: header navigation buttons work"

### DIFF
--- a/app/components/contest-page/navigation.hbs
+++ b/app/components/contest-page/navigation.hbs
@@ -3,6 +3,7 @@
     <LinkTo
       @route="contest"
       @model={{this.previousContest.slug}}
+      @disabled={{this.isPreviousContestDisabled}}
       class="flex items-center rounded-l-md border border-r-[0.5px] border-gray-800 hover:border-gray-700 hover:bg-gray-900 px-2 py-1.5
         {{if this.isPreviousContestDisabled 'pointer-events-none opacity-50'}}"
       data-test-previous-contest-button
@@ -16,6 +17,7 @@
     <LinkTo
       @route="contest"
       @model={{this.nextContest.slug}}
+      @disabled={{this.isNextContestDisabled}}
       class="flex items-center rounded-r-md border border-l-[0.5px] border-gray-800 hover:border-gray-700 hover:bg-gray-900 px-2 py-1.5
         {{if this.isNextContestDisabled 'pointer-events-none opacity-50'}}"
       data-test-next-contest-button


### PR DESCRIPTION
### Brief

There's a new warning that appeared recently when running tests, coming from `tests/acceptance/contests-test.js`. It clicks on a `LinkTo` whose model is set to `null`.

> WARNING: This link is in an inactive loading state because at least one of its models currently has a null/undefined value, or the provided route name is invalid.

<img width="685" alt="Знімок екрана 2024-02-04 о 13 44 02" src="https://github.com/codecrafters-io/frontend/assets/493875/ea527597-af3d-499a-a4b2-184685ac809c">


### Details

Pass a `@disabled` argument to the `LinkTo`'s in `app/components/contest-page/navigation.hbs`, bound to `isPreviousContestDisabled` and `isNextContestDisabled` properties, to truly disable the links and prevent `click` from happening and generating a warning.

Ember's [`LinkTo` Component](https://api.emberjs.com/ember/release/classes/Ember.Templates.components/methods/LinkTo?anchor=LinkTo) supports `@disabled` natively.

### Checklist

- [x] I've thoroughly self-reviewed my changes
- [x] I've added tests for my changes, unless they affect admin-only areas (or are otherwise not worth testing)
- [ ] I've verified any visual changes using Percy (add a commit with `[percy]` in the message to trigger)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
    - Added disabled attribute binding for previous and next contest buttons in the navigation component.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->