### PR TITLE
feat: add ScrollToTopOnInsertModifier to scroll to top on insert

### DIFF
--- a/app/modifiers/scroll-to-top-on-insert.ts
+++ b/app/modifiers/scroll-to-top-on-insert.ts
@@ -1,0 +1,20 @@
+import Modifier from 'ember-modifier';
+import scrollToTop from 'codecrafters-frontend/utils/scroll-to-top';
+
+type Signature = {
+  Args: {
+    Positional: [];
+  };
+};
+
+export default class ScrollToTopOnInsertModifier extends Modifier<Signature> {
+  modify() {
+    scrollToTop();
+  }
+}
+
+declare module '@glint/environment-ember-loose/registry' {
+  export default interface Registry {
+    'scroll-to-top-on-insert': typeof ScrollToTopOnInsertModifier;
+  }
+}

--- a/app/modifiers/upscroll-window-on-insert.ts
+++ b/app/modifiers/upscroll-window-on-insert.ts
@@ -7,7 +7,7 @@ type Signature = {
   };
 };
 
-export default class ScrollToTopOnInsertModifier extends Modifier<Signature> {
+export default class UpscrollWindowOnInsertModifier extends Modifier<Signature> {
   modify() {
     scrollToTop();
   }
@@ -15,6 +15,6 @@ export default class ScrollToTopOnInsertModifier extends Modifier<Signature> {
 
 declare module '@glint/environment-ember-loose/registry' {
   export default interface Registry {
-    'scroll-to-top-on-insert': typeof ScrollToTopOnInsertModifier;
+    'upscroll-window-on-insert': typeof UpscrollWindowOnInsertModifier;
   }
 }

--- a/app/templates/course.hbs
+++ b/app/templates/course.hbs
@@ -89,7 +89,7 @@
             @repository={{@model.activeRepository}}
             class="px-3 md:px-6 lg:px-10 w-full scroll-mt-20"
             {{! Confetti etc. makes more sense when the top section is focused }}
-            {{scroll-into-view block="start"}}
+            {{scroll-to-top-on-insert}}
           />
         {{/if}}
 

--- a/app/templates/course.hbs
+++ b/app/templates/course.hbs
@@ -89,7 +89,7 @@
             @repository={{@model.activeRepository}}
             class="px-3 md:px-6 lg:px-10 w-full scroll-mt-20"
             {{! Confetti etc. makes more sense when the top section is focused }}
-            {{scroll-to-top-on-insert}}
+            {{upscroll-window-on-insert}}
           />
         {{/if}}
 


### PR DESCRIPTION
The ScrollToTopOnInsertModifier is added to the codebase to enable scrolling to the top when a new element is inserted. This modifier uses the `ember-modifier` package and the `scroll-to-top` utility function from the `codecrafters-frontend` module.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Introduced a feature that automatically scrolls to the top of the page in certain scenarios for improved user navigation experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->