### PR TITLE
style: add w-full class to plus icon for Safari compatibility

### DIFF
--- a/app/components/course-leaderboard/invite-button-entry.hbs
+++ b/app/components/course-leaderboard/invite-button-entry.hbs
@@ -2,7 +2,8 @@
   <div
     class="flex w-8 h-8 p-1 items-center justify-center shadow-sm border rounded border-gray-300 group-hover/invite-entry:border-teal-500 group-hover/invite-entry:bg-teal-500 group-hover/invite-entry:shadow"
   >
-    {{svg-jar "plus" class="text-gray-400 group-hover/invite-entry:text-white"}}
+    {{! w-full is needed for Safari }}
+    {{svg-jar "plus" class="text-gray-400 group-hover/invite-entry:text-white w-full"}}
   </div>
 
   {{#unless @isCollapsed}}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
	- Improved compatibility with Safari by adjusting the styling of the invite button.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->