### PR TITLE
CC-1079 truncate large github usernames

### DIFF
--- a/app/components/user-page/sidebar-container.hbs
+++ b/app/components/user-page/sidebar-container.hbs
@@ -6,7 +6,7 @@
     {{@user.name}}
   </div>
 
-  <a class="group inline-flex items-center text-gray-400 mb-4" href={{@user.githubProfileUrl}}>
+  <a class="group inline-flex items-center text-gray-400 mb-4 w-full" href={{@user.githubProfileUrl}}>
     <div class="text-lg group-hover:underline truncate">
       {{@user.githubUsername}}
     </div>

--- a/app/components/user-page/sidebar-container.hbs
+++ b/app/components/user-page/sidebar-container.hbs
@@ -7,7 +7,7 @@
   </div>
 
   <a class="group inline-flex items-center text-gray-400 mb-4" href={{@user.githubProfileUrl}}>
-    <div class="text-lg group-hover:underline">
+    <div class="text-lg group-hover:underline truncate">
       {{@user.githubUsername}}
     </div>
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Style**
	- Improved the display of GitHub usernames in the sidebar by truncating longer names to ensure a cleaner, more uniform appearance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->