### PR TITLE
feat: Add check for currentUserCanAccessMembershipBenefits in acceptReferralContainer

### DIFF
--- a/app/components/affiliate-link-page/accept-referral-container.hbs
+++ b/app/components/affiliate-link-page/accept-referral-container.hbs
@@ -47,6 +47,8 @@
         <EmberTooltip
           @text="You've already accepted {{this.currentUser.currentAffiliateReferral.affiliateLink.usernameForDisplay}}'s referral offer."
         />
+      {{else if this.currentUserCanAccessMembershipBenefits}}
+        <EmberTooltip @text="As a CodeCrafters member, you already have full access." />
       {{/if}}
     </div>
 

--- a/app/components/affiliate-link-page/accept-referral-container.ts
+++ b/app/components/affiliate-link-page/accept-referral-container.ts
@@ -26,11 +26,20 @@ export default class AcceptReferralContainerComponent extends Component<Signatur
   @tracked isCreatingAffiliateReferral = false;
 
   get acceptOfferButtonIsEnabled() {
-    return !this.isCreatingAffiliateReferral && !this.currentUserIsReferrer && !this.currentUserIsAlreadyEligibleForReferralDiscount;
+    return (
+      !this.isCreatingAffiliateReferral &&
+      !this.currentUserIsReferrer &&
+      !this.currentUserIsAlreadyEligibleForReferralDiscount &&
+      !this.currentUserCanAccessMembershipBenefits
+    );
   }
 
   get currentUser() {
     return this.authenticator.currentUser;
+  }
+
+  get currentUserCanAccessMembershipBenefits() {
+    return this.authenticator.currentUser && this.authenticator.currentUser.canAccessMembershipBenefits;
   }
 
   get currentUserIsAlreadyEligibleForReferralDiscount() {


### PR DESCRIPTION
Added a check for currentUserCanAccessMembershipBenefits in the `acceptOfferButtonIsEnabled` method to ensure that CodeCrafters members already have full access.