### PR TITLE
Fix the copyright notice in the license file

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -6,7 +6,7 @@ FSL-1.1-MIT
 
 ## Notice
 
-Copyright 2024 GitButler Inc
+Copyright 2021-2024 CodeCrafters, Inc.
 
 ## Terms and Conditions
 


### PR DESCRIPTION
Hey @rohitpaulk! 👋 I'm getting ready to [submit FSL to SPDX](https://github.com/getsentry/fsl.software/issues/21) and am reviewing existing adoption as part of that. Thanks for picking up 1.1 already! I noticed a small copy/paste error in the copyright notice (and also added the initial year in the range). 🐭 

**Checklist**:

- [x] I've thoroughly self-reviewed my changes
- [x] I've added tests for my changes, unless they affect admin-only areas (or are otherwise not worth testing)
- [x] I've verified any visual changes using Percy (add a commit with `[percy]` in the message to trigger)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated copyright information in the license documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->