### PR TITLE
CC-977 automatically insert 'click_to_continue' block on save

### DIFF
--- a/app/components/concept-admin/blocks-page.ts
+++ b/app/components/concept-admin/blocks-page.ts
@@ -113,10 +113,12 @@ export default class BlocksPageComponent extends Component<Signature> {
     });
 
     if (blocks[blocks.length - 1]?.type !== 'click_to_continue') {
-      blocks.push(new ClickToContinueBlock({
-        type: 'click_to_continue',
-        args: {}
-      }));
+      blocks.push(
+        new ClickToContinueBlock({
+          type: 'click_to_continue',
+          args: {},
+        }),
+      );
     }
 
     return blocks.map((block) => block.toJSON);

--- a/tests/acceptance/concept-admin/edit-blocks-test.js
+++ b/tests/acceptance/concept-admin/edit-blocks-test.js
@@ -8,11 +8,11 @@ import blocksPage from 'codecrafters-frontend/tests/pages/concept-admin/blocks-p
 import testScenario from 'codecrafters-frontend/mirage/scenarios/test';
 import percySnapshot from '@percy/ember';
 
-module('Acceptance | concept-admin | edit-blocks', function(hooks) {
+module('Acceptance | concept-admin | edit-blocks', function (hooks) {
   setupApplicationTest(hooks);
   setupMirage(hooks);
 
-  test('can add/edit/delete markdown blocks', async function(assert) {
+  test('can add/edit/delete markdown blocks', async function (assert) {
     testScenario(this.server);
     signInAsStaff(this.owner, this.server);
 
@@ -73,7 +73,7 @@ module('Acceptance | concept-admin | edit-blocks', function(hooks) {
     assert.strictEqual(blocksPage.editableBlocks.length, 4, 'expected 4 editable blocks to be present');
   });
 
-  test('can reorder markdown blocks', async function(assert) {
+  test('can reorder markdown blocks', async function (assert) {
     testScenario(this.server);
     signInAsStaff(this.owner, this.server);
 
@@ -118,7 +118,7 @@ module('Acceptance | concept-admin | edit-blocks', function(hooks) {
     assert.strictEqual(blocksPage.editableBlocks[4].preview.text, 'block 4');
   });
 
-  test('dragging block to same position does not cause changes', async function(assert) {
+  test('dragging block to same position does not cause changes', async function (assert) {
     testScenario(this.server);
     signInAsStaff(this.owner, this.server);
 
@@ -150,7 +150,7 @@ module('Acceptance | concept-admin | edit-blocks', function(hooks) {
     assert.strictEqual(blocksPage.editableBlocks[1].preview.text, 'block 2');
   });
 
-  test('can add/edit question blocks', async function(assert) {
+  test('can add/edit question blocks', async function (assert) {
     testScenario(this.server);
     signInAsStaff(this.owner, this.server);
 
@@ -187,7 +187,7 @@ module('Acceptance | concept-admin | edit-blocks', function(hooks) {
     assert.strictEqual(blocksPage.editableBlocks.length, 2, 'expected 2 editable blocks to be present');
   });
 
-  test('click to continue block is automatically added when changes are published', async function(assert) {
+  test('click to continue block is automatically added when changes are published', async function (assert) {
     testScenario(this.server);
     signInAsStaff(this.owner, this.server);
 
@@ -218,6 +218,6 @@ module('Acceptance | concept-admin | edit-blocks', function(hooks) {
     await settled(); // Investigate why clickable() doesn't call settled()
 
     assert.strictEqual(blocksPage.editableBlocks.length, 4, 'expected 4 editable blocks to be present');
-    assert.ok(blocksPage.editableBlocks[3].text.includes('Continue'), 'expected the last block to be a click to continue block')
+    assert.ok(blocksPage.editableBlocks[3].text.includes('Continue'), 'expected the last block to be a click to continue block');
   });
 });


### PR DESCRIPTION
**Checklist**:

- [x] I've thoroughly self-reviewed my changes
- [x] I've added tests for my changes, unless they affect admin-only areas (or are otherwise not worth testing)
- [ ] I've verified any visual changes using Percy (add a commit with `[percy]` in the message to trigger)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced an automatic addition of a "click to continue" block in the concept admin interface to enhance user navigation and content interaction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->