### PR TITLE
feat: Increase margin-bottom in clone repository step

### DIFF
--- a/app/components/course-page/setup-step/repository-setup-card/clone-repository-step.hbs
+++ b/app/components/course-page/setup-step/repository-setup-card/clone-repository-step.hbs
@@ -6,7 +6,7 @@
     code for you.
   </p>
 
-  <div class="mb-2 inline-flex items-center gap-1">
+  <div class="mb-3 inline-flex items-center gap-1">
     {{#if @isComplete}}
       {{svg-jar "check-circle" class="w-6 h-6 text-teal-500 inline-flex mb-0.5"}}
     {{else}}
@@ -32,7 +32,7 @@
     </div>
   {{/if}}
 
-  <div class="mb-2 inline-flex items-center gap-1">
+  <div class="mb-3 inline-flex items-center gap-1">
     {{#if @isComplete}}
       {{svg-jar "check-circle" class="w-6 h-6 text-teal-500 inline-flex mb-0.5"}}
     {{else}}


### PR DESCRIPTION
Updated the margin-bottom from 2 to 3 in the clone repository step for better spacing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
	- Improved spacing for elements in the repository setup step based on completion status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->