### PR TITLE
CC-1011 add share button to concepts

### DIFF
--- a/app/components/concept-page/content.hbs
+++ b/app/components/concept-page/content.hbs
@@ -53,7 +53,7 @@
                   Learnt something new? Share it with a friend.
                 </span>
 
-                <CopyableCode @code={{this.conceptUrl}} @onCopyButtonClick={{this.handleCopyButtonClick}} />
+                <CopyableCode @code={{@concept.url}} @onCopyButtonClick={{this.handleCopyButtonClick}} />
               </div>
             </div>
 

--- a/app/components/concept-page/content.hbs
+++ b/app/components/concept-page/content.hbs
@@ -34,7 +34,7 @@
               You've completed this concept!
             </div>
 
-            <FeedbackButton @source="concept_completed" class="mr-4" as |dd|>
+            <FeedbackButton @source="concept_completed" class="mr-4 mb-16" as |dd|>
               <div
                 role="button"
                 class="rounded border
@@ -45,31 +45,28 @@
                 Share Feedback
               </div>
             </FeedbackButton>
-          </div>
 
-          <div>
-            {{#animated-if this.nextConcept}}
-              <div class="py-12" {{did-insert this.handleUpcomingConceptInserted}} data-test-upcoming-concept>
+            <div class="pt-16 pb-8 border-t w-full" data-test-share-concept-container>
+              <div class="flex flex-col items-start gap-4 border rounded shadow-sm p-4">
+                <span class="flex gap-2 items-center text-gray-700 text-sm">
+                  {{svg-jar "gift" class="w-5 text-teal-500"}}
+                  Learnt something new? Share it with a friend.
+                </span>
+
+                <CopyableCode @code={{this.conceptUrl}} @onCopyButtonClick={{this.handleCopyButtonClick}} />
+              </div>
+            </div>
+
+            {{#if this.nextConcept}}
+              <div class="py-8" data-test-upcoming-concept>
                 <div class="text-lg text-center text-gray-800 mb-8" data-test-upcoming-concept-title>
                   Next up in
                   {{@conceptGroup.title}}:
                 </div>
 
-                {{! @glint-expect-error not ts-ified yet}}
                 <ConceptsPage::ConceptCard @concept={{this.nextConcept}} />
               </div>
-            {{/animated-if}}
-          </div>
-
-          <div class="py-12 border-t" {{did-insert this.handleShareConceptContainerInserted}} data-test-share-concept-container>
-            <div class="flex flex-col items-start gap-4 border rounded shadow-sm p-4">
-              <span class="flex gap-2 items-center text-gray-700 text-sm">
-                {{svg-jar "gift" class="w-5 text-teal-500"}}
-                Learnt something new? Share it with a friend.
-              </span>
-
-              <CopyableCode @code={{this.conceptUrl}} @onCopyButtonClick={{this.handleCopyButtonClick}} />
-            </div>
+            {{/if}}
           </div>
         {{/animated-if}}
       </div>

--- a/app/components/concept-page/content.hbs
+++ b/app/components/concept-page/content.hbs
@@ -60,6 +60,17 @@
               </div>
             {{/animated-if}}
           </div>
+
+          <div class="py-12 border-t" {{did-insert this.handleShareConceptContainerInserted}}>
+            <div class="flex flex-col items-start gap-4 border rounded shadow-sm p-4">
+              <span class="flex gap-2 items-baseline">
+                {{svg-jar "gift" class="w-5 text-teal-500"}}
+                Learnt something new? Share it with a friend.
+              </span>
+
+              <CopyableCode @code={{this.conceptUrl}} />
+            </div>
+          </div>
         {{/animated-if}}
       </div>
 

--- a/app/components/concept-page/content.hbs
+++ b/app/components/concept-page/content.hbs
@@ -68,7 +68,7 @@
                 Learnt something new? Share it with a friend.
               </span>
 
-              <CopyableCode @code={{this.conceptUrl}} />
+              <CopyableCode @code={{this.conceptUrl}} @onCopyButtonClick={{this.handleCopyButtonClick}} />
             </div>
           </div>
         {{/animated-if}}

--- a/app/components/concept-page/content.hbs
+++ b/app/components/concept-page/content.hbs
@@ -63,7 +63,7 @@
 
           <div class="py-12 border-t" {{did-insert this.handleShareConceptContainerInserted}} data-test-share-concept-container>
             <div class="flex flex-col items-start gap-4 border rounded shadow-sm p-4">
-              <span class="flex gap-2 items-baseline">
+              <span class="flex gap-2 items-center text-gray-700 text-sm">
                 {{svg-jar "gift" class="w-5 text-teal-500"}}
                 Learnt something new? Share it with a friend.
               </span>

--- a/app/components/concept-page/content.hbs
+++ b/app/components/concept-page/content.hbs
@@ -68,7 +68,7 @@
                 Learnt something new? Share it with a friend.
               </span>
 
-              <CopyableCode @code={{this.conceptUrl}} @onCopyButtonClick={{this.handleCopyButtonClick}} data-test-copy-button />
+              <CopyableCode @code={{this.conceptUrl}} @onCopyButtonClick={{this.handleCopyButtonClick}} />
             </div>
           </div>
         {{/animated-if}}

--- a/app/components/concept-page/content.hbs
+++ b/app/components/concept-page/content.hbs
@@ -68,7 +68,7 @@
                 Learnt something new? Share it with a friend.
               </span>
 
-              <CopyableCode @code={{this.conceptUrl}} @onCopyButtonClick={{this.handleCopyButtonClick}} />
+              <CopyableCode @code={{this.conceptUrl}} @onCopyButtonClick={{this.handleCopyButtonClick}} data-test-copy-button />
             </div>
           </div>
         {{/animated-if}}

--- a/app/components/concept-page/content.hbs
+++ b/app/components/concept-page/content.hbs
@@ -49,7 +49,7 @@
 
           <div>
             {{#animated-if this.nextConcept}}
-              <div class="py-16" {{did-insert this.handleUpcomingConceptInserted}} data-test-upcoming-concept>
+              <div class="py-12" {{did-insert this.handleUpcomingConceptInserted}} data-test-upcoming-concept>
                 <div class="text-lg text-center text-gray-800 mb-8" data-test-upcoming-concept-title>
                   Next up in
                   {{@conceptGroup.title}}:
@@ -61,7 +61,7 @@
             {{/animated-if}}
           </div>
 
-          <div class="py-12 border-t" {{did-insert this.handleShareConceptContainerInserted}}>
+          <div class="py-12 border-t" {{did-insert this.handleShareConceptContainerInserted}} data-test-share-concept-container>
             <div class="flex flex-col items-start gap-4 border rounded shadow-sm p-4">
               <span class="flex gap-2 items-baseline">
                 {{svg-jar "gift" class="w-5 text-teal-500"}}

--- a/app/components/concept-page/content.ts
+++ b/app/components/concept-page/content.ts
@@ -52,14 +52,4 @@ export default class ContentComponent extends Component<Signature> {
   handleProgressPercentageChanged(progressPercentage: number) {
     this.currentProgressPercentage = progressPercentage;
   }
-
-  @action
-  handleShareConceptContainerInserted(element: HTMLElement) {
-    element.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
-  }
-
-  @action
-  handleUpcomingConceptInserted(element: HTMLElement) {
-    element.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
-  }
 }

--- a/app/components/concept-page/content.ts
+++ b/app/components/concept-page/content.ts
@@ -39,7 +39,7 @@ export default class ContentComponent extends Component<Signature> {
 
   @action
   handleCopyButtonClick() {
-    this.analyticsEventTracker.track('clicked_on_share_concept_button', {
+    this.analyticsEventTracker.track('clicked_share_concept_button', {
       concept_id: this.args.concept.id,
     });
   }

--- a/app/components/concept-page/content.ts
+++ b/app/components/concept-page/content.ts
@@ -16,7 +16,7 @@ export default class ContentComponent extends Component<Signature> {
   @tracked currentProgressPercentage = 0;
 
   get conceptUrl() {
-    return `https://app.codecrafters.io/concepts/${this.args.concept.slug}`
+    return `https://app.codecrafters.io/concepts/${this.args.concept.slug}`;
   }
 
   get hasCompletedConcept() {

--- a/app/components/concept-page/content.ts
+++ b/app/components/concept-page/content.ts
@@ -19,10 +19,6 @@ export default class ContentComponent extends Component<Signature> {
 
   @tracked currentProgressPercentage = 0;
 
-  get conceptUrl() {
-    return `https://app.codecrafters.io/concepts/${this.args.concept.slug}`;
-  }
-
   get hasCompletedConcept() {
     return this.currentProgressPercentage === 100;
   }

--- a/app/components/concept-page/content.ts
+++ b/app/components/concept-page/content.ts
@@ -44,7 +44,7 @@ export default class ContentComponent extends Component<Signature> {
   @action
   handleCopyButtonClick() {
     this.analyticsEventTracker.track('clicked_on_share_concept_button', {
-      concept_id: this.args.concept.id
+      concept_id: this.args.concept.id,
     });
   }
 

--- a/app/components/concept-page/content.ts
+++ b/app/components/concept-page/content.ts
@@ -15,6 +15,10 @@ interface Signature {
 export default class ContentComponent extends Component<Signature> {
   @tracked currentProgressPercentage = 0;
 
+  get conceptUrl() {
+    return `https://app.codecrafters.io/concepts/${this.args.concept.slug}`
+  }
+
   get hasCompletedConcept() {
     return this.currentProgressPercentage === 100;
   }
@@ -36,6 +40,11 @@ export default class ContentComponent extends Component<Signature> {
   @action
   handleProgressPercentageChanged(progressPercentage: number) {
     this.currentProgressPercentage = progressPercentage;
+  }
+
+  @action
+  handleShareConceptContainerInserted(element: HTMLElement) {
+    element.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
   }
 
   @action

--- a/app/components/concept-page/content.ts
+++ b/app/components/concept-page/content.ts
@@ -1,7 +1,9 @@
+import type AnalyticsEventTrackerService from 'codecrafters-frontend/services/analytics-event-tracker';
 import Component from '@glimmer/component';
 import ConceptGroupModel from 'codecrafters-frontend/models/concept-group';
 import ConceptModel from 'codecrafters-frontend/models/concept';
 import { action } from '@ember/object';
+import { inject as service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 
 interface Signature {
@@ -13,6 +15,8 @@ interface Signature {
 }
 
 export default class ContentComponent extends Component<Signature> {
+  @service declare analyticsEventTracker: AnalyticsEventTrackerService;
+
   @tracked currentProgressPercentage = 0;
 
   get conceptUrl() {
@@ -35,6 +39,13 @@ export default class ContentComponent extends Component<Signature> {
   @action
   handleConceptDidUpdate() {
     this.currentProgressPercentage = 0;
+  }
+
+  @action
+  handleCopyButtonClick() {
+    this.analyticsEventTracker.track('clicked_on_share_concept_button', {
+      concept_id: this.args.concept.id
+    });
   }
 
   @action

--- a/app/components/copyable-code.hbs
+++ b/app/components/copyable-code.hbs
@@ -10,6 +10,7 @@
       type="button"
       class="bg-teal-600 px-3 py-1 text-white flex items-center rounded-r rounded-l-none text-sm font-bold"
       {{on "click" this.handleCopyButtonClick}}
+      data-test-copy-button
     >
       {{if this.codeWasCopiedRecently "COPIED" "COPY"}}
     </button>

--- a/app/components/copyable-code.ts
+++ b/app/components/copyable-code.ts
@@ -8,7 +8,7 @@ interface Signature {
 
   Args: {
     code: string;
-  }
+  };
 }
 
 export default class CopyableCodeComponent extends Component<Signature> {

--- a/app/components/copyable-code.ts
+++ b/app/components/copyable-code.ts
@@ -1,5 +1,5 @@
 import Component from '@glimmer/component';
-import window from 'ember-window-mock';
+import config from 'codecrafters-frontend/config/environment';
 import { action } from '@ember/object';
 import { later } from '@ember/runloop';
 import { tracked } from '@glimmer/tracking';
@@ -18,7 +18,9 @@ export default class CopyableCodeComponent extends Component<Signature> {
 
   @action
   handleCopyButtonClick() {
-    window.navigator.clipboard.writeText(this.args.code);
+    if (config.environment !== 'test') {
+      navigator.clipboard.writeText(this.args.code);
+    }
 
     this.codeWasCopiedRecently = true;
 

--- a/app/components/copyable-code.ts
+++ b/app/components/copyable-code.ts
@@ -8,6 +8,7 @@ interface Signature {
 
   Args: {
     code: string;
+    onCopyButtonClick?: () => void;
   };
 }
 
@@ -27,6 +28,10 @@ export default class CopyableCodeComponent extends Component<Signature> {
       },
       1000,
     );
+
+    if (this.args.onCopyButtonClick) {
+      this.args.onCopyButtonClick();
+    }
   }
 }
 

--- a/app/components/copyable-code.ts
+++ b/app/components/copyable-code.ts
@@ -1,4 +1,5 @@
 import Component from '@glimmer/component';
+import window from 'ember-window-mock';
 import { action } from '@ember/object';
 import { later } from '@ember/runloop';
 import { tracked } from '@glimmer/tracking';
@@ -17,7 +18,7 @@ export default class CopyableCodeComponent extends Component<Signature> {
 
   @action
   handleCopyButtonClick() {
-    navigator.clipboard.writeText(this.args.code);
+    window.navigator.clipboard.writeText(this.args.code);
 
     this.codeWasCopiedRecently = true;
 

--- a/app/components/copyable-code.ts
+++ b/app/components/copyable-code.ts
@@ -3,8 +3,16 @@ import { action } from '@ember/object';
 import { later } from '@ember/runloop';
 import { tracked } from '@glimmer/tracking';
 
-export default class CopyableCodeComponent extends Component {
-  @tracked codeWasCopiedRecently;
+interface Signature {
+  Element: HTMLElement;
+
+  Args: {
+    code: string;
+  }
+}
+
+export default class CopyableCodeComponent extends Component<Signature> {
+  @tracked codeWasCopiedRecently: boolean = false;
 
   @action
   handleCopyButtonClick() {
@@ -19,5 +27,11 @@ export default class CopyableCodeComponent extends Component {
       },
       1000,
     );
+  }
+}
+
+declare module '@glint/environment-ember-loose/registry' {
+  export default interface Registry {
+    CopyableCode: typeof CopyableCodeComponent;
   }
 }

--- a/app/models/concept.ts
+++ b/app/models/concept.ts
@@ -61,6 +61,10 @@ export default class ConceptModel extends Model {
     });
   }
 
+  get url(): string {
+    return `https://app.codecrafters.io/concepts/${this.slug}`;
+  }
+
   declare updateBlocks: (this: Model, payload: unknown) => Promise<void>;
 }
 

--- a/tests/acceptance/concepts-test.js
+++ b/tests/acceptance/concepts-test.js
@@ -165,6 +165,56 @@ module('Acceptance | concepts-test', function (hooks) {
     );
   });
 
+  test('tracks when share concept button is clicked', async function (assert) {
+    testScenario(this.server);
+    createConcepts(this.server);
+
+    signInAsStaff(this.owner, this.server);
+
+    this.server.schema.conceptGroups.create({
+      conceptSlugs: ['network-protocols', 'tcp-overview'],
+      descriptionMarkdown: 'This is a group about network concepts',
+      slug: 'network-primer',
+      title: 'Network Primer',
+    });
+
+    await conceptsPage.visit();
+
+    await conceptsPage.clickOnConceptCard('Network Protocols');
+    await conceptPage.clickOnContinueButton();
+    await conceptPage.clickOnContinueButton();
+    await conceptPage.questionCards[0].selectOption('PDF');
+    await conceptPage.questionCards[0].clickOnSubmitButton();
+    await conceptPage.clickOnContinueButton();
+    await conceptPage.clickOnContinueButton();
+    await conceptPage.clickOnContinueButton();
+    await conceptPage.questionCards[1].clickOnShowExplanationButton();
+    await conceptPage.clickOnContinueButton();
+    await conceptPage.clickOnContinueButton();
+    await conceptPage.clickOnContinueButton();
+    await conceptPage.questionCards[2].clickOnShowExplanationButton();
+    await conceptPage.clickOnContinueButton();
+    await conceptPage.clickOnContinueButton();
+    await conceptPage.clickOnContinueButton();
+    await conceptPage.clickOnContinueButton();
+    await conceptPage.clickOnContinueButton();
+    await conceptPage.clickOnContinueButton();
+    await conceptPage.questionCards[3].clickOnShowExplanationButton();
+    await conceptPage.clickOnContinueButton();
+    await conceptPage.clickOnContinueButton();
+    await conceptPage.clickOnContinueButton();
+    await conceptPage.clickOnContinueButton();
+    await conceptPage.clickOnContinueButton();
+
+    await conceptPage.shareConceptContainer.clickOnCopyButton();
+
+    const store = this.owner.lookup('service:store');
+    const analyticsEvents = await store.findAll('analytics-event', { backgroundReload: false });
+    const analyticsEventNames = analyticsEvents.map((analyticsEvent) => analyticsEvent.name);
+
+    assert.ok(analyticsEventNames.includes('clicked_on_share_concept_button'), 'clicked_on_share_concept_button event should be tracked');
+  });
+
   test('submit button does not work when no option is selected for question card', async function (assert) {
     testScenario(this.server);
     createConcepts(this.server);

--- a/tests/acceptance/concepts-test.js
+++ b/tests/acceptance/concepts-test.js
@@ -211,7 +211,7 @@ module('Acceptance | concepts-test', function (hooks) {
     const filteredAnalyticsEvents = analyticsEvents.filter((event) => event.name !== 'feature_flag_called');
     const filteredAnalyticsEventsNames = filteredAnalyticsEvents.map((event) => event.name);
 
-    assert.ok(filteredAnalyticsEventsNames.includes('clicked_on_share_concept_button'), 'clicked_on_share_concept_button event should be tracked');
+    assert.ok(filteredAnalyticsEventsNames.includes('clicked_share_concept_button'), 'clicked_on_share_concept_button event should be tracked');
   });
 
   test('submit button does not work when no option is selected for question card', async function (assert) {

--- a/tests/acceptance/concepts-test.js
+++ b/tests/acceptance/concepts-test.js
@@ -207,11 +207,11 @@ module('Acceptance | concepts-test', function (hooks) {
 
     await conceptPage.shareConceptContainer.clickOnCopyButton();
 
-    const store = this.owner.lookup('service:store');
-    const analyticsEvents = await store.findAll('analytics-event', { backgroundReload: false });
-    const analyticsEventNames = analyticsEvents.map((analyticsEvent) => analyticsEvent.name);
+    const analyticsEvents = this.server.schema.analyticsEvents.all().models;
+    const filteredAnalyticsEvents = analyticsEvents.filter((event) => event.name !== 'feature_flag_called');
+    const filteredAnalyticsEventsNames = filteredAnalyticsEvents.map((event) => event.name);
 
-    assert.ok(analyticsEventNames.includes('clicked_on_share_concept_button'), 'clicked_on_share_concept_button event should be tracked');
+    assert.ok(filteredAnalyticsEventsNames.includes('clicked_on_share_concept_button'), 'clicked_on_share_concept_button event should be tracked');
   });
 
   test('submit button does not work when no option is selected for question card', async function (assert) {

--- a/tests/acceptance/concepts-test.js
+++ b/tests/acceptance/concepts-test.js
@@ -183,8 +183,7 @@ module('Acceptance | concepts-test', function (hooks) {
     await conceptsPage.clickOnConceptCard('Network Protocols');
     await conceptPage.clickOnContinueButton();
     await conceptPage.clickOnContinueButton();
-    await conceptPage.questionCards[0].selectOption('PDF');
-    await conceptPage.questionCards[0].clickOnSubmitButton();
+    await conceptPage.questionCards[0].clickOnShowExplanationButton();
     await conceptPage.clickOnContinueButton();
     await conceptPage.clickOnContinueButton();
     await conceptPage.clickOnContinueButton();

--- a/tests/acceptance/concepts-test.js
+++ b/tests/acceptance/concepts-test.js
@@ -78,6 +78,7 @@ module('Acceptance | concepts-test', function (hooks) {
 
     assert.true(conceptPage.upcomingConcept.title.text.includes('Network Primer'), 'Concept group title is correct');
     assert.true(conceptPage.upcomingConcept.card.title.text.includes('TCP: An Overview'), 'Next concept title is correct');
+    assert.true(conceptPage.shareConceptContainer.text.includes('https://app.codecrafters.io/concepts/network-protocols'));
 
     await percySnapshot('Concept - Completed');
   });

--- a/tests/pages/concept-page.js
+++ b/tests/pages/concept-page.js
@@ -20,6 +20,7 @@ export default createPage({
   }),
 
   shareConceptContainer: {
+    clickOnCopyButton: clickable('[data-test-copy-button]'),
     scope: '[data-test-share-concept-container]',
   },
 

--- a/tests/pages/concept-page.js
+++ b/tests/pages/concept-page.js
@@ -19,6 +19,10 @@ export default createPage({
     hasSubmitted: isPresent('[data-test-question-submitted]'),
   }),
 
+  shareConceptContainer: {
+    scope: '[data-test-share-concept-container]',
+  },
+
   upcomingConcept: {
     card: {
       title: {


### PR DESCRIPTION
**Checklist**:

- [x] I've thoroughly self-reviewed my changes
- [x] I've added tests for my changes, unless they affect admin-only areas (or are otherwise not worth testing)
- [ ] I've verified any visual changes using Percy (add a commit with `[percy]` in the message to trigger)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Introduced a new section for sharing concepts with friends, complete with a gift icon and a copyable code snippet feature.
- **Style**
	- Adjusted padding for the concept section for improved layout.
	- Enhanced the share concept container with a border, rounded corners, shadow, and padding for better visual appeal.
- **Tests**
	- Added assertions and tests to ensure proper tracking of analytics events related to concept sharing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->