### PR TITLE
CC-1114 update time for deleting in the delete repository modal

### DIFF
--- a/app/components/course-page/delete-repository-modal.hbs
+++ b/app/components/course-page/delete-repository-modal.hbs
@@ -29,7 +29,7 @@
 
   <div class="prose mb-4 text-red-600">
     To proceed, press and hold the button below for
-    <span class="font-bold">5 seconds</span>:
+    <span class="font-bold">3 seconds</span>:
   </div>
 
   <DangerButtonWithTimedConfirmation @onConfirm={{this.deleteRepository}} @size="regular" data-test-delete-repository-button>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Reduced the hold time for the confirmation button from 5 seconds to 3 seconds on the course deletion modal.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->