### PR TITLE
CC-1027 use mirage instead of the data store for testing analytics events

### DIFF
--- a/tests/acceptance/course-page/view-course-stages-test.js
+++ b/tests/acceptance/course-page/view-course-stages-test.js
@@ -549,12 +549,12 @@ module('Acceptance | course-page | view-course-stages-test', function (hooks) {
     await coursePage.clickOnExpandSidebarButton();
     assert.ok(coursePage.hasExpandedSidebar, 'sidebar should be expanded');
 
-    const store = this.owner.lookup('service:store');
-    const analyticsEvents = await store.findAll('analytics-event', { backgroundReload: false });
-    const analyticsEventNames = analyticsEvents.map((analyticsEvent) => analyticsEvent.name);
+    const analyticsEvents = this.server.schema.analyticsEvents.all().models;
+    const filteredAnalyticsEvents = analyticsEvents.filter((event) => event.name !== 'feature_flag_called');
+    const filteredAnalyticsEventsNames = filteredAnalyticsEvents.map((event) => event.name);
 
-    assert.ok(analyticsEventNames.includes('collapsed_course_page_sidebar'), 'collapsed_course_page_sidebar event should be tracked');
-    assert.ok(analyticsEventNames.includes('expanded_course_page_sidebar'), 'expanded_course_page_sidebar event should be tracked');
+    assert.ok(filteredAnalyticsEventsNames .includes('collapsed_course_page_sidebar'), 'collapsed_course_page_sidebar event should be tracked');
+    assert.ok(filteredAnalyticsEventsNames .includes('expanded_course_page_sidebar'), 'expanded_course_page_sidebar event should be tracked');
   });
 
   test('it should have a working expand/collapse leaderboard button', async function (assert) {
@@ -571,12 +571,12 @@ module('Acceptance | course-page | view-course-stages-test', function (hooks) {
     await coursePage.clickOnExpandLeaderboardButton();
     assert.ok(coursePage.hasExpandedLeaderboard, 'leaderboard should be expanded');
 
-    const store = this.owner.lookup('service:store');
-    const analyticsEvents = await store.findAll('analytics-event', { backgroundReload: false });
-    const analyticsEventNames = analyticsEvents.map((analyticsEvent) => analyticsEvent.name);
+    const analyticsEvents = this.server.schema.analyticsEvents.all().models;
+    const filteredAnalyticsEvents = analyticsEvents.filter((event) => event.name !== 'feature_flag_called');
+    const filteredAnalyticsEventsNames = filteredAnalyticsEvents.map((event) => event.name);
 
-    assert.ok(analyticsEventNames.includes('collapsed_course_page_leaderboard'), 'collapsed_course_page_leaderboard event should be tracked');
-    assert.ok(analyticsEventNames.includes('expanded_course_page_leaderboard'), 'expanded_course_page_leaderboard event should be tracked');
+    assert.ok(filteredAnalyticsEventsNames .includes('collapsed_course_page_leaderboard'), 'collapsed_course_page_leaderboard event should be tracked');
+    assert.ok(filteredAnalyticsEventsNames .includes('expanded_course_page_leaderboard'), 'expanded_course_page_leaderboard event should be tracked');
   });
 
   test('it should show a screencasts link in the second stage if there are screencasts available', async function (assert) {
@@ -659,11 +659,11 @@ module('Acceptance | course-page | view-course-stages-test', function (hooks) {
     await catalogPage.clickOnCourse('Build your own Redis');
     await coursePage.monthlyChallengeBanner.click();
 
-    const store = this.owner.lookup('service:store');
-    const analyticsEvents = await store.findAll('analytics-event', { backgroundReload: false });
-    const analyticsEventNames = analyticsEvents.map((analyticsEvent) => analyticsEvent.name);
+    const analyticsEvents = this.server.schema.analyticsEvents.all().models;
+    const filteredAnalyticsEvents = analyticsEvents.filter((event) => event.name !== 'feature_flag_called');
+    const filteredAnalyticsEventsNames = filteredAnalyticsEvents.map((event) => event.name);
 
-    assert.ok(analyticsEventNames.includes('clicked_monthly_challenge_banner'), 'clicked_monthly_challenge_banner event should be tracked');
+    assert.ok(filteredAnalyticsEventsNames .includes('clicked_monthly_challenge_banner'), 'clicked_monthly_challenge_banner event should be tracked');
   });
 
   test('stage should restrict admin access to user if user is course author and course is not authored by user', async function (assert) {
@@ -764,11 +764,11 @@ module('Acceptance | course-page | view-course-stages-test', function (hooks) {
     await visit('/courses/redis/stages/2');
     await coursePage.installCliLink.click();
 
-    const store = this.owner.lookup('service:store');
-    const analyticsEvents = await store.findAll('analytics-event', { backgroundReload: false });
-    const analyticsEventNames = analyticsEvents.map((analyticsEvent) => analyticsEvent.name);
+    const analyticsEvents = this.server.schema.analyticsEvents.all().models;
+    const filteredAnalyticsEvents = analyticsEvents.filter((event) => event.name !== 'feature_flag_called');
+    const filteredAnalyticsEventsNames = filteredAnalyticsEvents.map((event) => event.name);
 
-    assert.ok(analyticsEventNames.includes('clicked_cli_installation_link'), 'clicked_cli_installation_link event should be tracked');
+    assert.ok(filteredAnalyticsEventsNames .includes('clicked_cli_installation_link'), 'clicked_cli_installation_link event should be tracked');
   });
 
   test('header should have a badge that shows the remaining time in days', async function (assert) {

--- a/tests/acceptance/course-page/view-course-stages-test.js
+++ b/tests/acceptance/course-page/view-course-stages-test.js
@@ -553,8 +553,8 @@ module('Acceptance | course-page | view-course-stages-test', function (hooks) {
     const filteredAnalyticsEvents = analyticsEvents.filter((event) => event.name !== 'feature_flag_called');
     const filteredAnalyticsEventsNames = filteredAnalyticsEvents.map((event) => event.name);
 
-    assert.ok(filteredAnalyticsEventsNames .includes('collapsed_course_page_sidebar'), 'collapsed_course_page_sidebar event should be tracked');
-    assert.ok(filteredAnalyticsEventsNames .includes('expanded_course_page_sidebar'), 'expanded_course_page_sidebar event should be tracked');
+    assert.ok(filteredAnalyticsEventsNames.includes('collapsed_course_page_sidebar'), 'collapsed_course_page_sidebar event should be tracked');
+    assert.ok(filteredAnalyticsEventsNames.includes('expanded_course_page_sidebar'), 'expanded_course_page_sidebar event should be tracked');
   });
 
   test('it should have a working expand/collapse leaderboard button', async function (assert) {
@@ -575,8 +575,11 @@ module('Acceptance | course-page | view-course-stages-test', function (hooks) {
     const filteredAnalyticsEvents = analyticsEvents.filter((event) => event.name !== 'feature_flag_called');
     const filteredAnalyticsEventsNames = filteredAnalyticsEvents.map((event) => event.name);
 
-    assert.ok(filteredAnalyticsEventsNames .includes('collapsed_course_page_leaderboard'), 'collapsed_course_page_leaderboard event should be tracked');
-    assert.ok(filteredAnalyticsEventsNames .includes('expanded_course_page_leaderboard'), 'expanded_course_page_leaderboard event should be tracked');
+    assert.ok(
+      filteredAnalyticsEventsNames.includes('collapsed_course_page_leaderboard'),
+      'collapsed_course_page_leaderboard event should be tracked',
+    );
+    assert.ok(filteredAnalyticsEventsNames.includes('expanded_course_page_leaderboard'), 'expanded_course_page_leaderboard event should be tracked');
   });
 
   test('it should show a screencasts link in the second stage if there are screencasts available', async function (assert) {
@@ -663,7 +666,7 @@ module('Acceptance | course-page | view-course-stages-test', function (hooks) {
     const filteredAnalyticsEvents = analyticsEvents.filter((event) => event.name !== 'feature_flag_called');
     const filteredAnalyticsEventsNames = filteredAnalyticsEvents.map((event) => event.name);
 
-    assert.ok(filteredAnalyticsEventsNames .includes('clicked_monthly_challenge_banner'), 'clicked_monthly_challenge_banner event should be tracked');
+    assert.ok(filteredAnalyticsEventsNames.includes('clicked_monthly_challenge_banner'), 'clicked_monthly_challenge_banner event should be tracked');
   });
 
   test('stage should restrict admin access to user if user is course author and course is not authored by user', async function (assert) {
@@ -768,7 +771,7 @@ module('Acceptance | course-page | view-course-stages-test', function (hooks) {
     const filteredAnalyticsEvents = analyticsEvents.filter((event) => event.name !== 'feature_flag_called');
     const filteredAnalyticsEventsNames = filteredAnalyticsEvents.map((event) => event.name);
 
-    assert.ok(filteredAnalyticsEventsNames .includes('clicked_cli_installation_link'), 'clicked_cli_installation_link event should be tracked');
+    assert.ok(filteredAnalyticsEventsNames.includes('clicked_cli_installation_link'), 'clicked_cli_installation_link event should be tracked');
   });
 
   test('header should have a badge that shows the remaining time in days', async function (assert) {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Tests**
	- Updated acceptance tests for the course page to handle analytics events more efficiently by retrieving events from the server schema and filtering out specific event names.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->