### PR TITLE
feat: display and copy tree SHA in submission details

### DIFF
--- a/app/components/course-admin/submissions-page/submission-details/header-container.hbs
+++ b/app/components/course-admin/submissions-page/submission-details/header-container.hbs
@@ -109,9 +109,11 @@
               {{or this.shortSubmissionTreeSha "Unknown"}}
             </span>
 
-            <TertiaryButton @size="extra-small" class="mr-2" {{on "click" this.handleCopyTreeShaButtonClick}} data-test-copy-tree-sha-button>
+            <TertiaryButton @size="extra-small" @isDisabled={{eq this.shortSubmissionTreeSha "Unknown"}} class="mr-2" {{on "click" this.handleCopyTreeShaButtonClick}} data-test-copy-tree-sha-button>
               {{svg-jar "clipboard-list" class="w-4 text-gray-500"}}
-              <EmberTooltip @text="Click to copy Git tree SHA" />
+                {{#if (not-eq this.shortSubmissionTreeSha "Unknown")}}
+                  <EmberTooltip @text="Click to copy Git tree SHA" />
+                {{/if}}
             </TertiaryButton>
           </div>
         </CourseAdmin::SubmissionsPage::SubmissionDetails::HeaderContainerRow>

--- a/app/components/course-admin/submissions-page/submission-details/header-container.hbs
+++ b/app/components/course-admin/submissions-page/submission-details/header-container.hbs
@@ -106,7 +106,7 @@
         <CourseAdmin::SubmissionsPage::SubmissionDetails::HeaderContainerRow @title="Tree SHA" data-test-tree-sha>
           <div class="flex items-center">
             <span class="mr-2 text-gray-600">
-              {{this.shortSubmissionTreeSha}}
+              {{or this.shortSubmissionTreeSha "Unknown"}}
             </span>
 
             <TertiaryButton @size="extra-small" class="mr-2" {{on "click" this.handleCopyTreeShaButtonClick}} data-test-copy-tree-sha-button>

--- a/app/components/course-admin/submissions-page/submission-details/header-container.hbs
+++ b/app/components/course-admin/submissions-page/submission-details/header-container.hbs
@@ -109,11 +109,17 @@
               {{or this.shortSubmissionTreeSha "Unknown"}}
             </span>
 
-            <TertiaryButton @size="extra-small" @isDisabled={{eq this.shortSubmissionTreeSha "Unknown"}} class="mr-2" {{on "click" this.handleCopyTreeShaButtonClick}} data-test-copy-tree-sha-button>
+            <TertiaryButton
+              @size="extra-small"
+              @isDisabled={{eq this.shortSubmissionTreeSha "Unknown"}}
+              class="mr-2"
+              {{on "click" this.handleCopyTreeShaButtonClick}}
+              data-test-copy-tree-sha-button
+            >
               {{svg-jar "clipboard-list" class="w-4 text-gray-500"}}
-                {{#if (not-eq this.shortSubmissionTreeSha "Unknown")}}
-                  <EmberTooltip @text="Click to copy Git tree SHA" />
-                {{/if}}
+              {{#if (not-eq this.shortSubmissionTreeSha "Unknown")}}
+                <EmberTooltip @text="Click to copy Git tree SHA" />
+              {{/if}}
             </TertiaryButton>
           </div>
         </CourseAdmin::SubmissionsPage::SubmissionDetails::HeaderContainerRow>

--- a/app/components/course-admin/submissions-page/submission-details/header-container.hbs
+++ b/app/components/course-admin/submissions-page/submission-details/header-container.hbs
@@ -103,6 +103,19 @@
           </div>
         </CourseAdmin::SubmissionsPage::SubmissionDetails::HeaderContainerRow>
 
+        <CourseAdmin::SubmissionsPage::SubmissionDetails::HeaderContainerRow @title="Tree SHA" data-test-tree-sha>
+          <div class="flex items-center">
+            <span class="mr-2 text-gray-600">
+              {{this.shortSubmissionTreeSha}}
+            </span>
+
+            <TertiaryButton @size="extra-small" class="mr-2" {{on "click" this.handleCopyTreeShaButtonClick}} data-test-copy-tree-sha-button>
+              {{svg-jar "clipboard-list" class="w-4 text-gray-500"}}
+              <EmberTooltip @text="Click to copy Git tree SHA" />
+            </TertiaryButton>
+          </div>
+        </CourseAdmin::SubmissionsPage::SubmissionDetails::HeaderContainerRow>
+
         {{#if this.shouldShowTesterVersion}}
           <CourseAdmin::SubmissionsPage::SubmissionDetails::HeaderContainerRow
             @title="Tester version"

--- a/app/components/course-admin/submissions-page/submission-details/header-container.js
+++ b/app/components/course-admin/submissions-page/submission-details/header-container.js
@@ -32,6 +32,10 @@ export default class AdminCourseSubmissionsPageSubmissionDetailsHeaderContainerC
   }
 
   get shortSubmissionTreeSha() {
+    if (!this.args.submission.treeSha) {
+      return 'Unknown';
+    }
+
     return this.args.submission.treeSha.substring(0, 8);
   }
 

--- a/app/components/course-admin/submissions-page/submission-details/header-container.js
+++ b/app/components/course-admin/submissions-page/submission-details/header-container.js
@@ -31,6 +31,10 @@ export default class AdminCourseSubmissionsPageSubmissionDetailsHeaderContainerC
     return this.args.submission.commitSha.substring(0, 8);
   }
 
+  get shortSubmissionTreeSha() {
+    return this.args.submission.treeSha.substring(0, 8);
+  }
+
   get shouldShowTesterVersion() {
     return this.authenticator.currentUser.isStaff;
   }
@@ -51,6 +55,11 @@ export default class AdminCourseSubmissionsPageSubmissionDetailsHeaderContainerC
   @action
   async handleCopyRepositoryURLButtonClick() {
     await navigator.clipboard.writeText(this.args.submission.repository.cloneUrl);
+  }
+
+  @action
+  async handleCopyTreeShaButtonClick() {
+    await navigator.clipboard.writeText(this.args.submission.treeSha);
   }
 
   @action

--- a/app/models/submission.ts
+++ b/app/models/submission.ts
@@ -26,7 +26,7 @@ export default class SubmissionModel extends Model {
   @attr('string') declare githubStorageHtmlUrl: string;
   @attr('boolean') declare wasSubmittedViaCli: boolean;
   @attr('string') declare status: string;
-  @attr('string') declare treeSha: string;
+  @attr('string') declare treeSha: string | null;
 
   get hasChangedFiles() {
     return this.changedFiles && this.changedFiles.length > 0;

--- a/app/models/submission.ts
+++ b/app/models/submission.ts
@@ -26,6 +26,7 @@ export default class SubmissionModel extends Model {
   @attr('string') declare githubStorageHtmlUrl: string;
   @attr('boolean') declare wasSubmittedViaCli: boolean;
   @attr('string') declare status: string;
+  @attr('string') declare treeSha: string;
 
   get hasChangedFiles() {
     return this.changedFiles && this.changedFiles.length > 0;

--- a/mirage/factories/submission.js
+++ b/mirage/factories/submission.js
@@ -52,6 +52,8 @@ export default Factory.extend({
 
   commitSha: () => generateRandomAlphanumericString(40),
 
+  treeSha: () => generateRandomAlphanumericString(40),
+
   githubStorageHtmlUrl: 'https://github.com',
 
   withFailureStatus: trait({

--- a/tests/acceptance/course-admin/view-submissions-test.js
+++ b/tests/acceptance/course-admin/view-submissions-test.js
@@ -1,5 +1,5 @@
 import { assertTooltipContent } from 'ember-tooltips/test-support';
-import { currentURL, pauseTest } from '@ember/test-helpers';
+import { currentURL } from '@ember/test-helpers';
 import { module, test } from 'qunit';
 import { setupApplicationTest } from 'codecrafters-frontend/tests/helpers';
 import { signInAsCourseAuthor, signInAsStaff } from 'codecrafters-frontend/tests/support/authentication-helpers';

--- a/tests/pages/course-admin/submissions-page.js
+++ b/tests/pages/course-admin/submissions-page.js
@@ -24,6 +24,15 @@ export default create({
       scope: '[data-test-commit-sha]',
     },
 
+    treeSha: {
+      copyButton: {
+        hover: triggerable('mouseenter'),
+        scope: '[data-test-copy-tree-sha-button]',
+      },
+
+      scope: '[data-test-tree-sha]',
+    },
+
     userProficiencyInfoIcon: {
       hover: triggerable('mouseenter'),
       scope: '[data-test-user-proficiency-info-icon]',


### PR DESCRIPTION
This commit adds functionality to display and copy the tree SHA in the submission details section of the submissions page in the course admin interface. The tree SHA is now included in the header of the submission details and users can click on a button to copy the Git tree SHA to the clipboard. This change provides easier access to the tree SHA information for users reviewing submissions.

**Checklist**:

- [X] I've thoroughly self-reviewed my changes
- [X] I've added tests for my changes, unless they affect admin-only areas (or are otherwise not worth testing)
- [ ] I've verified any visual changes using Percy (add a commit with `[percy]` in the message to trigger)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Added a "Tree SHA" section with copy functionality in the course admin submissions page. This allows users to easily copy the Git tree SHA of a submission.
- **Enhancements**
	- Introduced a truncated version of the submission's tree SHA for better display and usability.
- **Tests**
	- Implemented tests to verify the new tree SHA feature's presence, display properties, and copy functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->