### PR TITLE
refactor: Update naming conventions for extension activations

### DIFF
--- a/app/components/course-page/configure-extensions-modal/extension-card.ts
+++ b/app/components/course-page/configure-extensions-modal/extension-card.ts
@@ -29,7 +29,7 @@ export default class ExtensionCardComponent extends Component<Signature> {
   @tracked unsavedIsActivatedValue: boolean | null = null;
 
   get activations() {
-    return this.args.repository.courseExtensionActivations.filter((activation) => activation.extension === this.args.extension);
+    return this.args.repository.extensionActivations.filter((activation) => activation.extension === this.args.extension);
   }
 
   get isActivated(): boolean {

--- a/app/models/course-extension-activation.ts
+++ b/app/models/course-extension-activation.ts
@@ -4,7 +4,7 @@ import RepositoryModel from 'codecrafters-frontend/models/repository';
 
 export default class CourseExtensionActivation extends Model {
   @belongsTo('course-extension', { async: false, inverse: null }) declare extension: CourseExtensionModel;
-  @belongsTo('repository', { async: false, inverse: 'courseExtensionActivations' }) declare repository: RepositoryModel;
+  @belongsTo('repository', { async: false, inverse: 'extensionActivations' }) declare repository: RepositoryModel;
 
   @attr('date') declare activatedAt: Date;
 }

--- a/app/models/repository.ts
+++ b/app/models/repository.ts
@@ -39,7 +39,7 @@ export default class RepositoryModel extends Model {
 
   @hasMany('autofix-request', { async: false, inverse: 'repository' }) declare autofixRequests: AutofixRequestModel[];
   @belongsTo('course', { async: false, inverse: null }) declare course: CourseModel;
-  @hasMany('course-extension-activation', { async: false, inverse: 'repository' }) declare courseExtensionActivations: CourseExtensionActivation[];
+  @hasMany('course-extension-activation', { async: false, inverse: 'repository' }) declare extensionActivations: CourseExtensionActivation[];
   @hasMany('course-stage-completion', { async: false, inverse: 'repository' }) declare courseStageCompletions: CourseStageCompletionModel[];
   @hasMany('course-stage-feedback-submission', { async: false, inverse: 'repository' })
   declare courseStageFeedbackSubmissions: CourseStageFeedbackSubmissionModel[];
@@ -63,7 +63,7 @@ export default class RepositoryModel extends Model {
   @attr('number') declare submissionsCount: number;
 
   get activatedCourseExtensions() {
-    return this.courseExtensionActivations
+    return this.extensionActivations
       .sortBy('activatedAt')
       .map((activation) => activation.extension)
       .uniq();

--- a/app/utils/repository-poller.js
+++ b/app/utils/repository-poller.js
@@ -3,9 +3,9 @@ import Poller from 'codecrafters-frontend/utils/poller';
 export default class RepositoryPoller extends Poller {
   static defaultIncludedResources = [
     'language',
-    'course-extension-activations',
-    'course-extension-activations.extension',
-    'course-extension-activations.repository',
+    'extension-activations',
+    'extension-activations.extension',
+    'extension-activations.repository',
     'course',
     'course.extensions',
     'user',

--- a/mirage/utils/sync-repository-stage-lists.js
+++ b/mirage/utils/sync-repository-stage-lists.js
@@ -27,7 +27,7 @@ function syncRepositoryStageList(server, repository) {
   let currentStageListItemPosition = 1;
   let firstIncompleteStage = null;
 
-  const activatedExtensionSlugs = repository.courseExtensionActivations.models.map((activation) => activation.extension.slug);
+  const activatedExtensionSlugs = repository.extensionActivations.models.map((activation) => activation.extension.slug);
 
   const stageIdToStageListItem = {};
 


### PR DESCRIPTION
- Updated naming conventions from 'course-extension-activations' to 'extension-activations' to provide clarity and consistency throughout the codebase.
- Renamed variables and references in RepositoryPoller, RepositoryModel, CourseExtensionActivation, and ExtensionCardComponent for better code readability and maintainability.