### PR TITLE
build: Bump major version number to 6.0 for client update force.

### DIFF
--- a/config/environment.js
+++ b/config/environment.js
@@ -47,7 +47,7 @@ module.exports = function (environment) {
 
       // Update the major version number to force all clients to update.
       // The minor version doesn't do anything at the moment, might use in the future.
-      version: `5.0.${process.env.VERCEL_GIT_COMMIT_SHA?.slice(0, 7) || 'dev'}`,
+      version: `6.0.${process.env.VERCEL_GIT_COMMIT_SHA?.slice(0, 7) || 'dev'}`,
     },
     fastboot: {
       hostWhitelist: [/^localhost:\d+$/],


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
	- Updated the app version to 6.0, indicating a major update.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->