### PR TITLE
feat(view): Add screencast details to selected screencast player

### DIFF
--- a/app/components/course-page/course-stage-step/community-solution-card/header.hbs
+++ b/app/components/course-page/course-stage-step/community-solution-card/header.hbs
@@ -18,6 +18,17 @@
         <EmberTooltip @text="This solution was hand-picked by CodeCrafters staff." />
       </Pill>
     {{/if}}
+
+    {{#if @solution.screencast}}
+      <LinkTo @route="course.stage.screencasts" @query={{hash selectedScreencastId=@solution.screencast.id}} class="flex">
+        <Pill @color="blue">
+          {{svg-jar "play" class="w-4 h-4 mr-1 text-blue-500"}}
+          Screencast
+
+          <EmberTooltip @text="This solution has a linked screencast. Click to view." />
+        </Pill>
+      </LinkTo>
+    {{/if}}
   </div>
 
   <div class="flex items-center shrink-0">

--- a/app/controllers/course/stage/code-examples.ts
+++ b/app/controllers/course/stage/code-examples.ts
@@ -99,7 +99,7 @@ export default class CodeExamplesController extends Controller {
     this.solutions = (await this.store.query('community-course-stage-solution', {
       course_stage_id: this.courseStage.id,
       language_id: this.currentLanguage.id,
-      include: 'user,language,course-stage',
+      include: 'user,language,course-stage,screencasts',
       order: this.order,
     })) as unknown as CommunityCourseStageSolutionModel[]; // TODO: Doesn't store.query support model type inference?
 

--- a/app/models/community-course-stage-solution.ts
+++ b/app/models/community-course-stage-solution.ts
@@ -11,6 +11,7 @@ import { FileComparisonFromJSON, type FileComparison } from 'codecrafters-fronte
 
 /* eslint-disable ember/no-mixins */
 import ViewableMixin from 'codecrafters-frontend/mixins/viewable';
+import type CourseStageScreencastModel from './course-stage-screencast';
 
 export default class CommunityCourseStageSolutionModel extends Model.extend(ViewableMixin) {
   static defaultIncludedResources = ['user', 'language', 'comments', 'comments.user', 'comments.target', 'course-stage'];
@@ -22,6 +23,7 @@ export default class CommunityCourseStageSolutionModel extends Model.extend(View
   @belongsTo('user', { async: false, inverse: null }) declare user: UserModel;
 
   @hasMany('community-course-stage-solution-comment', { async: false, inverse: 'target' }) declare comments: CourseStageCommentModel[];
+  @hasMany('course-stage-screencast', { async: false, inverse: null }) declare screencasts: CourseStageScreencastModel[];
 
   // @ts-expect-error empty '' not supported
   @attr('') changedFiles: { diff: string; filename: string }[]; // free-form JSON
@@ -73,6 +75,10 @@ export default class CommunityCourseStageSolutionModel extends Model.extend(View
     }
 
     return Math.round(this.ratingStandardDeviation * 100) / 100;
+  }
+
+  get screencast() {
+    return this.screencasts[0];
   }
 
   @action

--- a/app/templates/course/stage/screencasts.hbs
+++ b/app/templates/course/stage/screencasts.hbs
@@ -5,13 +5,32 @@
       <FeedbackButton @source="screencast" class="font-blue-500 hover:font-blue-600 font-semibold underline">feedback</FeedbackButton>
     </div>.
   </Alert>
+
   {{#if this.selectedScreencast}}
-    {{! @glint-expect-error: not typesafe yet }}
-    <CourseStageScreencastPlayer
-      @screencast={{this.selectedScreencast}}
-      class="border-b pb-8 mb-8 scroll-mt-16"
-      {{did-insert this.handleDidInsertScreencastPlayer}}
-    />
+    <div class="border-b mb-8 scroll-mt-16" {{did-insert this.handleDidInsertScreencastPlayer}}>
+      {{! @glint-expect-error: not typesafe yet }}
+      <CourseStageScreencastPlayer @screencast={{this.selectedScreencast}} />
+
+      <div class="py-8">
+        <Pill @color="green">
+          {{this.selectedScreencast.language.name}}
+        </Pill>
+        <div class="font-semibold text-gray-800 text-xl mt-2" data-test-screencasts-previews-title>
+          {{this.selectedScreencast.title}}
+        </div>
+        <div class="flex items-center gap-3 mt-3">
+          <div class="flex items-center gap-1">
+            <img src={{this.selectedScreencast.sourceIconUrl}} class="h-5" alt="source" />
+            <div class="text-gray-600 text-xs">{{this.selectedScreencast.authorName}}</div>
+          </div>
+          <div class="w-px h-3 bg-gray-200"></div>
+          <div class="flex items-center">
+            {{svg-jar "calendar" class="w-4 text-gray-300 mr-1.5"}}
+            <div class="text-gray-600 text-xs">{{date-from-now this.selectedScreencast.publishedAt}}</div>
+          </div>
+        </div>
+      </div>
+    </div>
   {{/if}}
 
   <div class="grid grid-cols-1 gap-6 pb-16">


### PR DESCRIPTION
Added the display of screencast details such as language, title, author,
source icon, author name, publication date to the selected screencast
player. Also, updated the logic to show a linked screencast pill if a
screencast is present in the solution.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a "Screencast" indicator for community solutions that include screencasts, enhancing the visibility of available learning resources.
	- Expanded the course stage interface to display detailed screencast information, including language, title, author, and publication date, providing a richer user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->