### PR TITLE
fix: update route for PrimaryLinkButton to point to "pay" instead of "refer"

### DIFF
--- a/app/components/header/free-weeks-left-button.hbs
+++ b/app/components/header/free-weeks-left-button.hbs
@@ -1,4 +1,4 @@
-<PrimaryLinkButton @size="extra-small" @route="refer" class="mr-4" data-test-free-weeks-left-button>
+<PrimaryLinkButton @size="extra-small" @route="pay" class="mr-4" data-test-free-weeks-left-button>
   <span class="flex items-center gap-x-1">
     {{svg-jar "clock" class="w-4 fill-current"}}
     {{this.freeWeeksLeftCopy}}

--- a/tests/acceptance/course-page/view-course-stages-test.js
+++ b/tests/acceptance/course-page/view-course-stages-test.js
@@ -915,7 +915,7 @@ module('Acceptance | course-page | view-course-stages-test', function (hooks) {
     assert.false(coursePage.desktopHeader.freeWeeksLeftButton.isVisible, 'expect free weeks left badge to be hidden');
   });
 
-  test('free weeks left button redirects to refer', async function (assert) {
+  test('free weeks left button redirects to /pay', async function (assert) {
     testScenario(this.server);
 
     const user = this.server.schema.users.first();
@@ -928,6 +928,6 @@ module('Acceptance | course-page | view-course-stages-test', function (hooks) {
     await courseOverviewPage.clickOnStartCourse();
     await coursePage.desktopHeader.freeWeeksLeftButton.click();
 
-    assert.strictEqual(currentURL(), '/refer', 'expect to be redirected to refer page');
+    assert.strictEqual(currentURL(), '/pay', 'expect to be redirected to pay page');
   });
 });

--- a/tests/acceptance/referrals-page/view-referrals-test.js
+++ b/tests/acceptance/referrals-page/view-referrals-test.js
@@ -439,7 +439,7 @@ module('Acceptance | referrals-page | view-referrals', function (hooks) {
     await percySnapshot('Header | Has no VIP status and free usage grants');
   });
 
-  test('free weeks left button redirects to refer', async function (assert) {
+  test('free weeks left button redirects to /pay', async function (assert) {
     testScenario(this.server);
 
     const user = this.server.schema.users.first();
@@ -450,6 +450,6 @@ module('Acceptance | referrals-page | view-referrals', function (hooks) {
     await catalogPage.visit();
     await catalogPage.header.freeWeeksLeftButton.click();
 
-    assert.strictEqual(currentURL(), '/refer', 'expect to be redirected to refer page');
+    assert.strictEqual(currentURL(), '/pay', 'expect to be redirected to refer page');
   });
 });


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
    - Updated the navigation route for the "Free Weeks Left" button in the header to correctly redirect users to the payment page instead of the referral page.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->