### PR TITLE
feat: Refactor username section for ProfilePage component

### DIFF
--- a/app/components/settings/profile-page/about-section.hbs
+++ b/app/components/settings/profile-page/about-section.hbs
@@ -1,0 +1,38 @@
+<Settings::FormSection @title="About" @description="Shown on your profile page">
+  <div>
+    {{! template-lint-disable require-input-label }}
+    <Textarea
+      @value={{@user.profileDescriptionMarkdown}}
+      class="text-sm rounded px-3 py-2 placeholder-gray-300 focus:outline-none focus:ring-2 focus:ring-teal-500 border border-gray-300 shadow-sm w-full"
+      placeholder="I'm a software engineer who loves building things. Here are some of my projects..."
+      rows="3"
+      required
+      {{autoresize @user.profileDescriptionMarkdown}}
+      {{markdown-input}}
+      {{on "blur" this.handleBlur}}
+    />
+  </div>
+
+  <div class="text-xs mt-1">
+    {{#if this.isUpdating}}
+      <span class="text-teal-500 font-semibold">
+        Saving...
+      </span>
+    {{else if this.wasUpdatedRecently}}
+      <span class="text-teal-500 font-semibold">
+        Saved!
+      </span>
+    {{else}}
+      <span class="text-gray-400">
+        Displayed on your profile page. Markdown supported.
+      </span>
+    {{/if}}
+  </div>
+
+  <TertiaryLinkButton class="mt-4" @size="extra-small" @route="user" @models={{array @user.username}} @shouldOpenInNewTab={{true}}>
+    <div class="flex items-center gap-1">
+      {{svg-jar "external-link" class="w-4 h-4 text-gray-400"}}
+      Preview
+    </div>
+  </TertiaryLinkButton>
+</Settings::FormSection>

--- a/app/components/settings/profile-page/about-section.ts
+++ b/app/components/settings/profile-page/about-section.ts
@@ -1,0 +1,49 @@
+import { action } from '@ember/object';
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+import type UserModel from 'codecrafters-frontend/models/user';
+import { task, timeout } from 'ember-concurrency';
+
+interface Signature {
+  Element: HTMLDivElement;
+
+  Args: {
+    user: UserModel;
+  };
+}
+
+export default class AboutSectionComponent extends Component<Signature> {
+  @tracked isUpdating = false;
+  @tracked wasUpdatedRecently = false;
+
+  @action
+  async handleBlur() {
+    this.updateValue.perform();
+  }
+
+  updateValue = task({ keepLatest: true }, async (): Promise<void> => {
+    this.isUpdating = true;
+    this.wasUpdatedRecently = false;
+
+    try {
+      await this.args.user.save();
+    } catch (e) {
+      console.error(e);
+
+      // TODO: Handle error state?
+
+      return;
+    }
+
+    this.isUpdating = false;
+    this.wasUpdatedRecently = true;
+    await timeout(1000);
+    this.wasUpdatedRecently = false;
+  });
+}
+
+declare module '@glint/environment-ember-loose/registry' {
+  export default interface Registry {
+    'Settings::ProfilePage::AboutSection': typeof AboutSectionComponent;
+  }
+}

--- a/app/components/settings/profile-page/anonymous-mode-section.hbs
+++ b/app/components/settings/profile-page/anonymous-mode-section.hbs
@@ -1,0 +1,24 @@
+<Settings::FormSection @title="Anonymous Mode" @description="Hide your GitHub username & avatar">
+  <:belowDescription>
+    <Pill @color="green">
+      {{svg-jar "shield-check" class="w-4 h-4 text-green-500 mr-1"}}
+      Members only
+
+      <EmberTooltip @text="This feature is only available to CodeCrafters members." />
+    </Pill>
+  </:belowDescription>
+  <:default>
+    <div class="flex items-center gap-3">
+      <Toggle @isOn={{@user.hasAnonymousModeEnabled}} @isDisabled={{not @user.canAccessMembershipBenefits}} {{on "click" this.handleToggle}} />
+      <div class="text-gray-600 text-sm">Enable anonymous mode</div>
+
+      {{#unless @user.canAccessMembershipBenefits}}
+        <EmberTooltip @text="Become a CodeCrafters member to enable this feature." />
+      {{/unless}}
+    </div>
+    <div class="text-gray-400 text-xs mt-4 leading-relaxed">
+      When anonymous mode is enabled, your GitHub username &amp; avatar will be hidden on CodeCrafters. Your code examples &amp; profile page will
+      still be visible to the public, but under a random username.
+    </div>
+  </:default>
+</Settings::FormSection>

--- a/app/components/settings/profile-page/anonymous-mode-section.ts
+++ b/app/components/settings/profile-page/anonymous-mode-section.ts
@@ -1,0 +1,45 @@
+import { action } from '@ember/object';
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+import type UserModel from 'codecrafters-frontend/models/user';
+import { task } from 'ember-concurrency';
+
+interface Signature {
+  Element: HTMLDivElement;
+
+  Args: {
+    user: UserModel;
+  };
+}
+
+export default class AnonymousModeSectionComponent extends Component<Signature> {
+  @tracked isSaving = false;
+
+  @action
+  async handleToggle() {
+    this.toggleValue.perform();
+  }
+
+  toggleValue = task({ keepLatest: true }, async (): Promise<void> => {
+    this.isSaving = true;
+
+    try {
+      this.args.user.hasAnonymousModeEnabled = !this.args.user.hasAnonymousModeEnabled;
+      await this.args.user.save();
+    } catch (e) {
+      console.error(e);
+
+      // TODO: Handle error state?
+
+      return;
+    }
+
+    this.isSaving = false;
+  });
+}
+
+declare module '@glint/environment-ember-loose/registry' {
+  export default interface Registry {
+    'Settings::ProfilePage::AnonymousModeSection': typeof AnonymousModeSectionComponent;
+  }
+}

--- a/app/components/settings/profile-page/username-section.hbs
+++ b/app/components/settings/profile-page/username-section.hbs
@@ -1,0 +1,26 @@
+<Settings::FormSection @title="Username" @description="Your publicly visible username on CodeCrafters">
+  <div>
+    {{! template-lint-disable require-input-label }}
+    <Input
+      @value={{@user.username}}
+      class="text-sm rounded px-3 py-2 bg-gray-50 border w-full text-gray-500 font-mono cursor-not-allowed"
+      placeholder="cool_username"
+      disabled={{true}}
+    />
+
+    {{!-- TODO: Bring this back once implemented }}
+    {{!-- <EmberTooltip @text="This value is synced with your GitHub account. Click on the refresh button below to update your username." /> --}}
+    <EmberTooltip @text="This value is synced with your GitHub account." />
+  </div>
+  <div class="text-gray-400 text-xs mt-1">
+    This value is synced with your GitHub account.
+  </div>
+
+  {{!-- TODO: Bring this back once implemented }}
+  {{!-- <TertiaryButtonWithSpinner @size="extra-small" class="mt-4" @shouldShowSpinner={{false}}>
+    <div class="flex items-center gap-1">
+      {{svg-jar "refresh" class="w-4 h-4 text-gray-400"}}
+      Refresh from GitHub
+    </div>
+  </TertiaryButtonWithSpinner> --}}
+</Settings::FormSection>

--- a/app/components/settings/profile-page/username-section.ts
+++ b/app/components/settings/profile-page/username-section.ts
@@ -1,0 +1,18 @@
+import Component from '@glimmer/component';
+import type UserModel from 'codecrafters-frontend/models/user';
+
+interface Signature {
+  Element: HTMLDivElement;
+
+  Args: {
+    user: UserModel;
+  };
+}
+
+export default class UsernameSectionComponent extends Component<Signature> {}
+
+declare module '@glint/environment-ember-loose/registry' {
+  export default interface Registry {
+    'Settings::ProfilePage::UsernameSection': typeof UsernameSectionComponent;
+  }
+}

--- a/app/components/user-page/sidebar-container.hbs
+++ b/app/components/user-page/sidebar-container.hbs
@@ -6,13 +6,15 @@
     {{@user.name}}
   </div>
 
-  <a class="group inline-flex items-center text-gray-400 mb-4 w-full" href={{@user.githubProfileUrl}}>
-    <div class="text-lg group-hover:underline truncate">
-      {{@user.githubUsername}}
-    </div>
+  {{#unless @user.hasAnonymousModeEnabled}}
+    <a class="group inline-flex items-center text-gray-400 mb-4 w-full" href={{@user.githubProfileUrl}}>
+      <div class="text-lg group-hover:underline truncate">
+        {{@user.githubUsername}}
+      </div>
 
-    {{svg-jar "github" class="fill-current w-5 ml-2 group-hover:text-gray-500"}}
-  </a>
+      {{svg-jar "github" class="fill-current w-5 ml-2 group-hover:text-gray-500"}}
+    </a>
+  {{/unless}}
 
   {{#if (gt @user.completedCourseParticipations.length 0)}}
     <div class="mb-4 flex items-center space-x-1.5">

--- a/app/controllers/settings/profile.ts
+++ b/app/controllers/settings/profile.ts
@@ -1,37 +1,6 @@
 import Controller from '@ember/controller';
-import { action } from '@ember/object';
-import { tracked } from '@glimmer/tracking';
 import type { ModelType } from 'codecrafters-frontend/routes/settings';
-import { task, timeout } from 'ember-concurrency';
 
 export default class ProfileController extends Controller {
   declare model: ModelType;
-
-  @tracked isUpdatingProfileDescriptionMarkdown = false;
-  @tracked profileDescriptionMarkdownWasUpdatedRecently = false;
-
-  @action
-  async handleProfileDescriptionMarkdownUpdated() {
-    this.updateProfileDescriptionMarkdown.perform();
-  }
-
-  updateProfileDescriptionMarkdown = task({ keepLatest: true }, async (): Promise<void> => {
-    this.isUpdatingProfileDescriptionMarkdown = true;
-    this.profileDescriptionMarkdownWasUpdatedRecently = false;
-
-    try {
-      await this.model.user.save();
-    } catch (e) {
-      console.error(e);
-
-      // TODO: Handle error state?
-
-      return;
-    }
-
-    this.isUpdatingProfileDescriptionMarkdown = false;
-    this.profileDescriptionMarkdownWasUpdatedRecently = true;
-    await timeout(1000);
-    this.profileDescriptionMarkdownWasUpdatedRecently = false;
-  });
 }

--- a/app/models/user.ts
+++ b/app/models/user.ts
@@ -33,6 +33,7 @@ export default class UserModel extends Model {
   @attr() declare featureFlags: { [key: string]: string };
   @attr('string') declare githubUsername: string;
   @attr('boolean') declare hasActiveFreeUsageGrants: boolean;
+  @attr('boolean') declare hasAnonymousModeEnabled: boolean;
   @attr('boolean') declare isAdmin: boolean;
   @attr('boolean') declare isAffiliate: boolean;
   @attr('boolean') declare isConceptAuthor: boolean;

--- a/app/templates/settings/profile.hbs
+++ b/app/templates/settings/profile.hbs
@@ -1,31 +1,5 @@
 <Settings::ProfilePage::UsernameSection @user={{@model.user}} />
-
-{{! This isn't implemented yet }}
-{{!-- <Settings::FormDivider />
-
-<Settings::FormSection @title="Anonymous Mode" @description="Hide your GitHub username & avatar">
-  <:belowDescription>
-    <Pill @color="green">
-      {{svg-jar "shield-check" class="w-4 h-4 text-green-500 mr-1"}}
-      Members only
-
-      <EmberTooltip @text="This feature is only available to CodeCrafters members." />
-    </Pill>
-  </:belowDescription>
-  <:default>
-    <div class="flex items-center gap-3">
-      <Toggle @isOn={{true}} />
-      <div class="text-gray-600 text-sm">Enable anonymous mode</div>
-    </div>
-    <div class="text-gray-400 text-xs mt-4 leading-relaxed">
-      When anonymous mode is enabled, your GitHub username &amp; avatar will be hidden on CodeCrafters. Your code examples &amp; profile page will
-      still be visible to the public, but under a random username.
-    </div>
-  </:default>
-</Settings::FormSection>
-
---}}
-
 <Settings::FormDivider />
-
+<Settings::ProfilePage::AnonymousModeSection @user={{@model.user}} />
+<Settings::FormDivider />
 <Settings::ProfilePage::AboutSection @user={{@model.user}} />

--- a/app/templates/settings/profile.hbs
+++ b/app/templates/settings/profile.hbs
@@ -1,29 +1,4 @@
-<Settings::FormSection @title="Username" @description="Your publicly visible username on CodeCrafters">
-  <div>
-    {{! template-lint-disable require-input-label }}
-    <Input
-      @value={{@model.user.username}}
-      class="text-sm rounded px-3 py-2 bg-gray-50 border w-full text-gray-500 font-mono cursor-not-allowed"
-      placeholder="cool_username"
-      disabled={{true}}
-    />
-
-    {{!-- TODO: Bring this back once implemented }}
-    {{!-- <EmberTooltip @text="This value is synced with your GitHub account. Click on the refresh button below to update your username." /> --}}
-    <EmberTooltip @text="This value is synced with your GitHub account." />
-  </div>
-  <div class="text-gray-400 text-xs mt-1">
-    This value is synced with your GitHub account.
-  </div>
-
-  {{!-- TODO: Bring this back once implemented }}
-  {{!-- <TertiaryButtonWithSpinner @size="extra-small" class="mt-4" @shouldShowSpinner={{false}}>
-    <div class="flex items-center gap-1">
-      {{svg-jar "refresh" class="w-4 h-4 text-gray-400"}}
-      Refresh from GitHub
-    </div>
-  </TertiaryButtonWithSpinner> --}}
-</Settings::FormSection>
+<Settings::ProfilePage::UsernameSection @user={{@model.user}} />
 
 {{! This isn't implemented yet }}
 {{!-- <Settings::FormDivider />
@@ -53,41 +28,4 @@
 
 <Settings::FormDivider />
 
-<Settings::FormSection @title="About" @description="Shown on your profile page">
-  <div>
-    {{! template-lint-disable require-input-label }}
-    <Textarea
-      @value={{@model.user.profileDescriptionMarkdown}}
-      class="text-sm rounded px-3 py-2 placeholder-gray-300 focus:outline-none focus:ring-2 focus:ring-teal-500 border border-gray-300 shadow-sm w-full"
-      placeholder="I'm a software engineer who loves building things. Here are some of my projects..."
-      rows="3"
-      required
-      {{autoresize @model.user.profileDescriptionMarkdown}}
-      {{markdown-input}}
-      {{on "blur" this.handleProfileDescriptionMarkdownUpdated}}
-    />
-  </div>
-
-  <div class="text-xs mt-1">
-    {{#if this.isUpdatingProfileDescriptionMarkdown}}
-      <span class="text-teal-500 font-semibold">
-        Saving...
-      </span>
-    {{else if this.profileDescriptionMarkdownWasUpdatedRecently}}
-      <span class="text-teal-500 font-semibold">
-        Saved!
-      </span>
-    {{else}}
-      <span class="text-gray-400">
-        Displayed on your profile page. Markdown supported.
-      </span>
-    {{/if}}
-  </div>
-
-  <TertiaryLinkButton class="mt-4" @size="extra-small" @route="user" @models={{array "rohitpaulk"}} @shouldOpenInNewTab={{true}}>
-    <div class="flex items-center gap-1">
-      {{svg-jar "external-link" class="w-4 h-4 text-gray-400"}}
-      Preview
-    </div>
-  </TertiaryLinkButton>
-</Settings::FormSection>
+<Settings::ProfilePage::AboutSection @user={{@model.user}} />


### PR DESCRIPTION
- Moved username section to a separate component for reusability
- Updated the component structure to optimize code organization
- Simplified the implementation for better code readability

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
    - Added functionality for users to input and display markdown-formatted descriptions in the profile settings.
    - Introduced a feature to enable anonymous mode, allowing users to hide their GitHub username and avatar.

- **Refactor**
    - Restructured the profile settings to use dedicated components for managing the username, about section, and anonymous mode.
    - Enhanced user experience by simplifying UI elements and interactions in the profile settings.

- **Chores**
    - Removed outdated code related to profile description updates from the profile controller.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->