### PR TITLE
CC-1005 handle missing perk slugs in claim url

### DIFF
--- a/app/routes/perk.ts
+++ b/app/routes/perk.ts
@@ -1,5 +1,6 @@
 import AuthenticatorService from 'codecrafters-frontend/services/authenticator';
 import BaseRoute from 'codecrafters-frontend/utils/base-route';
+import PerkModel from 'codecrafters-frontend/models/perk';
 import RouterService from '@ember/routing/router-service';
 import Store from '@ember-data/store';
 import { inject as service } from '@ember/service';
@@ -8,6 +9,12 @@ export default class PerkRoute extends BaseRoute {
   @service declare authenticator: AuthenticatorService;
   @service declare router: RouterService;
   @service declare store: Store;
+
+  afterModel(model: PerkModel) {
+    if (!model) {
+      this.router.transitionTo('not-found');
+    }
+  }
 
   async model(params: { slug: string }) {
     const perk = await this.store.query('perk', { slug: params.slug });

--- a/tests/acceptance/perks-page/claim-test.js
+++ b/tests/acceptance/perks-page/claim-test.js
@@ -31,4 +31,13 @@ module('Acceptance | perks-page | claim-test', function (hooks) {
 
     assert.strictEqual(currentURL(), '/pay');
   });
+
+  test('it is redirected to /404 if perk slug is invalid', async function (assert) {
+    testScenario(this.server);
+    signIn(this.owner, this.server);
+
+    await visit('/perks/invalid-slug/claim');
+
+    assert.strictEqual(currentURL(), '/404');
+  });
 });


### PR DESCRIPTION
**Checklist**:

- [x] I've thoroughly self-reviewed my changes
- [x] I've added tests for my changes, unless they affect admin-only areas (or are otherwise not worth testing)
- [ ] I've verified any visual changes using Percy (add a commit with `[percy]` in the message to trigger)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit


- **New Features**
	- Introduced handling for missing perks, redirecting users to a 'not-found' page if a perk doesn't exist.
- **Tests**
	- Added tests to ensure proper redirection for invalid perk links.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->