### PR TITLE
Refactor test runner card component and add acceptance tests

### DIFF
--- a/app/components/copyable-terminal-command.hbs
+++ b/app/components/copyable-terminal-command.hbs
@@ -1,4 +1,8 @@
-<div class="flex flex-col items-stretch rounded bg-white dark:bg-gray-800 w-full max-w-2xl border border-gray-300 dark:border-gray-600" ...attributes data-test-copyable-terminal-command>
+<div
+  class="flex flex-col items-stretch rounded bg-white dark:bg-gray-800 w-full max-w-2xl border border-gray-300 dark:border-gray-600"
+  ...attributes
+  data-test-copyable-terminal-command
+>
   <div class="border-b border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-900 rounded-t pl-3 pr-1 py-1 flex items-center justify-between">
     <div class="flex items-center gap-1 mr-8">
       {{svg-jar "terminal" class="h-4 w-4 text-gray-400 dark:text-gray-600"}}

--- a/app/components/copyable-terminal-command.hbs
+++ b/app/components/copyable-terminal-command.hbs
@@ -1,4 +1,4 @@
-<div class="flex flex-col items-stretch rounded bg-white dark:bg-gray-800 w-full max-w-2xl border border-gray-300 dark:border-gray-600" ...attributes>
+<div class="flex flex-col items-stretch rounded bg-white dark:bg-gray-800 w-full max-w-2xl border border-gray-300 dark:border-gray-600" ...attributes data-test-copyable-terminal-command>
   <div class="border-b border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-900 rounded-t pl-3 pr-1 py-1 flex items-center justify-between">
     <div class="flex items-center gap-1 mr-8">
       {{svg-jar "terminal" class="h-4 w-4 text-gray-400 dark:text-gray-600"}}
@@ -23,7 +23,7 @@
 
   <div class="px-3 py-2.5 w-full font-mono text-xs overflow-x-auto">
     {{#each @commands as |command|}}
-      <div>
+      <div data-test-copyable-terminal-command-text>
         <span class="whitespace-nowrap text-gray-800 dark:text-gray-100 leading-loose">{{command}}</span>
       </div>
     {{/each}}

--- a/app/components/course-page/course-stage-step/test-runner-card/run-tests-instructions.hbs
+++ b/app/components/course-page/course-stage-step/test-runner-card/run-tests-instructions.hbs
@@ -1,10 +1,12 @@
-<div class="prose prose-sm prose-compact">
+<div class="prose prose-sm prose-compact mb-3">
   {{#if this.lastSubmissionWasForCurrentStage}}
-    <p>
+    <p class="mb-3">
       {{#if (eq this.lastSubmission.status "evaluating")}}
-        <b>Running tests... </b>
+        <b>Running tests...</b>
       {{else if (eq this.lastSubmission.status "failure")}}
-        <b>Tests failed. </b>
+        <b>Tests failed.</b>
+      {{else if (eq this.lastSubmission.status "error")}}
+        <b>Whoops! Looks like we ran into an internal error. Trying again might work.</b>
       {{/if}}
 
       <a href="#" role="button" {{on "click" @onViewLogsButtonClick}}>Click here</a>
@@ -14,26 +16,56 @@
 
   {{#if this.lastSubmissionWasForCurrentStage}}
     <p>
-      To run tests again, make changes to your code and run the test command:
+      To run tests again, make changes to your code and run the
+      {{#if (eq this.suggestedClientType "git")}}
+        following commands:
+      {{else}}
+        test command:
+      {{/if}}
     </p>
   {{else}}
     <p>
-      To run tests, make changes to your code and run the test command:
+      To run tests, make changes to your code and run the
+
+      {{#if (eq this.suggestedClientType "git")}}
+        following commands:
+      {{else}}
+        test command:
+      {{/if}}
     </p>
   {{/if}}
 </div>
 
-<CopyableTerminalCommand @commands={{array "codecrafters test"}} class="mt-3" />
+<CopyableTerminalCommand @commands={{this.suggestedCommands}} class="mb-4" />
 
-<div class="prose prose-sm mt-4 prose-compact">
-  <p>
-    Don't have the
-    <a href="https://codecrafters.io/cli" target="_blank" rel="noopener noreferrer">CLI</a>
-    installed? You can also submit code using Git:
-  </p>
+<div class="prose prose-sm prose-compact">
+  {{#if (eq this.suggestedClientType "cli")}}
+    <p>
+      Don't have the
+      <a href="https://codecrafters.io/cli" target="_blank" rel="noopener noreferrer">CLI</a>
+      installed? You can also submit code
+      <a href="#" {{on "click" this.toggleAlternateClientInstructions}} data-test-toggle-alternate-client-instructions-link>
+        using Git
+        {{if this.alternateClientInstructionsAreExpanded "↑" "↓"}}
+      </a>.
+    </p>
+  {{else}}
+    <p>
+      You can also submit code
+      <a href="#" {{on "click" this.toggleAlternateClientInstructions}} data-test-toggle-alternate-client-instructions-link>
+        using the codecrafters CLI
+        {{if this.alternateClientInstructionsAreExpanded "↑" "↓"}}
+      </a>.
+    </p>
+  {{/if}}
 </div>
 
-<CopyableTerminalCommand
-  @commands={{array "git add ." 'git commit --allow-empty -am "pass stage" # any message' "git push origin master"}}
-  class="mt-3"
-/>
+{{#if this.alternateClientInstructionsAreExpanded}}
+  <CopyableTerminalCommand @commands={{this.suggestedCommandsForAlternateClient}} class="mt-3" />
+
+  <TertiaryButton @size="extra-small" {{on "click" this.toggleAlternateClientInstructions}} class="mt-3">
+    ↑ Hide
+    {{if (eq this.suggestedClientType "git") "CLI" "Git"}}
+    instructions
+  </TertiaryButton>
+{{/if}}

--- a/app/components/course-page/course-stage-step/test-runner-card/run-tests-instructions.ts
+++ b/app/components/course-page/course-stage-step/test-runner-card/run-tests-instructions.ts
@@ -1,4 +1,6 @@
+import { action } from '@ember/object';
 import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
 import type CourseStageStep from 'codecrafters-frontend/utils/course-page-step-list/course-stage-step';
 
 interface Signature {
@@ -11,12 +13,43 @@ interface Signature {
 }
 
 export default class RunTestsInstructionsComponent extends Component<Signature> {
+  @tracked alternateClientInstructionsAreExpanded = false;
+
   get lastSubmission() {
     return this.args.currentStep.repository.lastSubmission;
   }
 
   get lastSubmissionWasForCurrentStage() {
     return this.lastSubmission?.courseStage === this.args.currentStep.courseStage;
+  }
+
+  get suggestedClientType() {
+    if (this.args.currentStep.courseStage.isFirst || this.args.currentStep.courseStage.isSecond) {
+      return 'git';
+    } else {
+      return 'cli';
+    }
+  }
+
+  get suggestedCommands() {
+    return this.suggestedClientType === 'git' ? this.suggestedCommandsForGit : this.suggestedCommandsForCli;
+  }
+
+  get suggestedCommandsForAlternateClient() {
+    return this.suggestedClientType === 'git' ? this.suggestedCommandsForCli : this.suggestedCommandsForGit;
+  }
+
+  get suggestedCommandsForCli() {
+    return ['codecrafters test'];
+  }
+
+  get suggestedCommandsForGit() {
+    return ['git add .', 'git commit --allow-empty -m "pass stage" # any message', 'git push origin master'];
+  }
+
+  @action
+  toggleAlternateClientInstructions() {
+    this.alternateClientInstructionsAreExpanded = !this.alternateClientInstructionsAreExpanded;
   }
 }
 

--- a/app/components/course-page/course-stage-step/test-runner-card/tests-passed-instructions.hbs
+++ b/app/components/course-page/course-stage-step/test-runner-card/tests-passed-instructions.hbs
@@ -30,7 +30,7 @@
   </p>
 </div>
 
-<CopyableTerminalCommand @commands={{array "git add . " "git commit --allow-empty -am 'pass stage'" "git push origin master"}} />
+<CopyableTerminalCommand @commands={{array "git add . " "git commit --allow-empty -m 'pass stage'" "git push origin master"}} />
 
 {{! TODO: Revive this when we're handling regular git pushes}}
 

--- a/tests/acceptance/course-page/attempt-course-stage-test.js
+++ b/tests/acceptance/course-page/attempt-course-stage-test.js
@@ -166,7 +166,6 @@ module('Acceptance | course-page | attempt-course-stage', function (hooks) {
     await Promise.all(window.pollerInstances.map((poller) => poller.forcePoll()));
     await animationsSettled();
 
-    // TODO: Add tests for badge display
     assert.strictEqual(coursePage.desktopHeader.stepName, 'Bind to a port', 'first stage is still active');
     assert.ok(coursePage.earnedBadgeNotice.isVisible, 'badge is visible');
 

--- a/tests/acceptance/course-page/test-runner-card-test.js
+++ b/tests/acceptance/course-page/test-runner-card-test.js
@@ -1,0 +1,93 @@
+import catalogPage from 'codecrafters-frontend/tests/pages/catalog-page';
+import coursePage from 'codecrafters-frontend/tests/pages/course-page';
+import testScenario from 'codecrafters-frontend/mirage/scenarios/test';
+import { setupAnimationTest } from 'ember-animated/test-support';
+import { currentURL } from '@ember/test-helpers';
+import { module, test } from 'qunit';
+import { setupApplicationTest } from 'codecrafters-frontend/tests/helpers';
+import { signIn } from 'codecrafters-frontend/tests/support/authentication-helpers';
+
+module('Acceptance | course-page | test-runner-card', function (hooks) {
+  setupApplicationTest(hooks);
+  setupAnimationTest(hooks);
+
+  test('suggests Git by default for stage 2', async function (assert) {
+    testScenario(this.server);
+    signIn(this.owner, this.server);
+
+    let currentUser = this.server.schema.users.first();
+    let python = this.server.schema.languages.findBy({ name: 'Python' });
+    let redis = this.server.schema.courses.findBy({ slug: 'redis' });
+
+    this.server.create('repository', 'withFirstStageCompleted', {
+      course: redis,
+      language: python,
+      user: currentUser,
+    });
+
+    await catalogPage.visit();
+    await catalogPage.clickOnCourse('Build your own Redis');
+
+    assert.strictEqual(currentURL(), '/courses/redis/stages/2', 'current URL is course page URL');
+
+    await coursePage.testRunnerCard.click(); // Expand to view instructions
+
+    assert.strictEqual(coursePage.testRunnerCard.copyableTerminalCommands.length, 1, 'only one copyable terminal command is present by default');
+
+    assert.deepEqual(coursePage.testRunnerCard.copyableTerminalCommands[0].commands, [
+      'git add .',
+      'git commit --allow-empty -m "pass stage" # any message',
+      'git push origin master',
+    ]);
+
+    await coursePage.testRunnerCard.clickOnToggleAlternateClientInstructionsLink();
+
+    assert.strictEqual(coursePage.testRunnerCard.copyableTerminalCommands.length, 2, 'two copyable terminal commands are present');
+    assert.deepEqual(coursePage.testRunnerCard.copyableTerminalCommands[1].commands, ['codecrafters test']);
+
+    await coursePage.testRunnerCard.clickOnToggleAlternateClientInstructionsLink();
+    assert.strictEqual(coursePage.testRunnerCard.copyableTerminalCommands.length, 1, 'only one copyable terminal command is present by default');
+  });
+
+  test('suggests CLI by default for stage 3', async function (assert) {
+    testScenario(this.server);
+    signIn(this.owner, this.server);
+
+    let currentUser = this.server.schema.users.first();
+    let python = this.server.schema.languages.findBy({ name: 'Python' });
+    let redis = this.server.schema.courses.findBy({ slug: 'redis' });
+
+    const repository = this.server.create('repository', 'withFirstStageCompleted', {
+      course: redis,
+      language: python,
+      user: currentUser,
+    });
+
+    this.server.create('submission', 'withStageCompletion', {
+      repository: repository,
+      courseStage: redis.stages.models.sortBy('position')[1],
+    });
+
+    await catalogPage.visit();
+    await catalogPage.clickOnCourse('Build your own Redis');
+
+    assert.strictEqual(currentURL(), '/courses/redis/stages/3', 'current URL is course page URL');
+
+    await coursePage.testRunnerCard.click(); // Expand to view instructions
+
+    assert.strictEqual(coursePage.testRunnerCard.copyableTerminalCommands.length, 1, 'only one copyable terminal command is present by default');
+    assert.deepEqual(coursePage.testRunnerCard.copyableTerminalCommands[0].commands, ['codecrafters test']);
+
+    await coursePage.testRunnerCard.clickOnToggleAlternateClientInstructionsLink();
+
+    assert.strictEqual(coursePage.testRunnerCard.copyableTerminalCommands.length, 2, 'two copyable terminal commands are present');
+    assert.deepEqual(coursePage.testRunnerCard.copyableTerminalCommands[1].commands, [
+      'git add .',
+      'git commit --allow-empty -m "pass stage" # any message',
+      'git push origin master',
+    ]);
+
+    await coursePage.testRunnerCard.clickOnToggleAlternateClientInstructionsLink();
+    assert.strictEqual(coursePage.testRunnerCard.copyableTerminalCommands.length, 1, 'only one copyable terminal command is present by default');
+  });
+});

--- a/tests/pages/components/copyable-terminal-command.js
+++ b/tests/pages/components/copyable-terminal-command.js
@@ -1,0 +1,9 @@
+import { collection } from 'ember-cli-page-object';
+
+export default {
+  commandTexts: collection('[data-test-copyable-terminal-command-text]', {}),
+
+  get commands() {
+    return this.commandTexts.map((commandText) => commandText.text.trim());
+  },
+};

--- a/tests/pages/course-page.js
+++ b/tests/pages/course-page.js
@@ -1,5 +1,6 @@
 import CommentCard from 'codecrafters-frontend/tests/pages/components/comment-card';
 import CommentList from 'codecrafters-frontend/tests/pages/components/course-page/comment-list';
+import CopyableTerminalCommand from 'codecrafters-frontend/tests/pages/components/copyable-terminal-command';
 import ConfigureExtensionsModal from 'codecrafters-frontend/tests/pages/components/course-page/configure-extensions-modal';
 import CreateRepositoryCard from 'codecrafters-frontend/tests/pages/components/course-page/create-repository-card';
 import DesktopHeader from 'codecrafters-frontend/tests/pages/components/course-page/desktop-header';
@@ -182,6 +183,8 @@ export default create({
   testResultsBar: TestResultsBar,
 
   testRunnerCard: {
+    copyableTerminalCommands: collection('[data-test-copyable-terminal-command]', CopyableTerminalCommand),
+    clickOnToggleAlternateClientInstructionsLink: clickable('[data-test-toggle-alternate-client-instructions-link]'),
     clickOnHideInstructionsButton: clickable('[data-test-hide-instructions-button]'),
     borderIsTeal: hasClass('border-teal-500'), // Used when tests have passed
     scope: '[data-test-test-runner-card]',


### PR DESCRIPTION
This commit refactors the RunTestsInstructionsComponent in the test-runner-card component. It introduces a new property alternateClientInstructionsAreExpanded to toggle between Git and CLI instructions. It also adds
computed properties suggestedClientType, suggestedCommands, suggestedCommandsForAlternateClient, suggestedCommandsForCli to determine the suggested commands based on the stage and client type.

Additionally, acceptance tests are added to verify the default suggestions for Git and CLI instructions based on the stage.

The changes are committed under 80 characters.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced the test runner card with dynamic Git command suggestions based on the client type.
	- Added functionality to toggle the display of alternate client instructions.
	- Introduced new user-friendly messages for internal error statuses during test runs.

- **Bug Fixes**
	- Corrected a typo in the Git commit command within the test-passed instructions.

- **Tests**
	- Added acceptance tests for the test runner card's functionality, including command suggestions and toggling instructions.

- **Documentation**
	- Improved user interface elements with data attributes for better testing and accessibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->