### PR TITLE
Add staff check to should show language guide

### DIFF
--- a/app/controllers/course/stage/instructions.ts
+++ b/app/controllers/course/stage/instructions.ts
@@ -41,7 +41,7 @@ export default class CourseStageInstructionsController extends Controller {
   }
 
   get shouldShowLanguageGuide() {
-    return !this.model.courseStage.isFirst;
+    return !this.model.courseStage.isFirst && this.authenticator.currentUser?.isStaff;
   }
 
   get shouldShowPrerequisites() {

--- a/tests/acceptance/course-page/attempt-course-stage-test.js
+++ b/tests/acceptance/course-page/attempt-course-stage-test.js
@@ -40,7 +40,7 @@ module('Acceptance | course-page | attempt-course-stage', function (hooks) {
         'fetch repositories (course page)',
         'fetch leaderboard entries (course page)',
         'fetch hints (course page)',
-        'fetch language guide (course page)',
+        // 'fetch language guide (course page)',
       ].length,
     );
 

--- a/tests/acceptance/course-page/resume-course-test.js
+++ b/tests/acceptance/course-page/resume-course-test.js
@@ -39,7 +39,7 @@ module('Acceptance | course-page | resume-course-test', function (hooks) {
         'fetch repositories (course page)',
         'fetch leaderboard entries (course page)',
         'fetch hints (course page)',
-        'fetch language guide (course page)',
+        // 'fetch language guide (course page)',
       ].length,
     );
   });

--- a/tests/acceptance/course-page/try-other-language-test.js
+++ b/tests/acceptance/course-page/try-other-language-test.js
@@ -39,7 +39,7 @@ module('Acceptance | course-page | try-other-language', function (hooks) {
       'fetch repositories (course page)',
       'fetch leaderboard entries (course page)',
       'fetch hints (course page)',
-      'fetch language guide (course page)',
+      // 'fetch language guide (course page)',
     ].length;
 
     await catalogPage.visit();


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Refactor**
	- Updated the course stage instructions to also show the language guide for staff members, regardless of the course stage.
- **Tests**
	- Commented out the line fetching the language guide on the course page in several test files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->