### PR TITLE
Don't pass in language when creating comments

### DIFF
--- a/app/components/course-page/comment-list.hbs
+++ b/app/components/course-page/comment-list.hbs
@@ -1,7 +1,8 @@
 <div data-test-comment-list {{did-update this.loadComments @requestedSolutionLanguage @courseStage}}>
   <CoursePage::CommentTimelineItem @author={{this.currentUser}}>
     <div class="shadow-sm rounded border border-gray-300 w-full mb-4">
-      <CommentForm @target={{@courseStage}} @language={{@language}} @commentModelType="course-stage-comment" />
+      {{! TODO: Pass in language here so that users can choose whether their comment is language-specific }}
+      <CommentForm @target={{@courseStage}} @commentModelType="course-stage-comment" />
     </div>
   </CoursePage::CommentTimelineItem>
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Updated the comment form to temporarily remove language selection, with plans to enhance language choice for user comments in the future.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->