### PR TITLE
Concepts keyboard shortcuts - v1

### DIFF
--- a/app/components/blocks/concept-question-block.hbs
+++ b/app/components/blocks/concept-question-block.hbs
@@ -14,21 +14,12 @@
         @onContinueButtonClick={{@onContinueButtonClick}}
         @onStepBackButtonClick={{@onStepBackButtonClick}}
         @continueButtonText="Continue"
-        @shouldEnableKeyboardShortcuts={{false}}
         @shouldHighlightKeyboardShortcuts={{true}}
         @shouldShowContinueButton={{this.isSubmitted}}
         @shouldShowStepBackButton={{true}}
         class="mt-6 scroll-mb-10 md:scroll-mb-[20vh]"
         {{did-insert this.handleDidInsertContinueOrStepBackElement}}
       />
-    {{/if}}
-
-    {{#if @isCurrentBlock}}
-      {{#if this.isSubmitted}}
-        {{on-key "Enter" @onContinueButtonClick}}
-      {{/if}}
-
-      {{on-key "Backspace" @onStepBackButtonClick}}
     {{/if}}
   </div>
 {{else}}

--- a/app/components/concept-admin/blocks-page/block-preview.hbs
+++ b/app/components/concept-admin/blocks-page/block-preview.hbs
@@ -10,7 +10,6 @@
       @continueButtonText={{this.modelAsClickToContinueBlock.buttonTextForDisplay}}
       @shouldShowContinueButton={{true}}
       @shouldShowStepBackButton={{false}}
-      @shouldEnableKeyboardShortcuts={{false}}
       @shouldHighlightKeyboardShortcuts={{false}}
     />
   {{else if (eq @model.type "concept_question")}}

--- a/app/components/concept.hbs
+++ b/app/components/concept.hbs
@@ -28,7 +28,6 @@
               @continueButtonText={{block.buttonTextForDisplay}}
               @onContinueButtonClick={{this.handleContinueButtonClick}}
               @onStepBackButtonClick={{this.handleStepBackButtonClick}}
-              @shouldEnableKeyboardShortcuts={{true}}
               @shouldHighlightKeyboardShortcuts={{true}}
               @shouldShowContinueButton={{true}}
               @shouldShowStepBackButton={{not-eq this.currentBlockGroupIndex 0}}

--- a/app/components/concept/continue-or-step-back.hbs
+++ b/app/components/concept/continue-or-step-back.hbs
@@ -5,6 +5,8 @@
         {{on "click" @onContinueButtonClick}}
         {{(if @shouldHighlightKeyboardShortcuts (modifier "focus-on-insert"))}}
         data-test-continue-button
+        {{! @glint-expect-error on-key modifier types aren't right? }}
+        {{on-key "Enter"}}
       >
         {{or @continueButtonText "Continue"}}
       </PrimaryButton>
@@ -18,7 +20,14 @@
   {{/if}}
 
   {{#if @shouldShowStepBackButton}}
-    <div class="flex items-center py-3 group" role="button" data-test-step-back-button {{on "click" @onStepBackButtonClick}}>
+    <div
+      class="flex items-center py-3 group"
+      role="button"
+      data-test-step-back-button
+      {{on "click" @onStepBackButtonClick}}
+      {{! @glint-expect-error on-key modifier types aren't right? }}
+      {{on-key "Backspace"}}
+    >
       <span>{{svg-jar "arrow-up" class="w-3 fill-current text-gray-400 group-hover:text-gray-700"}}</span>
       <div class="ml-1 text-gray-500 group-hover:text-gray-800 text-xs hover:underline">
         Step back
@@ -28,15 +37,5 @@
         <EmberTooltip @text="Shortcut: Backspace ⌫" @side="bottom" @delay={{500}} @duration={{2500}} />
       {{/if}}
     </div>
-  {{/if}}
-
-  {{#if @shouldEnableKeyboardShortcuts}}
-    {{#if @shouldShowContinueButton}}
-      {{on-key "Enter" @onContinueButtonClick}}
-    {{/if}}
-
-    {{#if @shouldShowStepBackButton}}
-      {{on-key "Backspace" @onStepBackButtonClick}}
-    {{/if}}
   {{/if}}
 </div>

--- a/app/components/concept/continue-or-step-back.hbs
+++ b/app/components/concept/continue-or-step-back.hbs
@@ -1,7 +1,11 @@
 <div class="flex items-start gap-4" ...attributes>
   {{#if @shouldShowContinueButton}}
     <div class="flex flex-col items-center">
-      <PrimaryButton {{on "click" @onContinueButtonClick}} data-test-continue-button>
+      <PrimaryButton
+        {{on "click" @onContinueButtonClick}}
+        {{(if @shouldHighlightKeyboardShortcuts (modifier "focus-on-insert"))}}
+        data-test-continue-button
+      >
         {{or @continueButtonText "Continue"}}
       </PrimaryButton>
 

--- a/app/components/concept/continue-or-step-back.hbs
+++ b/app/components/concept/continue-or-step-back.hbs
@@ -5,8 +5,9 @@
         {{on "click" @onContinueButtonClick}}
         {{(if @shouldHighlightKeyboardShortcuts (modifier "focus-on-insert"))}}
         data-test-continue-button
+        {{did-insert this.handleDidInsertContinueButtonElement}}
         {{! @glint-expect-error on-key modifier types aren't right? }}
-        {{on-key "Enter"}}
+        {{on-key "Enter" this.handleEnterKeyPress}}
       >
         {{or @continueButtonText "Continue"}}
       </PrimaryButton>

--- a/app/components/concept/continue-or-step-back.ts
+++ b/app/components/concept/continue-or-step-back.ts
@@ -6,7 +6,6 @@ interface Signature {
   Args: {
     onContinueButtonClick: () => void;
     onStepBackButtonClick: () => void;
-    shouldEnableKeyboardShortcuts: boolean;
     shouldHighlightKeyboardShortcuts: boolean;
     shouldShowStepBackButton: boolean;
     shouldShowContinueButton: boolean;

--- a/app/components/concept/continue-or-step-back.ts
+++ b/app/components/concept/continue-or-step-back.ts
@@ -1,4 +1,6 @@
+import { action } from '@ember/object';
 import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
 
 interface Signature {
   Element: HTMLDivElement;
@@ -13,7 +15,23 @@ interface Signature {
   };
 }
 
-export default class ContinueOrStepBackComponent extends Component<Signature> {}
+export default class ContinueOrStepBackComponent extends Component<Signature> {
+  @tracked continueButtonElement: HTMLButtonElement | null = null;
+
+  @action
+  handleDidInsertContinueButtonElement(element: HTMLButtonElement): void {
+    this.continueButtonElement = element;
+  }
+
+  @action
+  handleEnterKeyPress(event: KeyboardEvent): void {
+    if (event.target === this.continueButtonElement) {
+      return; // Continue button already has a click handler
+    }
+
+    this.args.onContinueButtonClick();
+  }
+}
 
 declare module '@glint/environment-ember-loose/registry' {
   export default interface Registry {

--- a/app/components/primary-button.hbs
+++ b/app/components/primary-button.hbs
@@ -1,7 +1,7 @@
 <BaseButton
   @size={{@size}}
   @isDisabled={{@isDisabled}}
-  class="bg-teal-500 dark:bg-teal-600 hover:bg-teal-600 dark:hover:bg-teal-500 dark:border-teal-600 dark:hover:border-teal-500 border-teal-500 hover:border-teal-600 text-white dark:text-gray-100"
+  class="bg-teal-500 dark:bg-teal-600 hover:bg-teal-600 dark:hover:bg-teal-500 dark:border-teal-600 dark:hover:border-teal-500 border-teal-500 hover:border-teal-600 text-white dark:text-gray-100 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-teal-500"
   ...attributes
 >
   {{yield}}

--- a/app/components/tertiary-button.hbs
+++ b/app/components/tertiary-button.hbs
@@ -1,7 +1,7 @@
 <BaseButton
   @size={{@size}}
   @isDisabled={{@isDisabled}}
-  class="transition-colors duration-75 dark:bg-gray-800 bg-white hover:bg-gray-50 dark:text-gray-300 dark:hover:text-white text-gray-800 dark:border-gray-600 border-gray-300"
+  class="transition-colors duration-75 dark:bg-gray-800 bg-white hover:bg-gray-50 dark:text-gray-300 dark:hover:text-white text-gray-800 dark:border-gray-600 border-gray-300 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-gray-600"
   ...attributes
 >
   {{yield}}

--- a/app/modifiers/focus-on-insert.ts
+++ b/app/modifiers/focus-on-insert.ts
@@ -1,0 +1,21 @@
+import Modifier from 'ember-modifier';
+
+type Signature = {
+  Args: {
+    Positional: [];
+
+    Named: Record<string, never>;
+  };
+};
+
+export default class FocusOnInsertModifier extends Modifier<Signature> {
+  modify(element: HTMLElement, _positional: [], _named: Signature['Args']['Named']) {
+    element.focus();
+  }
+}
+
+declare module '@glint/environment-ember-loose/registry' {
+  export default interface Registry {
+    'focus-on-insert': typeof FocusOnInsertModifier;
+  }
+}


### PR DESCRIPTION
Added a focus-on-insert modifier to ensure focus on the continue button when
highlighting keyboard shortcuts. Updated the continue button component to use
the modifier when needed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
	- Removed the `@shouldEnableKeyboardShortcuts` parameter from multiple component invocations for cleaner code.
	- Added a conditional modifier based on `@shouldHighlightKeyboardShortcuts` to enhance functionality in the `continue-or-step-back` component.
- **Style**
	- Added focus styles to primary and tertiary button components for improved accessibility and user experience.
- **New Features**
	- Introduced a modifier `focus-on-insert.ts` to automatically focus on newly inserted elements in the application.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->