### PR TITLE
Update free course tooltip

### DIFF
--- a/app/components/free-course-label.ts
+++ b/app/components/free-course-label.ts
@@ -35,7 +35,7 @@ export default class FreeCourseLabelComponent extends Component<Signature> {
   }
 
   get tooltipCopy(): string {
-    return `This course is free until ${format(this.args.course.isFreeUntil as Date, 'd MMMM yyyy')}!`;
+    return `This challenge is free until ${format(this.args.course.isFreeUntil as Date, 'd MMMM yyyy')}!`;
   }
 
   get tooltipSide(): 'top' | 'bottom' | 'left' | 'right' {

--- a/app/templates/course-overview.hbs
+++ b/app/templates/course-overview.hbs
@@ -11,9 +11,8 @@
         </Alert>
       {{else if this.model.course.isFreeUntil}}
         <Alert @type="success" class="mb-4" data-test-course-free-notice>
-          We're keeping this course free until
-          {{this.formattedCourseIsFreeExpirationDate}}
-          to gather feedback.
+          This challenge is free until
+          {{this.formattedCourseIsFreeExpirationDate}}!
         </Alert>
       {{/if}}
 

--- a/tests/acceptance/course-page/view-course-stages-test.js
+++ b/tests/acceptance/course-page/view-course-stages-test.js
@@ -755,7 +755,7 @@ module('Acceptance | course-page | view-course-stages-test', function (hooks) {
     await coursePage.freeCourseLabel.hover();
 
     assertTooltipContent(assert, {
-      contentString: 'This course is free until 16 January 2024!',
+      contentString: 'This challenge is free until 16 January 2024!',
     });
   });
 

--- a/tests/acceptance/view-course-overview-test.js
+++ b/tests/acceptance/view-course-overview-test.js
@@ -96,7 +96,7 @@ module('Acceptance | view-course-overview', function (hooks) {
     await catalogPage.visit();
     await catalogPage.clickOnCourse('Build your own Redis');
 
-    assert.strictEqual(courseOverviewPage.freeNoticeText, "We're keeping this course free until 21 January 2024 to gather feedback.");
+    assert.strictEqual(courseOverviewPage.freeNoticeText, 'This challenge is free until 21 January 2024!');
   });
 
   test('stages for extensions are ordered properly', async function (assert) {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Updated the tooltip message for free courses to provide a clearer notification about the free availability period.
	- Enhanced the message displayed in the course overview template to emphasize the free nature of challenges until a specific date.
	- Improved the tooltip content on the course page to clearly indicate the free status until a specific date.
	- Updated the text on the course overview page to emphasize the free status until a specific date.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->