### PR TITLE
Add release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,29 @@
+name: Release
+
+on:
+  push:
+    branches:
+      - master
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  release:
+    runs-on: 'namespace-profile-frontend' # Change this to namespace-profile-frontend-light if we're low on namespace credits
+    timeout-minutes: 10
+
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Create Sentry release
+        uses: getsentry/action-release@v1
+        env:
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+          SENTRY_ORG: 'codecrafters'
+          SENTRY_PROJECT: 'frontend'
+        with:
+          environment: production


### PR DESCRIPTION
This is an integration commit for the virtual branches that GitButler is tracking.

Due to GitButler managing multiple virtual branches, you cannot switch back and forth between git branches and virtual branches easily. 

If you switch to another branch, GitButler will need to be reinitialized. If you commit on this branch, GitButler will throw it away.

Here are the branches that are currently applied:
 - Add sentry release action (refs/gitbutler/add-sentry-release-action) branch head: b2f80be1cf357892dcfd1448c7a3ef7f25501472
   - .github/workflows/release.yml

Your previous branch was: refs/heads/add-tracks-controller-and-catalog-route

The sha for that commit was: b2790304e0debfd861dba5c30d1f1b8e222726fc

For more information about what we're doing here, check out our docs: https://docs.gitbutler.com/features/virtual-branches/integration-branch

**Checklist**:

- [ ] I've thoroughly self-reviewed my changes
- [ ] I've added tests for my changes, unless they affect admin-only areas (or are otherwise not worth testing)
- [ ] I've verified any visual changes using Percy (add a commit with `[percy]` in the message to trigger)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Implemented a new GitHub Actions workflow to automate Sentry releases for the 'codecrafters/frontend' project upon pushes to the master branch.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->