### PR TITLE
participation-list-visibility-update

### DIFF
--- a/app/components/course-admin/stage-insights-page/participation-list-item.hbs
+++ b/app/components/course-admin/stage-insights-page/participation-list-item.hbs
@@ -27,8 +27,8 @@
       <circle cx="1" cy="1" r="1" />
     </svg>
     <div class="text-gray-400 text-xs">
-      Last attempt
-      <span class="font-semibold text-gray-500">{{date-from-now @participation.lastAttemptAt}}</span>
+      First attempt
+      <span class="font-semibold text-gray-500">{{date-from-now @participation.firstAttemptAt}}</span>
       <EmberTooltip @text="The number of times the user attempted this stage." />
     </div>
   </div>

--- a/app/components/course-admin/stage-insights-page/participation-list-section.hbs
+++ b/app/components/course-admin/stage-insights-page/participation-list-section.hbs
@@ -12,7 +12,11 @@
       Include single attempts
     </div>
 
-    <Toggle @isOn={{this.shouldShowParticipationsWithSingleAttempt}} {{on "click" this.handleShowParticipationsWithSingleAttemptToggle}} class="flex-shrink-0" />
+    <Toggle
+      @isOn={{this.shouldShowParticipationsWithSingleAttempt}}
+      {{on "click" this.handleShowParticipationsWithSingleAttemptToggle}}
+      class="flex-shrink-0"
+    />
   </div>
 </div>
 

--- a/app/components/course-admin/stage-insights-page/participation-list-section.hbs
+++ b/app/components/course-admin/stage-insights-page/participation-list-section.hbs
@@ -1,0 +1,19 @@
+<div class="border-b pb-1 flex items-center justify-between" ...attributes>
+  <div class="flex items-center gap-2">
+    <h1 class="text-2xl text-gray-700 font-bold tracking-tighter">{{@title}}</h1>
+
+    <div>
+      {{svg-jar "information-circle" class="w-4 h-4 fill-current text-gray-200 hover:text-gray-300"}}
+      <EmberTooltip @text={{@tooltipText}} />
+    </div>
+  </div>
+  <div class="flex items-center gap-2">
+    <div class="text-xs text-gray-400">
+      Include single attempts
+    </div>
+
+    <Toggle @isOn={{this.shouldShowParticipationsWithSingleAttempt}} {{on "click" this.handleShowParticipationsWithSingleAttemptToggle}} class="flex-shrink-0" />
+  </div>
+</div>
+
+<CourseAdmin::StageInsightsPage::ParticipationList @participations={{this.filteredParticipations}} class="mt-4" />

--- a/app/components/course-admin/stage-insights-page/participation-list-section.ts
+++ b/app/components/course-admin/stage-insights-page/participation-list-section.ts
@@ -1,0 +1,37 @@
+import { action } from '@ember/object';
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+import type CourseStageParticipationModel from 'codecrafters-frontend/models/course-stage-participation';
+
+type Signature = {
+  Element: HTMLDivElement;
+
+  Args: {
+    title: string;
+    tooltipText: string;
+    participations: CourseStageParticipationModel[];
+  };
+};
+
+export default class ParticipationListSectionComponent extends Component<Signature> {
+  @tracked shouldShowParticipationsWithSingleAttempt = false;
+
+  get filteredParticipations() {
+    if (this.shouldShowParticipationsWithSingleAttempt) {
+      return this.args.participations;
+    } else {
+      return this.args.participations.filter((participation) => participation.attemptsCount > 1);
+    }
+  }
+
+  @action
+  handleShowParticipationsWithSingleAttemptToggle() {
+    this.shouldShowParticipationsWithSingleAttempt = !this.shouldShowParticipationsWithSingleAttempt;
+  }
+}
+
+declare module '@glint/environment-ember-loose/registry' {
+  export default interface Registry {
+    'CourseAdmin::StageInsightsPage::ParticipationListSection': typeof ParticipationListSectionComponent;
+  }
+}

--- a/app/controllers/course-admin/stage-insights.ts
+++ b/app/controllers/course-admin/stage-insights.ts
@@ -11,21 +11,21 @@ export default class StageInsightsController extends Controller {
   get sortedActiveParticipations() {
     return this.model.stage.participations
       .filter((participation) => participation.status === 'active')
-      .sortBy('lastAttemptAt')
+      .sortBy('firstAttemptAt')
       .reverse();
   }
 
   get sortedCompleteParticipations() {
     return this.model.stage.participations
       .filter((participation) => participation.status === 'complete')
-      .sortBy('lastAttemptAt')
+      .sortBy('firstAttemptAt')
       .reverse();
   }
 
   get sortedDroppedOffParticipations() {
     return this.model.stage.participations
       .filter((participation) => participation.status === 'dropped_off')
-      .sortBy('lastAttemptAt')
+      .sortBy('firstAttemptAt')
       .reverse();
   }
 }

--- a/app/templates/course-admin/stage-insights.hbs
+++ b/app/templates/course-admin/stage-insights.hbs
@@ -25,13 +25,14 @@
     <div class="prose mt-4">
       <ul>
         <li>Total: {{this.participationAnalysis.participationsCount}}</li>
-        <li>Complete:
-          {{this.participationAnalysis.completeParticipationsCount}}
-          ({{this.participationAnalysis.completeParticipationsPercentage}}%)</li>
-        <li>Dropped off:
-          {{this.participationAnalysis.droppedOffParticipationsCount}}
-          ({{this.participationAnalysis.droppedOffParticipationsPercentage}}%)</li>
-        <li>Active: {{this.participationAnalysis.activeParticipationsCount}} ({{this.participationAnalysis.activeParticipationsPercentage}}%)</li>
+        <ul>
+          <li>Complete:
+            {{this.participationAnalysis.completeParticipationsCount}}
+            ({{this.participationAnalysis.completeParticipationsPercentage}}%)</li>
+          <li>Dropped off:
+            {{this.participationAnalysis.droppedOffParticipationsCount}}
+            ({{this.participationAnalysis.droppedOffParticipationsPercentage}}%)</li>
+        </ul>
       </ul>
     </div>
 
@@ -39,13 +40,6 @@
       @title="Dropped Off"
       @tooltipText="These are users who attempted this stage more than once but didn't complete it."
       @participations={{this.sortedDroppedOffParticipations}}
-      class="mt-6"
-    />
-
-    <CourseAdmin::StageInsightsPage::ParticipationListSection
-      @title="Active"
-      @tooltipText="These are users who attempted this stage in the past 7 days but haven't completed it yet."
-      @participations={{this.sortedActiveParticipations}}
       class="mt-6"
     />
 

--- a/app/templates/course-admin/stage-insights.hbs
+++ b/app/templates/course-admin/stage-insights.hbs
@@ -35,37 +35,25 @@
       </ul>
     </div>
 
-    <div class="border-b pb-1 flex items-center gap-2 mt-6">
-      <h1 class="text-2xl text-gray-700 font-bold tracking-tighter">Dropped Off</h1>
+    <CourseAdmin::StageInsightsPage::ParticipationListSection
+      @title="Dropped Off"
+      @tooltipText="These are users who attempted this stage more than once but didn't complete it."
+      @participations={{this.sortedDroppedOffParticipations}}
+      class="mt-6"
+    />
 
-      <div>
-        {{svg-jar "information-circle" class="w-4 h-4 fill-current text-gray-200 hover:text-gray-300"}}
-        <EmberTooltip @text="These are users who attempted this stage more than once but didn't complete it." />
-      </div>
-    </div>
+    <CourseAdmin::StageInsightsPage::ParticipationListSection
+      @title="Active"
+      @tooltipText="These are users who attempted this stage in the past 7 days but haven't completed it yet."
+      @participations={{this.sortedActiveParticipations}}
+      class="mt-6"
+    />
 
-    <CourseAdmin::StageInsightsPage::ParticipationList @participations={{this.sortedDroppedOffParticipations}} class="mt-4" />
-
-    <div class="border-b pb-1 flex items-center gap-2 mt-6">
-      <h1 class="text-2xl text-gray-700 font-bold tracking-tighter">Active</h1>
-
-      <div>
-        {{svg-jar "information-circle" class="w-4 h-4 fill-current text-gray-200 hover:text-gray-300"}}
-        <EmberTooltip @text="These are users who attempted this stage in the past 7 days but haven't completed it yet." />
-      </div>
-    </div>
-
-    <CourseAdmin::StageInsightsPage::ParticipationList @participations={{this.sortedActiveParticipations}} class="mt-4" />
-
-    <div class="border-b pb-1 flex items-center gap-2 mt-6">
-      <h1 class="text-2xl text-gray-700 font-bold tracking-tighter">Complete</h1>
-
-      <div>
-        {{svg-jar "information-circle" class="w-4 h-4 fill-current text-gray-200 hover:text-gray-300"}}
-        <EmberTooltip @text="These are users who completed this stage." />
-      </div>
-    </div>
-
-    <CourseAdmin::StageInsightsPage::ParticipationList @participations={{this.sortedCompleteParticipations}} class="mt-4" />
+    <CourseAdmin::StageInsightsPage::ParticipationListSection
+      @title="Complete"
+      @tooltipText="These are users who completed this stage."
+      @participations={{this.sortedCompleteParticipations}}
+      class="mt-6"
+    />
   </div>
 </div>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Introduced a new section in the course admin stage insights page for managing participation lists with enhanced functionality, including a toggle for displaying single attempts and a tooltip for additional information.
- **Improvements**
	- Updated the participation list item to display the "First attempt" date instead of the "Last attempt" date.
	- Enhanced the sorting logic in the Stage Insights Controller to sort participations by the first attempt date.
	- Refactored the stage insights page to use new `ParticipationListSection` components for improved modularity and readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->