### PR TITLE
feat: add login tooltip for anonymous users in StageListItemComponent

### DIFF
--- a/app/components/track-page/course-card/stage-list-item.hbs
+++ b/app/components/track-page/course-card/stage-list-item.hbs
@@ -1,5 +1,11 @@
-<div class="w-full" ...attributes data-test-stage-list-item>
-  <div class="flex items-center justify-between mb-3">
+<LinkTo
+  @route="course.stage.instructions"
+  @models={{array @stage.course.slug @stage.identifierForURL}}
+  class="block hover:bg-gray-50 py-1.5 -mx-1.5 px-1.5 rounded"
+  data-test-stage-list-item
+  ...attributes
+>
+  <div class="flex items-center justify-between">
     <div class="flex items-center">
       <div class="w-2 h-2 {{if @isComplete 'bg-teal-500' 'bg-gray-200'}} rounded-full mr-2"></div>
 
@@ -19,4 +25,8 @@
       </div>
     {{/if}}
   </div>
-</div>
+
+  {{#if this.authenticator.isAnonymous}}
+    <EmberTooltip @text="Login via GitHub to view this stage" />
+  {{/if}}
+</LinkTo>

--- a/app/components/track-page/course-card/stage-list-item.ts
+++ b/app/components/track-page/course-card/stage-list-item.ts
@@ -1,8 +1,10 @@
+import { service } from '@ember/service';
 import Component from '@glimmer/component';
 import type CourseStageModel from 'codecrafters-frontend/models/course-stage';
+import type AuthenticatorService from 'codecrafters-frontend/services/authenticator';
 
 type Signature = {
-  Element: HTMLDivElement;
+  Element: HTMLAnchorElement;
 
   Args: {
     isComplete: boolean;
@@ -10,7 +12,9 @@ type Signature = {
   };
 };
 
-export default class StageListItemComponent extends Component<Signature> {}
+export default class StageListItemComponent extends Component<Signature> {
+  @service declare authenticator: AuthenticatorService;
+}
 
 declare module '@glint/environment-ember-loose/registry' {
   export default interface Registry {


### PR DESCRIPTION
The changes in this commit add a login tooltip for anonymous users in the StageListItemComponent. When an anonymous user hovers over a stage item, a tooltip will appear with the text "Login via GitHub to view this stage". This provides a prompt for anonymous users to log in and access the stage content.

**Checklist**:

- [ ] I've thoroughly self-reviewed my changes
- [ ] I've added tests for my changes, unless they affect admin-only areas (or are otherwise not worth testing)
- [ ] I've verified any visual changes using Percy (add a commit with `[percy]` in the message to trigger)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced navigation by introducing clickable stages that directly link to their respective content.
- **Improvements**
	- Conditional tooltips now provide additional guidance based on user authentication status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->