### PR TITLE
refactor: Add internal link for setupTabs in TabListComponent

### DIFF
--- a/app/components/course-page/header/tab-list.ts
+++ b/app/components/course-page/header/tab-list.ts
@@ -44,7 +44,7 @@ export default class TabListComponent extends Component<Signature> {
     return this.allTabs.filter((tab) => this.tabIsAvailable(tab));
   }
 
-  get courseCompletedTabs() {
+  get courseCompletedTabs(): Tab[] {
     return [
       {
         icon: 'sparkles',
@@ -59,7 +59,7 @@ export default class TabListComponent extends Component<Signature> {
     ];
   }
 
-  get introductionTabs() {
+  get introductionTabs(): Tab[] {
     return [
       {
         icon: 'document-text',
@@ -74,20 +74,22 @@ export default class TabListComponent extends Component<Signature> {
     ];
   }
 
-  get setupTabs() {
+  get setupTabs(): Tab[] {
     return [
       {
         icon: 'document-text',
         name: 'Instructions',
         slug: 'instructions',
-        route: this.args.currentStep.routeParams.route,
-        models: this.args.currentStep.routeParams.models,
+        internalLink: {
+          route: this.args.currentStep.routeParams.route,
+          models: this.args.currentStep.routeParams.models,
+        },
         isActive: this.router.currentRouteName === this.args.currentStep.routeParams.route,
       },
     ];
   }
 
-  get stageTabs() {
+  get stageTabs(): Tab[] {
     const tabs: Tab[] = [];
 
     tabs.push({


### PR DESCRIPTION
Refactor setupTabs in TabListComponent to include an internal link object
containing route and models, instead of directly assigning the values. This
improves readability and maintainability.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Improved type safety in course page tabs by specifying return types.
	- Enhanced navigation within course setup tabs by adding internal links.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->