### PR TITLE
refactor: Remove redundant isExpanded and onCollapseButtonClick props

### DIFF
--- a/app/components/course-page/course-stage-step/community-solution-card.hbs
+++ b/app/components/course-page/course-stage-step/community-solution-card.hbs
@@ -4,10 +4,7 @@
   ...attributes
   {{did-insert this.handleDidInsert}}
 >
-  <CoursePage::CourseStageStep::CommunitySolutionCard::Header
-    @solution={{@solution}}
-    class="mb-3"
-  />
+  <CoursePage::CourseStageStep::CommunitySolutionCard::Header @solution={{@solution}} class="mb-3" />
 
   <div class={{if this.isExpanded "visible" "hidden"}}>
     <button

--- a/app/components/course-page/course-stage-step/community-solution-card.hbs
+++ b/app/components/course-page/course-stage-step/community-solution-card.hbs
@@ -6,10 +6,22 @@
 >
   <CoursePage::CourseStageStep::CommunitySolutionCard::Header
     @solution={{@solution}}
-    @isExpanded={{this.isExpanded}}
-    @onCollapseButtonClick={{this.handleCollapseButtonClick}}
     class="mb-3"
   />
+
+  <div class={{if this.isExpanded "visible" "hidden"}}>
+    <button
+      class="mb-3 border hover:bg-gray-100 hover:border-gray-300 transition-colors px-4 py-5 text-gray-700 text-sm rounded flex flex-col items-center w-full group"
+      type="button"
+      {{on "click" this.handleCollapseButtonClick}}
+      data-test-collapse-button
+    >
+      <div class="font-bold flex items-center sm:mb-0">
+        Collapse example
+        {{svg-jar "arrow-up" class="w-4 ml-2 fill-current"}}
+      </div>
+    </button>
+  </div>
 
   <div class="{{if this.isCollapsed 'h-72 overflow-hidden'}}">
     <CoursePage::CourseStageStep::CommunitySolutionCard::Content

--- a/app/components/course-page/course-stage-step/community-solution-card/header.hbs
+++ b/app/components/course-page/course-stage-step/community-solution-card/header.hbs
@@ -14,19 +14,6 @@
     {{/if}}
   </div>
 
-  <div class={{if @isExpanded "visible" "hidden"}}>
-    <button
-      class="border hover:bg-gray-100 hover:border-gray-300 transition-colors px-2 py-1.5 text-gray-700 text-xs rounded flex flex-col items-center w-full"
-      type="button"
-      {{on "click" @onCollapseButtonClick}}
-    >
-      <div class="font-bold flex items-center sm:mb-0">
-        Collapse example
-        {{svg-jar "arrow-up" class="w-3 ml-1 fill-current"}}
-      </div>
-    </button>
-  </div>
-
   <div class="flex items-center shrink-0">
     {{#if (or (current-user-is-staff) (current-user-is-course-author @solution.courseStage.course))}}
       <div class="flex items-center">

--- a/app/components/course-page/course-stage-step/community-solution-card/header.ts
+++ b/app/components/course-page/course-stage-step/community-solution-card/header.ts
@@ -6,8 +6,6 @@ type Signature = {
 
   Args: {
     solution: CommunityCourseStageSolutionModel;
-    isExpanded: boolean;
-    onCollapseButtonClick: () => void;
   };
 };
 

--- a/tests/pages/course-page.js
+++ b/tests/pages/course-page.js
@@ -43,8 +43,12 @@ export default create({
     languageDropdown: LanguageDropdown,
 
     solutionCards: collection('[data-test-community-solution-card]', {
+      clickOnCollapseButton: async function () {
+        await this.collapseButtons.at(0).click();
+      },
+
       clickOnExpandButton: clickable('[data-test-expand-button]'),
-      clickOnCollapseButton: clickable('[data-test-collapse-button]'),
+      collapseButtons: collection('[data-test-collapse-button]'),
       toggleCommentsButtons: collection('[data-test-toggle-comments-button]'),
       commentCards: collection('[data-test-comment-card]', CommentCard),
     }),

--- a/tests/pages/course-page.js
+++ b/tests/pages/course-page.js
@@ -44,7 +44,7 @@ export default create({
 
     solutionCards: collection('[data-test-community-solution-card]', {
       clickOnCollapseButton: async function () {
-        await this.collapseButtons.at(0).click();
+        await this.collapseButtons[0].click();
       },
 
       clickOnExpandButton: clickable('[data-test-expand-button]'),


### PR DESCRIPTION
The isExpanded and onCollapseButtonClick props are no longer needed as they were replaced with this.isExpanded and this.handleCollapseButtonClick within the component. The unnecessary props have been removed to clean up the code.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Added a button to collapse examples in the community solution card, enhancing user interaction.
- **Refactor**
	- Simplified the community solution card by adjusting how examples are expanded or collapsed.
- **Style**
	- Updated styling for the new collapse functionality in community solution cards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->