### PR TITLE
retain instructions state

### DIFF
--- a/app/components/course-page/course-stage-step/first-stage-instructions-card.hbs
+++ b/app/components/course-page/course-stage-step/first-stage-instructions-card.hbs
@@ -31,14 +31,16 @@
       {{/if}}
     </ExpandableStepList>
 
-    <div class="prose prose-sm prose-compact mt-5">
-      <p>
-        {{svg-jar "information-circle" class="w-5 h-5 mb-0.5 inline-flex text-sky-500"}}
-        <b>Note:</b>
-        After your first Git push, you should see
-        <code class="font-semibold text-red-700 bg-red-100 border border-red-200">Tests failed</code>
-        in the bar below this card. This is expected! Complete the steps above to pass the tests.
-      </p>
-    </div>
+    {{#unless this.markStageAsCompleteStepIsComplete}}
+      <div class="prose prose-sm prose-compact mt-5">
+        <p>
+          {{svg-jar "information-circle" class="w-5 h-5 mb-0.5 inline-flex text-sky-500"}}
+          <b>Note:</b>
+          After your first Git push, you should see
+          <code class="font-semibold text-red-700 bg-red-100 border border-red-200">Tests failed</code>
+          in the bar below this card. This is expected! Complete the steps above to pass the tests.
+        </p>
+      </div>
+    {{/unless}}
   </:content>
 </CoursePage::InstructionsCard>

--- a/app/components/course-page/course-stage-step/first-stage-instructions-card/submit-code-step.hbs
+++ b/app/components/course-page/course-stage-step/first-stage-instructions-card/submit-code-step.hbs
@@ -13,7 +13,7 @@
   <p class={{if @isComplete "line-through"}}>
     Once you run the commands above, the
     <code class="font-semibold text-red-700 bg-red-100 border border-red-200">Tests failed</code>
-    message above this card will change to
+    message below this card will change to
     <code class="font-semibold text-green-700 bg-green-100 border border-green-200">Tests passed</code>.
   </p>
 


### PR DESCRIPTION
- add failing test
- Refactor FirstStageInstructionsCardComponent and CoursePageStateService
- Refactor SecondStageInstructionsCardComponent
- Refactor first-stage-instructions-card.ts file
- Refactor instructions and test runner cards in course-page components
- Refactor first-stage-instructions-card.hbs and submit-code-step.hbs templates


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Adjusted the visibility of instructional content related to test failures on the course page based on completion status.
	- Corrected text instructions regarding the location of test results on the course page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->