### PR TITLE
feat: Add optional icon field to tab signature

### DIFF
--- a/app/components/tabs.hbs
+++ b/app/components/tabs.hbs
@@ -1,4 +1,3 @@
-{{! @glint-nocheck: not typesafe yet }}
 <div>
   <ul class="flex items-center overflow-x-scroll pb-4 mb-2">
     {{#each @tabs as |tab|}}

--- a/app/components/tabs.ts
+++ b/app/components/tabs.ts
@@ -6,6 +6,7 @@ type Signature = {
     tabs: {
       slug: string;
       title: string;
+      icon?: string;
     }[];
   };
 


### PR DESCRIPTION
Added an optional icon field to the Signature type in order to provide
icon support for tabs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit


- **New Features**
	- Introduced an optional icon for tabs to enhance user interface.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->