### PR TITLE
feat: Update wording for affiliate link page

### DIFF
--- a/app/components/affiliate-link-page/accept-referral-container.hbs
+++ b/app/components/affiliate-link-page/accept-referral-container.hbs
@@ -18,9 +18,9 @@
 
     <div class="prose text-center max-w-sm mt-10 text-gry-600">
       <b>@{{@affiliateLink.usernameForDisplay}}</b>
-      wants you to try CodeCrafters with
-      <b>40%</b>
-      waived.
+      wants you to try CodeCrafters. Signing up is free.
+      <b>40% off</b>
+      if you upgrade.
     </div>
 
     <div class="inline-flex mt-8">


### PR DESCRIPTION
Update wording on affiliate link page to clarify that signing up is free
and that users get 40% off if they upgrade.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Updated the promotional message for CodeCrafters on the affiliate link page to emphasize a free signup and a 40% discount on upgrading.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->