### PR TITLE
Add links to turbo/perks on /pay page

### DIFF
--- a/app/components/pay-page/pricing-card.hbs
+++ b/app/components/pay-page/pricing-card.hbs
@@ -87,9 +87,16 @@
   </div>
   <div class="p-6 rounded-b-lg">
     {{#each this.featureDescriptions as |featureDescription|}}
-      <div class="flex items-center py-1">
+      <div class="flex items-center py-1 gap-2">
         {{svg-jar "check" class="w-6 fill-current text-teal-500"}}
-        <span class="text-gray-600 text-sm ml-2">{{featureDescription}}</span>
+        {{#if featureDescription.link}}
+          <a href={{featureDescription.link}} target="_blank" class="flex items-center gap-1 group">
+            <span class="text-gray-600 text-sm underline decoration-dotted">{{featureDescription.text}}</span>
+            {{svg-jar "information-circle" class="w-4 h-4 fill-current text-gray-300 group-hover:text-gray-400"}}
+          </a>
+        {{else}}
+          <span class="text-gray-600 text-sm">{{featureDescription.text}}</span>
+        {{/if}}
       </div>
     {{/each}}
   </div>

--- a/app/components/pay-page/pricing-card.hbs
+++ b/app/components/pay-page/pricing-card.hbs
@@ -89,8 +89,9 @@
     {{#each this.featureDescriptions as |featureDescription|}}
       <div class="flex items-center py-1 gap-2">
         {{svg-jar "check" class="w-6 fill-current text-teal-500"}}
+
         {{#if featureDescription.link}}
-          <a href={{featureDescription.link}} target="_blank" class="flex items-center gap-1 group">
+          <a href={{featureDescription.link}} target="_blank" class="flex items-center gap-1 group" rel="noopener noreferrer">
             <span class="text-gray-600 text-sm underline decoration-dotted">{{featureDescription.text}}</span>
             {{svg-jar "information-circle" class="w-4 h-4 fill-current text-gray-300 group-hover:text-gray-400"}}
           </a>

--- a/app/components/pay-page/pricing-card.ts
+++ b/app/components/pay-page/pricing-card.ts
@@ -38,7 +38,14 @@ export default class PricingCardComponent extends Component<Signature> {
   }
 
   get featureDescriptions() {
-    return ['One time payment', 'No limits on content', 'Community features', 'Access to Perks', 'Priority support'];
+    return [
+      { text: 'One time payment' },
+      { text: 'No limits on content' },
+      { text: 'Turbo test runs', link: 'https://codecrafters.io/turbo' },
+      { text: 'Community features' },
+      { text: 'Access to Perks', link: 'https://codecrafters.io/perks' },
+      { text: 'Priority support' },
+    ];
   }
 
   get numberOfMonths() {

--- a/app/components/pay-page/pricing-card.ts
+++ b/app/components/pay-page/pricing-card.ts
@@ -1,9 +1,29 @@
 import Component from '@glimmer/component';
 import { inject as service } from '@ember/service';
+import type AuthenticatorService from 'codecrafters-frontend/services/authenticator';
+import Store from '@ember-data/store';
+import type RegionalDiscountModel from 'codecrafters-frontend/models/regional-discount';
 
-export default class PricingCardComponent extends Component {
-  @service authenticator;
-  @service store;
+type Signature = {
+  Element: HTMLDivElement;
+
+  Args: {
+    actualPrice: number;
+    discountedPrice: number | null;
+    highlightedText?: string;
+    footerText: string;
+    onStartMembershipButtonClick: () => void;
+    isRecommended: boolean;
+    pricingFrequency: 'quarterly' | 'yearly' | 'lifetime';
+    regionalDiscount?: RegionalDiscountModel;
+    shouldShowAmortizedMonthlyPrice: boolean;
+    title: string;
+  };
+};
+
+export default class PricingCardComponent extends Component<Signature> {
+  @service declare authenticator: AuthenticatorService;
+  @service declare store: Store;
 
   get actualAmortizedMonthlyPrice() {
     return Math.round((this.args.actualPrice / this.numberOfMonths) * 100) / 100;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new pricing card on the payment page, enhancing the display of membership service costs and features. This includes detailed descriptions with links and calculations for amortized monthly prices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->