### PR TITLE
Run confetti for all stages, not just repository setup

### DIFF
--- a/app/components/course-page/setup-step/repository-setup-card.hbs
+++ b/app/components/course-page/setup-step/repository-setup-card.hbs
@@ -8,7 +8,7 @@
     <CoursePage::SetupStep::RepositorySetupCard::CloneRepositoryStep @repository={{@repository}} @isComplete={{this.isComplete}} />
 
     {{#if this.isComplete}}
-      <p class="text-gray-600 mt-4" {{did-insert this.handleDidInsertStepCompletedMessage}}>
+      <p class="text-gray-600 mt-4">
         <span class="text-xl mr-1">🎉</span>
         Git push received! The first stage is now activated.
       </p>

--- a/app/components/course-page/setup-step/repository-setup-card.ts
+++ b/app/components/course-page/setup-step/repository-setup-card.ts
@@ -2,9 +2,6 @@ import Component from '@glimmer/component';
 import { inject as service } from '@ember/service';
 import type RepositoryModel from 'codecrafters-frontend/models/repository';
 import type CoursePageStateService from 'codecrafters-frontend/services/course-page-state';
-import { action } from '@ember/object';
-import type ConfettiService from 'codecrafters-frontend/services/confetti';
-import { tracked } from 'tracked-built-ins';
 
 export type Signature = {
   Element: HTMLDivElement;
@@ -16,28 +13,9 @@ export type Signature = {
 
 export default class RepositorySetupCardComponent extends Component<Signature> {
   @service declare coursePageState: CoursePageStateService;
-  @service declare confetti: ConfettiService;
-
-  @tracked isCompleteOriginallyWas: boolean | undefined;
-
-  constructor(owner: unknown, args: Signature['Args']) {
-    super(owner, args);
-
-    this.isCompleteOriginallyWas = this.isComplete;
-  }
 
   get isComplete() {
     return this.coursePageState.currentStep.status === 'complete';
-  }
-
-  @action
-  handleDidInsertStepCompletedMessage(_element: HTMLParagraphElement) {
-    if (this.isComplete && !this.isCompleteOriginallyWas) {
-      this.confetti.fireOnFocus({
-        particleCount: 200,
-        spread: 120,
-      });
-    }
   }
 }
 

--- a/app/controllers/course.ts
+++ b/app/controllers/course.ts
@@ -2,6 +2,7 @@ import { action } from '@ember/object';
 import { inject as service } from '@ember/service';
 import { next } from '@ember/runloop';
 import { tracked } from '@glimmer/tracking';
+import type ConfettiService from 'codecrafters-frontend/services/confetti';
 import Controller from '@ember/controller';
 import RepositoryPoller from 'codecrafters-frontend/utils/repository-poller';
 import config from 'codecrafters-frontend/config/environment';
@@ -14,6 +15,8 @@ import type VisibilityService from 'codecrafters-frontend/services/visibility';
 import type ActionCableConsumerService from 'codecrafters-frontend/services/action-cable-consumer';
 import type RepositoryModel from 'codecrafters-frontend/models/repository';
 import type { ModelType } from 'codecrafters-frontend/routes/course';
+import type { Step } from 'codecrafters-frontend/utils/course-page-step-list';
+import type { StepStatus, StepType } from 'codecrafters-frontend/utils/course-page-step-list/step';
 
 export default class CourseController extends Controller {
   declare model: ModelType;
@@ -24,6 +27,7 @@ export default class CourseController extends Controller {
 
   @service declare actionCableConsumer: ActionCableConsumerService;
   @service declare authenticator: AuthenticatorService;
+  @service declare confetti: ConfettiService;
   @service declare coursePageState: CoursePageStateService;
   @service declare store: Store;
   @service declare router: RouterService;
@@ -40,6 +44,11 @@ export default class CourseController extends Controller {
   @tracked sidebarIsExpandedOnDesktop = true;
   @tracked sidebarIsExpandedOnMobile = false;
   @tracked leaderboardIsExpanded = true;
+
+  // Used for deciding when to fire confetting
+  @tracked stepStatusPreviouslyWas: StepStatus | null = null;
+  @tracked stepIdPreviouslyWas: string | null = null;
+  @tracked stepTypePreviouslyWas: StepType | null = null;
 
   get currentUser() {
     return this.authenticator.currentUser;
@@ -140,6 +149,26 @@ export default class CourseController extends Controller {
   @action
   setupRouteChangeListeners() {
     this.router.on('routeDidChange', this.handleRouteChanged);
+  }
+
+  @action
+  setOrUpdateCurrentStepValues(_: HTMLDivElement, [step, _id, _status, _type]: [Step, string, string, string]) {
+    const stepIsCompleteButNotPreviouslyComplete =
+      step.status === 'complete' && this.stepStatusPreviouslyWas && this.stepStatusPreviouslyWas !== 'complete';
+
+    const stepHasNotChanged = this.stepIdPreviouslyWas === step.id && this.stepTypePreviouslyWas === step.type;
+    const stepIsSetupOrCourseStageStep = step.type === 'CourseStageStep' || step.type === 'SetupStep';
+
+    if (stepIsSetupOrCourseStageStep && stepIsCompleteButNotPreviouslyComplete && stepHasNotChanged) {
+      this.confetti.fireOnFocus({
+        particleCount: 200,
+        spread: 120,
+      });
+    }
+
+    this.stepStatusPreviouslyWas = step.status;
+    this.stepIdPreviouslyWas = step.id;
+    this.stepTypePreviouslyWas = step.type;
   }
 
   startRepositoryPoller() {

--- a/app/templates/course.hbs
+++ b/app/templates/course.hbs
@@ -5,6 +5,20 @@
   {{did-insert this.handleDidInsertContainer}}
   {{will-destroy this.handleWillDestroyContainer}}
   {{did-update this.handleDidUpdateActiveRepositoryId @model.activeRepository.id}}
+  {{did-insert
+    this.setOrUpdateCurrentStepValues
+    this.coursePageState.currentStep
+    this.coursePageState.currentStep.id
+    this.coursePageState.currentStep.status
+    this.coursePageState.currentStep.type
+  }}
+  {{did-update
+    this.setOrUpdateCurrentStepValues
+    this.coursePageState.currentStep
+    this.coursePageState.currentStep.id
+    this.coursePageState.currentStep.status
+    this.coursePageState.currentStep.type
+  }}
 >
   {{#if this.isDevelopmentOrTest}}
     <FakeDataToolbar @repository={{@model.activeRepository}} class="absolute top-4 left-4 hidden" />
@@ -67,7 +81,6 @@
       @nextStep={{this.coursePageState.nextStep}}
       class="px-3 md:px-6 lg:pl-10 bg-gray-50"
     />
-
     <div class="flex flex-grow bg-white">
 
       <div class="flex-grow flex-shrink min-w-0">

--- a/app/utils/course-page-step-list/step.ts
+++ b/app/utils/course-page-step-list/step.ts
@@ -1,6 +1,22 @@
 import type ProgressIndicator from 'codecrafters-frontend/utils/course-page-step-list/progress-indicator';
 import { type ProgressIndicatorWithDot } from 'codecrafters-frontend/utils/course-page-step-list/progress-indicator';
 
+export type StepType =
+  | 'IntroductionStep'
+  | 'SetupStep'
+  | 'CourseStageStep'
+  | 'BaseStagesCompletedStep'
+  | 'ExtensionCompletedStep'
+  | 'CourseCompletedStep';
+
+// Status definitions:
+//
+// - complete: the step has been completed
+// - not_started: the step hasn't been started yet
+// - in_progress: the step is in progress
+// - locked: the step isn't ready to be worked on (it might depend on other steps)
+export type StepStatus = 'complete' | 'not_started' | 'in_progress' | 'locked';
+
 export default class Step {
   declare globalPosition: number; // Set soon after construction
   declare positionInGroup: number; // Set soon after construction
@@ -11,6 +27,10 @@ export default class Step {
     }
 
     return "You've completed this step.";
+  }
+
+  get id(): string {
+    return `${this.routeParams.route}-${this.routeParams.models.join('-')}`;
   }
 
   get isHidden(): boolean {
@@ -57,13 +77,7 @@ export default class Step {
     return this.title;
   }
 
-  // Status definitions:
-  //
-  // - complete: the step has been completed
-  // - not_started: the step hasn't been started yet
-  // - in_progress: the step is in progress
-  // - locked: the step isn't ready to be worked on (it might depend on other steps)
-  get status(): 'complete' | 'not_started' | 'in_progress' | 'locked' {
+  get status(): StepStatus {
     throw new Error('Subclasses of Step must implement a status getter');
   }
 
@@ -71,7 +85,7 @@ export default class Step {
     throw new Error('Subclasses of Step must implement a title getter');
   }
 
-  get type(): 'IntroductionStep' | 'SetupStep' | 'CourseStageStep' | 'BaseStagesCompletedStep' | 'ExtensionCompletedStep' | 'CourseCompletedStep' {
+  get type(): StepType {
     throw new Error('Subclasses of Step must implement a routeParams getter');
   }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced `StepType` and `StepStatus` enums to enhance course step management.
	- Added new logic to fire confetti upon completing specific steps in a course.
- **Refactor**
	- Removed `confetti` service and related completion logic from `RepositorySetupCardComponent`.
	- Updated course page logic to better handle step changes and confetti firing.
- **Style**
	- Adjusted `repository-setup-card` UI to remove the activation message's `did-insert` modifier.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->