### PR TITLE
style: add min-width to flex container in leaderboard entry component

### DIFF
--- a/app/components/leaderboard-entry.hbs
+++ b/app/components/leaderboard-entry.hbs
@@ -6,7 +6,7 @@
     {{if @isForCurrentUser 'border-teal-500' 'border-transparent'}}"
   data-test-leaderboard-entry
 >
-  <div class="flex items-center">
+  <div class="flex items-center min-w-0">
     <div class="{{unless @isCollapsed 'mr-2'}} flex-shrink-0">
       {{#if this.isSkeleton}}
         <div class="w-8 h-8 bg-gray-200 rounded"></div>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
	- Improved the layout of leaderboard entries for better visibility on various screen sizes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->