### PR TITLE
[PREVIEW] Allow voting within configure extensions modal

### DIFF
--- a/app/components/course-page/configure-extensions-modal.hbs
+++ b/app/components/course-page/configure-extensions-modal.hbs
@@ -1,5 +1,5 @@
 <ModalBody @isWide={{true}} @allowManualClose={{true}} @onClose={{@onClose}} class="w-full" data-test-configure-extensions-modal>
-  <div class="mb-6 font-semibold text-2xl text-gray-600 mr-8">
+  <div class="mb-6 font-bold text-2xl text-gray-700 mr-8">
     Configure Extensions
   </div>
 
@@ -7,9 +7,28 @@
     Extensions are sets of additional stages that can be added to your repository. You can add &amp; remove extensions at any time.
   </Alert>
 
-  <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
+  <div class="grid grid-cols-1 sm:grid-cols-2 gap-4 mb-6">
     {{#each @repository.course.extensions as |extension|}}
       <CoursePage::ConfigureExtensionsModal::ExtensionCard @extension={{extension}} @repository={{@repository}} />
+    {{/each}}
+  </div>
+
+  <div class="border-b pb-1 mb-6 flex items-center gap-2">
+    <h1 class="text-2xl text-gray-700 font-bold tracking-tighter">Vote on future extensions</h1>
+
+    <div>
+      {{svg-jar "information-circle" class="w-4 h-4 fill-current text-gray-200 hover:text-gray-300"}}
+      <EmberTooltip @text={{"These are ideas for extensions we'll build in the future. Vote to let us know which ones you're interested in!"}} />
+    </div>
+  </div>
+
+  <div class="grid grid-cols-1 gap-3 lg:grid-cols-2 mb-8">
+    {{! @glint-expect-error not ts-ified yet }}
+    <VotePage::SubmitCourseExtensionIdeaCard @course={{@repository.course}} />
+
+    {{#each this.orderedCourseExtensionIdeas as |courseExtensionIdea|}}
+      {{! @glint-expect-error not ts-ified yet }}
+      <VotePage::CourseExtensionIdeaCard @courseExtensionIdea={{courseExtensionIdea}} />
     {{/each}}
   </div>
 </ModalBody>

--- a/app/components/course-page/configure-extensions-modal.ts
+++ b/app/components/course-page/configure-extensions-modal.ts
@@ -1,5 +1,7 @@
 import Component from '@glimmer/component';
 import RepositoryModel from 'codecrafters-frontend/models/repository';
+import Store from '@ember-data/store';
+import { inject as service } from '@ember/service';
 
 type Signature = {
   Element: HTMLDivElement;
@@ -10,7 +12,19 @@ type Signature = {
   };
 };
 
-export default class ConfigureExtensionsModalComponent extends Component<Signature> {}
+export default class ConfigureExtensionsModalComponent extends Component<Signature> {
+  @service declare store: Store;
+
+  constructor(owner: unknown, args: Signature['Args']) {
+    super(owner, args);
+
+    this.store.findAll('course-extension-idea', { include: 'course' });
+  }
+
+  get orderedCourseExtensionIdeas() {
+    return this.args.repository.course.extensionIdeas.sortBy('reverseSortPositionForVotePage').reverse();
+  }
+}
 
 declare module '@glint/environment-ember-loose/registry' {
   export default interface Registry {


### PR DESCRIPTION
- Added `store` service injection in `ConfigureExtensionsModalComponent`
- Modified constructor to fetch all `course-extension-idea` records from the store
- Added `orderedCourseExtensionIdeas` computed property to sort and reverse the `extensionIdeas` array
- Updated the markup in the template to display a section for voting on future extensions
- Added a heading and information icon with tooltip for the voting section
- Added a grid layout for the voting cards, including a card for submitting new extension ideas and cards for existing extension ideas

This change allows users to vote on future extensions they are interested in.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added a voting section for future course extensions, including the ability to submit and view extension ideas.
- **Style**
	- Updated the "Configure Extensions" text style to bold.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->