### PR TITLE
refactor: Update tab links to use LinkTo component and define internal/external link types

### DIFF
--- a/app/components/concept-admin/header.hbs
+++ b/app/components/concept-admin/header.hbs
@@ -27,7 +27,9 @@
 
     <div class="flex items-center">
       {{#each this.tabs key="slug" as |tab|}}
-        <CoursePage::Header::TabLink @icon={{tab.icon}} @route={{tab.route}} @models={{tab.models}} @text={{tab.name}} @isActive={{tab.isActive}} />
+        <LinkTo @route={{tab.route}} @models={{tab.models}} class="flex">
+          <CoursePage::Header::TabLink @icon={{tab.icon}} @text={{tab.name}} @isActive={{tab.isActive}} />
+        </LinkTo>
       {{/each}}
     </div>
   </div>

--- a/app/components/course-admin/header.hbs
+++ b/app/components/course-admin/header.hbs
@@ -16,7 +16,9 @@
 
     <div class="flex items-center">
       {{#each this.tabs key="slug" as |tab|}}
-        <CoursePage::Header::TabLink @icon={{tab.icon}} @route={{tab.route}} @models={{tab.models}} @text={{tab.name}} @isActive={{tab.isActive}} />
+        <LinkTo @route={{tab.route}} @models={{tab.models}} class="flex">
+          <CoursePage::Header::TabLink @icon={{tab.icon}} @text={{tab.name}} @isActive={{tab.isActive}} />
+        </LinkTo>
       {{/each}}
     </div>
   </div>

--- a/app/components/course-page/header/tab-link.hbs
+++ b/app/components/course-page/header/tab-link.hbs
@@ -1,6 +1,4 @@
-<LinkTo
-  @route={{@route}}
-  @models={{@models}}
+<div
   class="flex flex-shrink-0 items-center px-2 py-2 mr-2 border-b-2 text-sm group
     {{if @isActive 'border-teal-500' 'border-transparent hover:border-gray-300'}}"
   data-test-header-tab-link
@@ -13,4 +11,4 @@
   {{/if}}
 
   <span class="whitespace-nowrap {{if @isActive 'text-gray-700' 'text-gray-600'}}">{{@text}}</span>
-</LinkTo>
+</div>

--- a/app/components/course-page/header/tab-link.ts
+++ b/app/components/course-page/header/tab-link.ts
@@ -1,11 +1,9 @@
 import Component from '@glimmer/component';
 
 interface Signature {
-  Element: HTMLAnchorElement;
+  Element: HTMLDivElement;
 
   Args: {
-    route: string;
-    models: string[];
     isActive: boolean;
     iconUrl?: string;
     icon?: string;
@@ -18,10 +16,10 @@ interface Signature {
   };
 }
 
-export default class InstructionsCardComponent extends Component<Signature> {}
+export default class TabLinkComponent extends Component<Signature> {}
 
 declare module '@glint/environment-ember-loose/registry' {
   export default interface Registry {
-    'CoursePage::Header::TabLink': typeof InstructionsCardComponent;
+    'CoursePage::Header::TabLink': typeof TabLinkComponent;
   }
 }

--- a/app/components/course-page/header/tab-list.hbs
+++ b/app/components/course-page/header/tab-list.hbs
@@ -1,5 +1,16 @@
 <div class="flex items-center overflow-x-scroll" ...attributes>
   {{#each this.availableTabs key="slug" as |tab|}}
-    <CoursePage::Header::TabLink @icon={{tab.icon}} @route={{tab.route}} @models={{tab.models}} @text={{tab.name}} @isActive={{tab.isActive}} />
+    {{#if tab.externalLink}}
+      <a href={{tab.externalLink.url}} class="flex" target="_blank" rel="noopener noreferrer">
+        <CoursePage::Header::TabLink @icon={{tab.icon}} @text={{tab.name}} @isActive={{tab.isActive}} />
+      </a>
+    {{else}}
+      {{! this if condition just helps with type checking }}
+      {{#if tab.internalLink}}
+        <LinkTo @route={{tab.internalLink.route}} @models={{tab.internalLink.models}} class="flex">
+          <CoursePage::Header::TabLink @icon={{tab.icon}} @text={{tab.name}} @isActive={{tab.isActive}} />
+        </LinkTo>
+      {{/if}}
+    {{/if}}
   {{/each}}
 </div>

--- a/app/components/course-page/header/tab-list.ts
+++ b/app/components/course-page/header/tab-list.ts
@@ -21,8 +21,8 @@ type Tab = {
   icon: string;
   name: string;
   slug: string;
-  route: string;
-  models: string[];
+  externalLink?: { url: string };
+  internalLink?: { route: string; models: string[] }; // Easier to type this using two params than one union type
   isActive: boolean;
 };
 
@@ -50,8 +50,10 @@ export default class TabListComponent extends Component<Signature> {
         icon: 'sparkles',
         name: 'Congratulations!',
         slug: 'congratulations',
-        route: this.args.currentStep.routeParams.route,
-        models: this.args.currentStep.routeParams.models,
+        internalLink: {
+          route: this.args.currentStep.routeParams.route,
+          models: this.args.currentStep.routeParams.models,
+        },
         isActive: this.router.currentRouteName === this.args.currentStep.routeParams.route,
       },
     ];
@@ -63,8 +65,10 @@ export default class TabListComponent extends Component<Signature> {
         icon: 'document-text',
         name: 'Instructions',
         slug: 'instructions',
-        route: this.args.currentStep.routeParams.route,
-        models: this.args.currentStep.routeParams.models,
+        internalLink: {
+          route: this.args.currentStep.routeParams.route,
+          models: this.args.currentStep.routeParams.models,
+        },
         isActive: this.router.currentRouteName === this.args.currentStep.routeParams.route,
       },
     ];
@@ -90,8 +94,10 @@ export default class TabListComponent extends Component<Signature> {
       icon: 'document-text',
       name: 'Instructions',
       slug: 'instructions',
-      route: 'course.stage.instructions',
-      models: this.args.currentStep.routeParams.models,
+      internalLink: {
+        route: 'course.stage.instructions',
+        models: this.args.currentStep.routeParams.models,
+      },
       isActive: this.router.currentRouteName === 'course.stage.instructions',
     });
 
@@ -99,8 +105,10 @@ export default class TabListComponent extends Component<Signature> {
       icon: 'code',
       name: 'Code Examples',
       slug: 'code_examples',
-      route: 'course.stage.code-examples',
-      models: this.args.currentStep.routeParams.models,
+      internalLink: {
+        route: 'course.stage.code-examples',
+        models: this.args.currentStep.routeParams.models,
+      },
       isActive: this.router.currentRouteName === 'course.stage.code-examples',
     });
 
@@ -110,8 +118,10 @@ export default class TabListComponent extends Component<Signature> {
         icon: 'play',
         name: 'Screencasts',
         slug: 'screencasts',
-        route: 'course.stage.screencasts',
-        models: this.args.currentStep.routeParams.models,
+        internalLink: {
+          route: 'course.stage.screencasts',
+          models: this.args.currentStep.routeParams.models,
+        },
         isActive: this.router.currentRouteName === 'course.stage.screencasts',
       });
     }
@@ -122,11 +132,23 @@ export default class TabListComponent extends Component<Signature> {
         icon: 'academic-cap',
         name: 'Concepts',
         slug: 'concepts',
-        route: 'course.stage.concepts',
-        models: this.args.currentStep.routeParams.models,
+        internalLink: {
+          route: 'course.stage.concepts',
+          models: this.args.currentStep.routeParams.models,
+        },
         isActive: this.router.currentRouteName === 'course.stage.concepts',
       });
     }
+
+    tabs.push({
+      icon: 'chat-alt-2',
+      name: 'Forum',
+      slug: 'forum',
+      externalLink: {
+        url: this.args.course.forumUrl,
+      },
+      isActive: false,
+    });
 
     return tabs;
   }


### PR DESCRIPTION
Tab links in the header components have been updated to use the LinkTo component for routing. 
Additionally, the Tab type in the tab-list.ts file has been refactored to have internalLink 
and externalLink types to distinguish between internal and external links for better typing and 
organization.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Improved navigation within the app by enhancing the way tabs are linked and rendered in course-related pages.
- **Refactor**
	- Updated components to better handle internal and external links, ensuring a more intuitive and seamless user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->