### PR TITLE
refactor: Update access control logic for membership benefits

### DIFF
--- a/app/components/referral-link-page/accept-referral-container.hbs
+++ b/app/components/referral-link-page/accept-referral-container.hbs
@@ -65,8 +65,10 @@
           <EmberTooltip
             @text="You've already accepted another referral offer. You can refer other users to get more free weeks. Visit /refer to get started."
           />
-        {{else if this.currentUser.canAccessPaidContent}}
+        {{else if this.currentUser.canAccessMembershipBenefits}}
           <EmberTooltip @text="As a CodeCrafters member, you already have full access." />
+        {{else if this.currentUser.canAccessPaidContent}}
+          <EmberTooltip @text="You already have full access to CodeCrafters content." />
         {{/if}}
       </div>
 

--- a/app/models/user.ts
+++ b/app/models/user.ts
@@ -73,8 +73,12 @@ export default class UserModel extends Model {
     return `${config.x.backendUrl}/admin/users/${this.id}`;
   }
 
+  get canAccessMembershipBenefits() {
+    return this.isVip || this.hasActiveSubscription || this.teamHasActiveSubscription || this.teamHasActivePilot;
+  }
+
   get canAccessPaidContent() {
-    return this.isVip || this.hasActiveSubscription || this.teamHasActiveSubscription || this.teamHasActivePilot || this.hasActiveFreeUsageGrants;
+    return this.canAccessMembershipBenefits || this.hasActiveFreeUsageGrants;
   }
 
   get codecraftersProfileUrl() {

--- a/app/routes/perk/claim.ts
+++ b/app/routes/perk/claim.ts
@@ -21,7 +21,7 @@ export default class PerksClaimRoute extends BaseRoute {
     await this.authenticator.authenticate();
     const perk = this.modelFor('perk') as PerkModel;
 
-    if (this.authenticator.currentUser!.canAccessPaidContent) {
+    if (this.authenticator.currentUser!.canAccessMembershipBenefits) {
       return (await perk.claim({})) as unknown as { claim_url: string };
     }
 

--- a/app/services/billing-status-display.ts
+++ b/app/services/billing-status-display.ts
@@ -12,7 +12,12 @@ export default class BillingStatusDisplayService extends Service {
   }
 
   get shouldShowFreeWeeksLeftButton(): boolean {
-    return !!this.currentUser && this.currentUser.hasActiveFreeUsageGrants && !this.currentUser.hasActiveFreeUsageGrantsValueIsOutdated;
+    return (
+      !!this.currentUser &&
+      !this.currentUser.canAccessMembershipBenefits &&
+      this.currentUser.hasActiveFreeUsageGrants &&
+      !this.currentUser.hasActiveFreeUsageGrantsValueIsOutdated
+    );
   }
 
   get shouldShowSubscribeButton(): boolean {


### PR DESCRIPTION
- Update shouldShowFreeWeeksLeftButton logic to include check for 
  canAccessMembershipBenefits.
- Update PerksClaimRoute to use canAccessMembershipBenefits instead of 
  canAccessPaidContent.
- Modify conditional rendering for tooltips in the UserModel template to 
  reflect canAccessMembershipBenefits status.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Improved logic for displaying tooltips based on user access rights.
	- Added a new property to enhance checks for user access to membership benefits.
- **Bug Fixes**
	- Updated conditions for accessing paid content and membership benefits to ensure accurate access control.
	- Refined the display logic for the "Free Weeks Left" button to better reflect user entitlements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->