### PR TITLE
refactor: Remove unnecessary font-mono class from Commit SHA title

### DIFF
--- a/app/components/course-admin/submissions-page/submission-details/header-container.hbs
+++ b/app/components/course-admin/submissions-page/submission-details/header-container.hbs
@@ -92,7 +92,7 @@
 
         <CourseAdmin::SubmissionsPage::SubmissionDetails::HeaderContainerRow @title="Commit SHA" data-test-commit-sha>
           <div class="flex items-center">
-            <span class="mr-2 font-mono text-gray-600">
+            <span class="mr-2 text-gray-600">
               {{this.shortSubmissionCommitSha}}
             </span>
 


### PR DESCRIPTION
Removed the font-mono class from the Commit SHA title in order to improve visual
consistency within the Submissions Page. This change makes the text color
consistent with the surrounding elements.