### PR TITLE
CC-1069 add commit sha to course admin submissions area

### DIFF
--- a/app/components/course-admin/submissions-page/submission-details/header-container.hbs
+++ b/app/components/course-admin/submissions-page/submission-details/header-container.hbs
@@ -90,6 +90,19 @@
           </div>
         </CourseAdmin::SubmissionsPage::SubmissionDetails::HeaderContainerRow>
 
+        <CourseAdmin::SubmissionsPage::SubmissionDetails::HeaderContainerRow @title="Commit SHA" data-test-commit-sha>
+          <div class="flex items-center">
+            <span class="mr-2 font-mono text-gray-600">
+              {{this.shortSubmissionCommitSha}}
+            </span>
+
+            <TertiaryButton @size="extra-small" class="mr-2" {{on "click" this.handleCopyCommitShaButtonClick}} data-test-copy-commit-sha-button>
+              {{svg-jar "clipboard-list" class="w-4 text-gray-500"}}
+              <EmberTooltip @text="Click to copy Git commit SHA" />
+            </TertiaryButton>
+          </div>
+        </CourseAdmin::SubmissionsPage::SubmissionDetails::HeaderContainerRow>
+
         {{#if this.shouldShowTesterVersion}}
           <CourseAdmin::SubmissionsPage::SubmissionDetails::HeaderContainerRow
             @title="Tester version"

--- a/app/components/course-admin/submissions-page/submission-details/header-container.js
+++ b/app/components/course-admin/submissions-page/submission-details/header-container.js
@@ -27,6 +27,10 @@ export default class AdminCourseSubmissionsPageSubmissionDetailsHeaderContainerC
     return capitalize(this.args.submission.repository.languageProficiencyLevel);
   }
 
+  get shortSubmissionCommitSha() {
+    return this.args.submission.commitSha.substring(0, 8);
+  }
+
   get shouldShowTesterVersion() {
     return this.authenticator.currentUser.isStaff;
   }
@@ -37,6 +41,11 @@ export default class AdminCourseSubmissionsPageSubmissionDetailsHeaderContainerC
     } else {
       return 'Unknown';
     }
+  }
+
+  @action
+  async handleCopyCommitShaButtonClick() {
+    await navigator.clipboard.writeText(this.args.submission.commitSha);
   }
 
   @action

--- a/app/models/submission.ts
+++ b/app/models/submission.ts
@@ -21,6 +21,7 @@ export default class SubmissionModel extends Model {
   @hasMany('submission-evaluation', { async: false, inverse: 'submission' }) declare evaluations: SubmissionEvaluationModel[];
 
   @attr() declare changedFiles: { diff: string; filename: string }[]; // free-form JSON
+  @attr('string') declare commitSha: string;
   @attr('date') declare createdAt: Date;
   @attr('string') declare githubStorageHtmlUrl: string;
   @attr('boolean') declare wasSubmittedViaCli: boolean;

--- a/mirage/factories/submission.js
+++ b/mirage/factories/submission.js
@@ -1,6 +1,18 @@
 import { Factory, trait } from 'miragejs';
 import config from 'codecrafters-frontend/config/environment';
 
+function generateRandomAlphanumericString(length) {
+  let result = '';
+  const characters = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
+  const charactersLength = characters.length;
+
+  for (let i = 0; i < length; i++) {
+      result += characters.charAt(Math.floor(Math.random() * charactersLength));
+  }
+
+  return result;
+}
+
 export default Factory.extend({
   changedFiles: () => {
     return [
@@ -37,6 +49,9 @@ export default Factory.extend({
   },
 
   createdAt: () => new Date(),
+
+  commitSha: () => generateRandomAlphanumericString(40),
+
   githubStorageHtmlUrl: 'https://github.com',
 
   withFailureStatus: trait({

--- a/mirage/factories/submission.js
+++ b/mirage/factories/submission.js
@@ -7,7 +7,7 @@ function generateRandomAlphanumericString(length) {
   const charactersLength = characters.length;
 
   for (let i = 0; i < length; i++) {
-      result += characters.charAt(Math.floor(Math.random() * charactersLength));
+    result += characters.charAt(Math.floor(Math.random() * charactersLength));
   }
 
   return result;

--- a/tests/acceptance/course-admin/view-submissions-test.js
+++ b/tests/acceptance/course-admin/view-submissions-test.js
@@ -337,12 +337,12 @@ module('Acceptance | course-admin | view-submissions', function (hooks) {
     await submissionsPage.timelineContainer.entries[1].click();
 
     assert.true(submissionsPage.submissionDetails.commitSha.text.includes('a77c9d85'), 'commit sha is displayed');
-    assert.false(submissionsPage.submissionDetails.commitSha.text.includes('a77c9d851'), 'commit sha should be truncated')
+    assert.false(submissionsPage.submissionDetails.commitSha.text.includes('a77c9d851'), 'commit sha should be truncated');
 
     await submissionsPage.submissionDetails.commitSha.copyButton.hover();
 
     assertTooltipContent(assert, {
       contentString: 'Click to copy Git commit SHA',
     });
-  })
+  });
 });

--- a/tests/pages/course-admin/submissions-page.js
+++ b/tests/pages/course-admin/submissions-page.js
@@ -15,6 +15,15 @@ export default create({
   stageDropdown: CourseStageDropdown,
 
   submissionDetails: {
+    commitSha: {
+      copyButton: {
+        hover: triggerable('mouseenter'),
+        scope: '[data-test-copy-commit-sha-button]',
+      },
+
+      scope: '[data-test-commit-sha]',
+    },
+
     userProficiencyInfoIcon: {
       hover: triggerable('mouseenter'),
       scope: '[data-test-user-proficiency-info-icon]',


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Added a section in the submissions page header for displaying the Commit SHA with a copy functionality.
- **Tests**
	- Added tests to verify display and functionality of Commit SHA on the submissions page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->