### PR TITLE
refactor: Remove isDisabled property from RepositoryStageListItemModel

### DIFF
--- a/app/models/repository-stage-list-item.ts
+++ b/app/models/repository-stage-list-item.ts
@@ -8,7 +8,6 @@ export default class RepositoryStageListItemModel extends Model {
 
   @attr('date') declare completedAt: Date | null; // If the user completed the stage, when they did
   @attr('boolean') declare isCurrent: boolean; // Whether this is the current stage
-  @attr('boolean') declare isDisabled: boolean;
   @attr('number') declare position: number; // The position of the stage in the list
 
   get isBaseStage(): boolean {
@@ -17,10 +16,6 @@ export default class RepositoryStageListItemModel extends Model {
 
   get isCompleted(): boolean {
     return this.completedAt !== null;
-  }
-
-  get isEnabled(): boolean {
-    return !this.isDisabled;
   }
 
   get isExtensionStage(): boolean {

--- a/app/utils/course-page-step-list.ts
+++ b/app/utils/course-page-step-list.ts
@@ -39,7 +39,7 @@ export class StepList {
     if (!this.repository.stageList) {
       this.repository.course.sortedBaseStages.forEach((stage) => {
         // TODO: Find better way around this?
-        const fakeStageListItem = { stage: stage, isDisabled: false } as RepositoryStageListItemModel;
+        const fakeStageListItem = { stage: stage } as RepositoryStageListItemModel;
         steps.push(new CourseStageStep(this.repository, fakeStageListItem));
       });
     } else {
@@ -65,7 +65,7 @@ export class StepList {
         const steps: Step[] = [];
 
         extension.sortedStages.forEach((stage) => {
-          const fakeStageListItem = { stage, isDisabled: false } as RepositoryStageListItemModel;
+          const fakeStageListItem = { stage } as RepositoryStageListItemModel;
           steps.push(new CourseStageStep(this.repository, fakeStageListItem));
         });
 


### PR DESCRIPTION
Removed the isDisabled property from RepositoryStageListItemModel as it was not being used and did not serve any purpose. This simplifies the code and improves clarity.