### PR TITLE
CC-1036: Add eslint rule to enforce newlines between class methods.

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -25,6 +25,13 @@ module.exports = {
       { blankLine: 'always', prev: '*', next: 'multiline-block-like' },
       { blankLine: 'always', prev: 'multiline-block-like', next: '*' },
     ],
+    'lines-between-class-members': [
+      'error',
+      {
+        enforce: [{ blankLine: 'always', prev: 'method', next: 'method' }],
+      },
+    ],
+
     'ember/no-array-prototype-extensions': 'off', // Get to this later
     'ember/no-empty-glimmer-component-classes': 'off', // It's useful to have empty components since the names are shown in devtools
     'ember/no-runloop': 'off', // Run-loop isn't deprecated yet. Switching to ember-concurrency would require a lot of effort. We can use ember-lifeline as a drop-in replacement whenever run-loop becomes deprecated.

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -27,8 +27,9 @@ module.exports = {
     ],
     'lines-between-class-members': [
       'error',
+      'always',
       {
-        enforce: [{ blankLine: 'always', prev: 'method', next: 'method' }],
+        exceptAfterSingleLine: true,
       },
     ],
 

--- a/app/components/badges-page/badge-earned-modal.js
+++ b/app/components/badges-page/badge-earned-modal.js
@@ -25,6 +25,7 @@ export default class BadgeEarnedModalComponent extends Component {
   get userHasBadgeAward() {
     return this.args.badge && this.currentUserBadgeAwards.length > 0;
   }
+
   @action
   handleDidInsert() {
     this.analyticsEventTracker.track('viewed_badge', {

--- a/app/components/course-page/comment-list.js
+++ b/app/components/course-page/comment-list.js
@@ -42,6 +42,7 @@ export default class CommentListComponent extends Component {
       return this.topLevelPersistedComments.filter((comment) => comment.isApproved || comment.user === this.authenticator.currentUser);
     }
   }
+
   @action
   async loadComments() {
     this.isLoading = true;

--- a/app/components/course-page/course-stage-step/your-task-card/action-button-list.js
+++ b/app/components/course-page/course-stage-step/your-task-card/action-button-list.js
@@ -65,6 +65,7 @@ export default class ActionButtonListComponent extends Component {
   handleViewScreencastsButtonClicked() {
     this.router.transitionTo('course.stage.screencasts', this.args.courseStage.position);
   }
+
   @action
   handleViewTestCasesButtonClicked() {
     window.open(this.args.courseStage.testerSourceCodeUrl, '_blank').focus();

--- a/app/controllers/course-admin/update.ts
+++ b/app/controllers/course-admin/update.ts
@@ -14,6 +14,7 @@ export default class CourseAdminUpdateController extends Controller {
       syncCourseDefinitionUpdates: () => Promise<void>;
     };
   };
+
   @service declare store: Store;
 
   @tracked isApplyingUpdate = false;

--- a/app/controllers/course.ts
+++ b/app/controllers/course.ts
@@ -198,6 +198,7 @@ export default class CourseController extends Controller {
 
     this.polledRepository = null;
   }
+
   @action
   teardownRouteChangeListeners() {
     this.router.off('routeDidChange', this.handleRouteChanged);

--- a/app/controllers/refer.ts
+++ b/app/controllers/refer.ts
@@ -11,6 +11,7 @@ export default class ReferController extends Controller {
   get currentUser() {
     return this.authenticator.currentUser;
   }
+
   get referralLink() {
     return this.currentUser?.referralLinks[0];
   }

--- a/app/models/course-stage.ts
+++ b/app/models/course-stage.ts
@@ -16,6 +16,7 @@ export default class CourseStageModel extends Model {
   @hasMany('course-stage-comment', { async: false, inverse: 'target' }) declare comments: CourseStageCommentModel[];
   @hasMany('community-course-stage-solution', { async: false, inverse: 'courseStage' })
   declare communitySolutions: CommunityCourseStageSolutionModel[];
+
   @hasMany('course-stage-language-guide', { async: false, inverse: 'courseStage' }) declare languageGuides: CourseStageLanguageGuideModel[];
   @hasMany('course-stage-solution', { async: false, inverse: 'courseStage' }) declare solutions: CourseStageSolutionModel[];
   @hasMany('course-stage-screencast', { async: false, inverse: 'courseStage' }) declare screencasts: CourseStageScreencastModel[];

--- a/app/models/repository.ts
+++ b/app/models/repository.ts
@@ -43,8 +43,10 @@ export default class RepositoryModel extends Model {
   @hasMany('course-stage-completion', { async: false, inverse: 'repository' }) declare courseStageCompletions: CourseStageCompletionModel[];
   @hasMany('course-stage-feedback-submission', { async: false, inverse: 'repository' })
   declare courseStageFeedbackSubmissions: CourseStageFeedbackSubmissionModel[];
+
   @hasMany('github-repository-sync-configuration', { async: false, inverse: 'repository' })
   declare githubRepositorySyncConfigurations: GithubRepositorySyncConfiguration[];
+
   @belongsTo('user', { async: false, inverse: 'repositories' }) declare user: UserModel;
   @belongsTo('language', { async: false, inverse: null }) declare language: LanguageModel | undefined;
   @belongsTo('submission', { async: false, inverse: null }) declare lastSubmission: SubmissionModel;

--- a/app/models/submission.ts
+++ b/app/models/submission.ts
@@ -13,6 +13,7 @@ export default class SubmissionModel extends Model {
   @belongsTo('course-stage', { async: false, inverse: null }) declare courseStage: CourseStageModel;
   @belongsTo('community-course-stage-solution', { async: false, inverse: null })
   declare communityCourseStageSolution: CommunityCourseStageSolutionModel;
+
   @belongsTo('course-tester-version', { async: false, inverse: null }) declare testerVersion: CourseTesterVersionModel;
   @belongsTo('repository', { async: false, inverse: 'submissions' }) declare repository: RepositoryModel;
 

--- a/app/routes/refer.ts
+++ b/app/routes/refer.ts
@@ -11,6 +11,7 @@ export default class ReferRoute extends BaseRoute {
   activate() {
     scrollToTop();
   }
+
   async model() {
     await this.authenticator.authenticate(); // Force loading referral links
 


### PR DESCRIPTION
**Checklist**:

- [X] I've thoroughly self-reviewed my changes
- [ ] I've added tests for my changes, unless they affect admin-only areas (or are otherwise not worth testing)
- [ ] I've verified any visual changes using Percy (add a commit with `[percy]` in the message to trigger)

Link to docs : 
https://eslint.org/docs/latest/rules/lines-between-class-members

Tried using `padding-line-between-statements`, but our usecase seems to not be supported by its options.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Added a "View Test Cases" button functionality to display tester source code in a new window for course stages.
	- Introduced a feature to retrieve the referral link of the current user.

- **Refactor**
	- Enforced blank lines between class methods for cleaner code structure across various components and controllers.

- **Style**
	- Applied code styling rules to ensure consistency in the codebase.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->