### PR TITLE
CC-1100 add test for changing profile description

### DIFF
--- a/app/components/settings/profile-page/about-section.hbs
+++ b/app/components/settings/profile-page/about-section.hbs
@@ -10,6 +10,7 @@
       {{autoresize @user.profileDescriptionMarkdown}}
       {{markdown-input}}
       {{on "blur" this.handleBlur}}
+      data-test-profile-description-input
     />
   </div>
 

--- a/app/components/settings/profile-page/about-section.ts
+++ b/app/components/settings/profile-page/about-section.ts
@@ -1,8 +1,6 @@
-import type AnalyticsEventTrackerService from 'codecrafters-frontend/services/analytics-event-tracker';
 import Component from '@glimmer/component';
 import type UserModel from 'codecrafters-frontend/models/user';
 import { action } from '@ember/object';
-import { inject as service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 import { task, timeout } from 'ember-concurrency';
 
@@ -15,18 +13,12 @@ interface Signature {
 }
 
 export default class AboutSectionComponent extends Component<Signature> {
-  @service declare analyticsEventTracker: AnalyticsEventTrackerService;
-
   @tracked isUpdating = false;
   @tracked wasUpdatedRecently = false;
 
   @action
   async handleBlur() {
     this.updateValue.perform();
-
-    if (!this.wasUpdatedRecently) {
-      this.analyticsEventTracker.track('updated_profile_description', {});
-    }
   }
 
   updateValue = task({ keepLatest: true }, async (): Promise<void> => {

--- a/app/components/settings/profile-page/about-section.ts
+++ b/app/components/settings/profile-page/about-section.ts
@@ -24,7 +24,7 @@ export default class AboutSectionComponent extends Component<Signature> {
   async handleBlur() {
     this.updateValue.perform();
 
-    if (!this.isUpdating && !this.wasUpdatedRecently) {
+    if (!this.wasUpdatedRecently) {
       this.analyticsEventTracker.track('updated_profile_description', {});
     }
   }

--- a/app/components/settings/profile-page/about-section.ts
+++ b/app/components/settings/profile-page/about-section.ts
@@ -1,7 +1,9 @@
-import { action } from '@ember/object';
+import type AnalyticsEventTrackerService from 'codecrafters-frontend/services/analytics-event-tracker';
 import Component from '@glimmer/component';
-import { tracked } from '@glimmer/tracking';
 import type UserModel from 'codecrafters-frontend/models/user';
+import { action } from '@ember/object';
+import { inject as service } from '@ember/service';
+import { tracked } from '@glimmer/tracking';
 import { task, timeout } from 'ember-concurrency';
 
 interface Signature {
@@ -13,12 +15,18 @@ interface Signature {
 }
 
 export default class AboutSectionComponent extends Component<Signature> {
+  @service declare analyticsEventTracker: AnalyticsEventTrackerService;
+
   @tracked isUpdating = false;
   @tracked wasUpdatedRecently = false;
 
   @action
   async handleBlur() {
     this.updateValue.perform();
+
+    if (!this.isUpdating && !this.wasUpdatedRecently) {
+      this.analyticsEventTracker.track('updated_profile_description', {});
+    }
   }
 
   updateValue = task({ keepLatest: true }, async (): Promise<void> => {

--- a/app/templates/user.hbs
+++ b/app/templates/user.hbs
@@ -17,7 +17,7 @@
       {{/if}}
 
       {{#if this.model.profileDescriptionMarkdown}}
-        <div class="bg-white rounded p-4 shadow-sm mb-8 border">
+        <div class="bg-white rounded p-4 shadow-sm mb-8 border" data-test-profile-description-markdown>
           <div class="prose">
             {{markdown-to-html this.model.profileDescriptionMarkdown}}
           </div>

--- a/mirage/config.js
+++ b/mirage/config.js
@@ -704,5 +704,6 @@ function routes() {
     });
   });
 
+  this.patch('/users/:id');
   this.post('/views');
 }

--- a/tests/acceptance/settings-page/profile-test.js
+++ b/tests/acceptance/settings-page/profile-test.js
@@ -12,8 +12,6 @@ module('Acceptance | settings-page | profile-test', function (hooks) {
     testScenario(this.server);
     signIn(this.owner, this.server);
 
-    const currentUser = this.server.schema.users.find('63c51e91-e448-4ea9-821b-a80415f266d3');
-
     await profilePage.visit();
     await profilePage.profileDescription.input.fillIn('Updated profile description');
     await profilePage.profileDescription.input.blur();
@@ -29,8 +27,6 @@ module('Acceptance | settings-page | profile-test', function (hooks) {
   test('tracks when the profile description is updated', async function (assert) {
     testScenario(this.server);
     signIn(this.owner, this.server);
-
-    const currentUser = this.server.schema.users.find('63c51e91-e448-4ea9-821b-a80415f266d3');
 
     await profilePage.visit();
     await profilePage.profileDescription.input.fillIn('Updated profile description');

--- a/tests/acceptance/settings-page/profile-test.js
+++ b/tests/acceptance/settings-page/profile-test.js
@@ -13,14 +13,18 @@ module('Acceptance | settings-page | profile-test', function (hooks) {
     signIn(this.owner, this.server);
 
     const currentUser = this.server.schema.users.find('63c51e91-e448-4ea9-821b-a80415f266d3');
-    currentUser.update({ profileDescriptionMarkdown: "" });
+    currentUser.update({ profileDescriptionMarkdown: '' });
 
     await profilePage.visit();
-    await profilePage.profileDescription.input.fillIn("Updated profile description");
+    await profilePage.profileDescription.input.fillIn('Updated profile description');
     await profilePage.profileDescription.input.blur();
 
     await userPage.visit({ username: 'rohitpaulk' });
-    assert.strictEqual(userPage.profileDescriptionMarkdown.text, "Updated profile description", 'user page should reflect updated profile description');
+    assert.strictEqual(
+      userPage.profileDescriptionMarkdown.text,
+      'Updated profile description',
+      'user page should reflect updated profile description',
+    );
   });
 
   test('tracks when the profile description is updated', async function (assert) {
@@ -28,10 +32,10 @@ module('Acceptance | settings-page | profile-test', function (hooks) {
     signIn(this.owner, this.server);
 
     const currentUser = this.server.schema.users.find('63c51e91-e448-4ea9-821b-a80415f266d3');
-    currentUser.update({ profileDescriptionMarkdown: "" });
+    currentUser.update({ profileDescriptionMarkdown: '' });
 
     await profilePage.visit();
-    await profilePage.profileDescription.input.fillIn("Updated profile description");
+    await profilePage.profileDescription.input.fillIn('Updated profile description');
     await profilePage.profileDescription.input.blur();
 
     await userPage.visit({ username: 'rohitpaulk' });
@@ -40,7 +44,7 @@ module('Acceptance | settings-page | profile-test', function (hooks) {
     const filteredAnalyticsEvents = analyticsEvents.filter((event) => event.name !== 'feature_flag_called');
     const filteredAnalyticsEventsNames = filteredAnalyticsEvents.map((event) => event.name);
 
-    console.log(filteredAnalyticsEventsNames)
+    console.log(filteredAnalyticsEventsNames);
     assert.ok(filteredAnalyticsEventsNames.includes('updated_profile_description'), 'updated_profile_description event should be tracked');
   });
 });

--- a/tests/acceptance/settings-page/profile-test.js
+++ b/tests/acceptance/settings-page/profile-test.js
@@ -13,13 +13,34 @@ module('Acceptance | settings-page | profile-test', function (hooks) {
     signIn(this.owner, this.server);
 
     const currentUser = this.server.schema.users.find('63c51e91-e448-4ea9-821b-a80415f266d3');
-    assert.strictEqual(currentUser.profileDescriptionMarkdown, undefined)
+    currentUser.update({ profileDescriptionMarkdown: "" });
 
     await profilePage.visit();
     await profilePage.profileDescription.input.fillIn("Updated profile description");
     await profilePage.profileDescription.input.blur();
 
     await userPage.visit({ username: 'rohitpaulk' });
-    assert.strictEqual(userPage.profileDescriptionMarkdown.text, "Updated profile description");
+    assert.strictEqual(userPage.profileDescriptionMarkdown.text, "Updated profile description", 'user page should reflect updated profile description');
+  });
+
+  test('tracks when the profile description is updated', async function (assert) {
+    testScenario(this.server);
+    signIn(this.owner, this.server);
+
+    const currentUser = this.server.schema.users.find('63c51e91-e448-4ea9-821b-a80415f266d3');
+    currentUser.update({ profileDescriptionMarkdown: "" });
+
+    await profilePage.visit();
+    await profilePage.profileDescription.input.fillIn("Updated profile description");
+    await profilePage.profileDescription.input.blur();
+
+    await userPage.visit({ username: 'rohitpaulk' });
+
+    const analyticsEvents = this.server.schema.analyticsEvents.all().models;
+    const filteredAnalyticsEvents = analyticsEvents.filter((event) => event.name !== 'feature_flag_called');
+    const filteredAnalyticsEventsNames = filteredAnalyticsEvents.map((event) => event.name);
+
+    console.log(filteredAnalyticsEventsNames)
+    assert.ok(filteredAnalyticsEventsNames.includes('updated_profile_description'), 'updated_profile_description event should be tracked');
   });
 });

--- a/tests/acceptance/settings-page/profile-test.js
+++ b/tests/acceptance/settings-page/profile-test.js
@@ -23,21 +23,4 @@ module('Acceptance | settings-page | profile-test', function (hooks) {
       'user page should reflect updated profile description',
     );
   });
-
-  test('tracks when the profile description is updated', async function (assert) {
-    testScenario(this.server);
-    signIn(this.owner, this.server);
-
-    await profilePage.visit();
-    await profilePage.profileDescription.input.fillIn('Updated profile description');
-    await profilePage.profileDescription.input.blur();
-
-    await userPage.visit({ username: 'rohitpaulk' });
-
-    const analyticsEvents = this.server.schema.analyticsEvents.all().models;
-    const filteredAnalyticsEvents = analyticsEvents.filter((event) => event.name !== 'feature_flag_called');
-    const filteredAnalyticsEventsNames = filteredAnalyticsEvents.map((event) => event.name);
-
-    assert.ok(filteredAnalyticsEventsNames.includes('updated_profile_description'), 'updated_profile_description event should be tracked');
-  });
 });

--- a/tests/acceptance/settings-page/profile-test.js
+++ b/tests/acceptance/settings-page/profile-test.js
@@ -13,7 +13,6 @@ module('Acceptance | settings-page | profile-test', function (hooks) {
     signIn(this.owner, this.server);
 
     const currentUser = this.server.schema.users.find('63c51e91-e448-4ea9-821b-a80415f266d3');
-    currentUser.update({ profileDescriptionMarkdown: '' });
 
     await profilePage.visit();
     await profilePage.profileDescription.input.fillIn('Updated profile description');
@@ -32,7 +31,6 @@ module('Acceptance | settings-page | profile-test', function (hooks) {
     signIn(this.owner, this.server);
 
     const currentUser = this.server.schema.users.find('63c51e91-e448-4ea9-821b-a80415f266d3');
-    currentUser.update({ profileDescriptionMarkdown: '' });
 
     await profilePage.visit();
     await profilePage.profileDescription.input.fillIn('Updated profile description');

--- a/tests/acceptance/settings-page/profile-test.js
+++ b/tests/acceptance/settings-page/profile-test.js
@@ -1,0 +1,25 @@
+import profilePage from 'codecrafters-frontend/tests/pages/settings/profile-page';
+import userPage from 'codecrafters-frontend/tests/pages/user-page';
+import testScenario from 'codecrafters-frontend/mirage/scenarios/test';
+import { module, test } from 'qunit';
+import { setupApplicationTest } from 'codecrafters-frontend/tests/helpers';
+import { signIn } from 'codecrafters-frontend/tests/support/authentication-helpers';
+
+module('Acceptance | settings-page | profile-test', function (hooks) {
+  setupApplicationTest(hooks);
+
+  test('can edit profile description', async function (assert) {
+    testScenario(this.server);
+    signIn(this.owner, this.server);
+
+    const currentUser = this.server.schema.users.find('63c51e91-e448-4ea9-821b-a80415f266d3');
+    assert.strictEqual(currentUser.profileDescriptionMarkdown, undefined)
+
+    await profilePage.visit();
+    await profilePage.profileDescription.input.fillIn("Updated profile description");
+    await profilePage.profileDescription.input.blur();
+
+    await userPage.visit({ username: 'rohitpaulk' });
+    assert.strictEqual(userPage.profileDescriptionMarkdown.text, "Updated profile description");
+  });
+});

--- a/tests/acceptance/settings-page/profile-test.js
+++ b/tests/acceptance/settings-page/profile-test.js
@@ -44,7 +44,6 @@ module('Acceptance | settings-page | profile-test', function (hooks) {
     const filteredAnalyticsEvents = analyticsEvents.filter((event) => event.name !== 'feature_flag_called');
     const filteredAnalyticsEventsNames = filteredAnalyticsEvents.map((event) => event.name);
 
-    console.log(filteredAnalyticsEventsNames);
     assert.ok(filteredAnalyticsEventsNames.includes('updated_profile_description'), 'updated_profile_description event should be tracked');
   });
 });

--- a/tests/pages/settings/profile-page.ts
+++ b/tests/pages/settings/profile-page.ts
@@ -1,0 +1,12 @@
+import { create, triggerable, visitable } from 'ember-cli-page-object';
+
+export default create({
+  profileDescription: {
+    input: {
+      blur: triggerable('blur'),
+      scope: '[data-test-profile-description-input]',
+    },
+  },
+
+  visit: visitable('/settings/profile'),
+});

--- a/tests/pages/user-page.js
+++ b/tests/pages/user-page.js
@@ -7,6 +7,10 @@ export default createPage({
     scope: '[data-test-admin-profile-button]',
   },
 
+  profileDescriptionMarkdown: {
+    scope: '[data-test-profile-description-markdown]',
+  },
+
   userLabel: {
     scope: '[data-test-user-label]',
     hover: triggerable('mouseenter'),


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Added a `data-test-profile-description-input` attribute to the profile description textarea for user editing.
	- Introduced markdown support for user profile descriptions.
	- Implemented analytics tracking for profile description updates.

- **Bug Fixes**
	- Updated backend route handling for accurate profile description updates.

- **Tests**
	- Included acceptance tests for profile description editing and tracking.
	- Created page objects to facilitate testing of profile and user pages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->