### PR TITLE
feat: Add Forum tab to course page header

### DIFF
--- a/app/components/course-page/header/tab-link.hbs
+++ b/app/components/course-page/header/tab-link.hbs
@@ -13,21 +13,4 @@
   {{/if}}
 
   <span class="whitespace-nowrap {{if @isActive 'text-gray-700' 'text-gray-600'}}">{{@text}}</span>
-
-  {{#if @authorDetails}}
-    <div class="ml-2 flex -space-x-3 hover:space-x-1 items-center">
-      {{! @glint-expect-error: not typesafe yet }}}
-      <ContributorAvatar @contributorDetails={{@authorDetails}} @contributorType="author" />
-
-      {{! @glint-expect-error: not typesafe yet }}}
-      {{#each @reviewersDetails as |reviewerDetails|}}
-        {{! @glint-expect-error: not typesafe yet }}}
-        <ContributorAvatar @contributorDetails={{reviewerDetails}} @contributorType="reviewer" />
-      {{/each}}
-    </div>
-  {{else}}
-    {{! alignment fix }}
-    <div class="h-6">
-    </div>
-  {{/if}}
 </LinkTo>

--- a/app/components/course-page/header/tab-link.ts
+++ b/app/components/course-page/header/tab-link.ts
@@ -10,7 +10,6 @@ interface Signature {
     iconUrl?: string;
     icon?: string;
     text: string;
-    authorDetails?: unknown;
   };
 
   Blocks: {

--- a/app/components/course-page/header/tab-list.ts
+++ b/app/components/course-page/header/tab-list.ts
@@ -128,15 +128,6 @@ export default class TabListComponent extends Component<Signature> {
       });
     }
 
-    tabs.push({
-      icon: 'code',
-      name: 'Forum',
-      slug: 'forum',
-      route: 'course.stage.code-examples',
-      models: this.args.currentStep.routeParams.models,
-      isActive: this.router.currentRouteName === 'course.stage.code-examples',
-    });
-
     return tabs;
   }
 

--- a/app/components/course-page/header/tab-list.ts
+++ b/app/components/course-page/header/tab-list.ts
@@ -128,6 +128,15 @@ export default class TabListComponent extends Component<Signature> {
       });
     }
 
+    tabs.push({
+      icon: 'code',
+      name: 'Forum',
+      slug: 'forum',
+      route: 'course.stage.code-examples',
+      models: this.args.currentStep.routeParams.models,
+      isActive: this.router.currentRouteName === 'course.stage.code-examples',
+    });
+
     return tabs;
   }
 

--- a/app/models/course.ts
+++ b/app/models/course.ts
@@ -33,6 +33,7 @@ export default class CourseModel extends Model {
   @attr('string') declare definitionRepositoryFullName: string;
   @attr('string') declare descriptionMarkdown: string;
   @attr('string') declare difficulty: string;
+  @attr('string') declare forumUrl: string;
   @attr('date') declare isFreeUntil: Date | null;
   @attr('string') declare name: string;
   @attr('string') declare releaseStatus: string;


### PR DESCRIPTION
Adds a new tab with icon 'code' and name 'Forum' to the course page header. 
The tab will link to 'course.stage.code-examples' route and will display
based on the current route. 

Removes unused authorDetails from tab-link component.

Adds new attribute forumUrl to CourseModel.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a "Forum" tab on the course page for easier access to discussions and community interactions.

- **Refactor**
	- Streamlined course page header by removing conditional rendering of contributor avatars.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->