### PR TITLE
Add syntax highlighting to copyable terminal commands

### DIFF
--- a/app/components/code-walkthrough-snippet.hbs
+++ b/app/components/code-walkthrough-snippet.hbs
@@ -1,18 +1,3 @@
-{{! @glint-nocheck: not typesafe yet }}
-{{!--
-<div class="mb-4 bg-white shadow-sm rounded border border-gray-300">
-  <a
-    href={{@link}}
-    target="_blank"
-    class="flex group justify-between items-center group bg-gray-100 rounded-t py-2 px-3 border-b border-gray-200 shadow-sm"
-    rel="noopener noreferrer"
-  >
-    <span class="font-mono text-xs text-gray-700 group-hover:text-blue-600">{{@filePath}}</span>
-    <span>{{svg-jar "external-link" class="w-4 fill-current text-gray-400 group-hover:text-blue-500"}}</span>
-  </a>
-</div>
---}}
-
 {{! template-lint-disable no-inline-styles }}
 <div class="text-sm rounded-lg overflow-hidden" style="background-color: #282c34;" ...attributes>
   <a
@@ -29,5 +14,12 @@
     </div>
     <div>{{svg-jar "external-link" class="w-4 fill-current text-gray-400 opacity-0 group-hover:opacity-100"}}</div>
   </a>
-  <SyntaxHighlightedCode @code={{@code}} @language={{@language}} @highlightedLines={{@highlightedLines}} @theme="one-dark-pro" class="py-2" />
+  <SyntaxHighlightedCode
+    @code={{@code}}
+    @language={{@language}}
+    @highlightedLines={{@highlightedLines}}
+    @theme="one-dark-pro"
+    @shouldDisplayLineNumbers={{true}}
+    class="py-2"
+  />
 </div>

--- a/app/components/code-walkthrough-snippet.ts
+++ b/app/components/code-walkthrough-snippet.ts
@@ -1,0 +1,25 @@
+import Component from '@glimmer/component';
+
+interface Signature {
+  Element: HTMLDivElement;
+
+  Args: {
+    code: string;
+    language: string;
+    link: string;
+    filePath: string;
+    highlightedLines: string;
+  };
+
+  Blocks: {
+    default: [];
+  };
+}
+
+export default class CodeWalkthroughSnippetComponent extends Component<Signature> {}
+
+declare module '@glint/environment-ember-loose/registry' {
+  export default interface Registry {
+    CodeWalkthroughSnippet: typeof CodeWalkthroughSnippetComponent;
+  }
+}

--- a/app/components/copyable-terminal-command.hbs
+++ b/app/components/copyable-terminal-command.hbs
@@ -25,7 +25,7 @@
     </TertiaryButton>
   </div>
 
-  <div class="w-full text-xs overflow-x-auto">
+  <div class="w-full text-xs overflow-x-auto" data-test-copyable-text>
     <SyntaxHighlightedCode @code={{this.codeForHighlighting}} @language="shellscript" @theme="github-light" @shouldDisplayLineNumbers={{false}} />
   </div>
 </div>

--- a/app/components/copyable-terminal-command.hbs
+++ b/app/components/copyable-terminal-command.hbs
@@ -1,5 +1,5 @@
 <div
-  class="flex flex-col items-stretch rounded bg-white dark:bg-gray-800 w-full max-w-2xl border border-gray-300 dark:border-gray-600"
+  class="flex flex-col items-stretch rounded bg-white dark:bg-gray-800 w-full max-w-2xl border border-gray-300 dark:border-gray-600 overflow-y-hidden"
   ...attributes
   data-test-copyable-terminal-command
 >
@@ -25,11 +25,7 @@
     </TertiaryButton>
   </div>
 
-  <div class="px-3 py-2.5 w-full font-mono text-xs overflow-x-auto">
-    {{#each @commands as |command|}}
-      <div data-test-copyable-terminal-command-text>
-        <span class="whitespace-nowrap text-gray-800 dark:text-gray-100 leading-loose">{{command}}</span>
-      </div>
-    {{/each}}
+  <div class="w-full text-xs overflow-x-auto">
+    <SyntaxHighlightedCode @code={{this.codeForHighlighting}} @language="shellscript" @theme="github-light" @shouldDisplayLineNumbers={{false}} />
   </div>
 </div>

--- a/app/components/copyable-terminal-command.ts
+++ b/app/components/copyable-terminal-command.ts
@@ -19,6 +19,10 @@ export default class CopyableTerminalCommandComponent extends Component<Signatur
 
   @tracked wasCopiedRecently: boolean = false;
 
+  get codeForHighlighting(): string {
+    return this.args.commands.join('\n');
+  }
+
   get copyableText(): string {
     return this.args.commands.join('\n');
   }

--- a/app/components/course-page/setup-step/repository-setup-card/clone-repository-step.hbs
+++ b/app/components/course-page/setup-step/repository-setup-card/clone-repository-step.hbs
@@ -1,52 +1,62 @@
-{{! @glint-nocheck: not typesafe yet }}
-<div class="text-gray-700 prose" data-test-clone-repository-step>
-  <p class="mb-5">
-    We've prepared a starter repository with some
-    {{@repository.language.name}}
-    code for you.
-  </p>
-
-  <div class="mb-3 inline-flex items-center gap-1">
-    {{#if @isComplete}}
-      {{svg-jar "check-circle" class="w-6 h-6 text-teal-500 inline-flex mb-0.5"}}
-    {{else}}
-      <b class="text-teal-600">Step 1:</b>
-    {{/if}}
-
-    Clone the repository
+<div data-test-clone-repository-step>
+  <div class="prose mb-5">
+    <p>
+      We've prepared a starter repository with some
+      {{@repository.language.name}}
+      code for you.
+    </p>
   </div>
 
-  {{#if @repository.isNew}}
-    <div class="prose mb-5">
-      <p>
-        <span class="text-lg">⚠️</span>
-        Select a language to see instructions to clone your repository.
-      </p>
-    </div>
-  {{else}}
-    <div class="mb-5">
-      <CopyableTerminalCommand
-        @commands={{array (concat "git clone " @repository.cloneUrl " " @repository.cloneDirectory) (concat "cd " @repository.cloneDirectory)}}
-        data-test-copyable-repository-clone-instructions
-      />
-    </div>
-  {{/if}}
+  <div class="prose mb-3">
+    <div class="inline-flex items-center gap-1">
+      {{#if @isComplete}}
+        {{svg-jar "check-circle" class="w-6 h-6 text-teal-500 inline-flex mb-0.5"}}
+      {{else}}
+        <b class="text-teal-600">Step 1:</b>
+      {{/if}}
 
-  <div class="mb-3 inline-flex items-center gap-1">
-    {{#if @isComplete}}
-      {{svg-jar "check-circle" class="w-6 h-6 text-teal-500 inline-flex mb-0.5"}}
+      Clone the repository
+    </div>
+  </div>
+
+  <div class="mb-5">
+    {{! @glint-expect-error isNew is not typed? }}
+    {{#if @repository.isNew}}
+      <div class="prose">
+        <p>
+          <span class="text-lg">⚠️</span>
+          Select a language to see instructions to clone your repository.
+        </p>
+      </div>
     {{else}}
-      <b class="text-teal-600">Step 2:</b>
+      <div class="mb-5">
+        <CopyableTerminalCommand
+          @commands={{array (concat "git clone " @repository.cloneUrl " " @repository.cloneDirectory) (concat "cd " @repository.cloneDirectory)}}
+          data-test-copyable-repository-clone-instructions
+        />
+      </div>
     {{/if}}
+  </div>
 
-    Push an empty commit
+  <div class="prose mb-3">
+    <div class="inline-flex items-center gap-1">
+      {{#if @isComplete}}
+        {{svg-jar "check-circle" class="w-6 h-6 text-teal-500 inline-flex mb-0.5"}}
+      {{else}}
+        <b class="text-teal-600">Step 2:</b>
+      {{/if}}
+
+      Push an empty commit
+    </div>
   </div>
 
   <div class="mb-5">
     <CopyableTerminalCommand @commands={{array "git commit --allow-empty -m 'test'" "git push origin master"}} />
   </div>
 
-  <p class={{if @isComplete "line-through"}}>
-    When you run the above command, the "Listening for a git push" message below will change, and the first stage will be activated.
-  </p>
+  <div class="prose">
+    <p class={{if @isComplete "line-through"}}>
+      When you run the above command, the "Listening for a git push" message below will change, and the first stage will be activated.
+    </p>
+  </div>
 </div>

--- a/app/components/file-contents-card.hbs
+++ b/app/components/file-contents-card.hbs
@@ -34,7 +34,7 @@
   </div>
 
   {{#unless @isCollapsed}}
-    <SyntaxHighlightedCode @code={{@code}} @language={{@language}} @theme="github-light" class="text-sm" />
+    <SyntaxHighlightedCode @code={{@code}} @language={{@language}} @theme="github-light" @shouldDisplayLineNumbers={{true}} class="text-sm" />
 
     {{#if @isCollapsible}}
       <div class="flex items-center justify-center mb-3">

--- a/app/components/syntax-highlighted-code.hbs
+++ b/app/components/syntax-highlighted-code.hbs
@@ -1,3 +1,3 @@
-<div class="syntax-highlighted-code leading-6" ...attributes>
+<div class="syntax-highlighted-code leading-6 {{if @shouldDisplayLineNumbers 'with-line-numbers'}}" ...attributes>
   {{this.highlightedHtml}}
 </div>

--- a/app/components/syntax-highlighted-code.ts
+++ b/app/components/syntax-highlighted-code.ts
@@ -11,6 +11,7 @@ export type Signature = {
   Args: {
     code: string;
     language: string;
+    shouldDisplayLineNumbers: boolean;
     theme: string;
     highlightedLines?: string;
   };

--- a/app/components/syntax-highlighted-code.ts
+++ b/app/components/syntax-highlighted-code.ts
@@ -36,6 +36,8 @@ export default class SyntaxHighlightedCodeComponent extends Component<Signature>
     highlighterPromise
       .then((highlighter) => {
         this.asyncHighlightedHTML = htmlSafe(highlighter.codeToHtml(this.trimmedCode, { lang: this.args.language, lineOptions: lineOptions }));
+
+        // Uncomment to test temporaryHTML rendering
         // this.asyncHighlightedHTML = this.temporaryHTML;
       })
       .catch((error) => {

--- a/app/styles/app.css
+++ b/app/styles/app.css
@@ -71,12 +71,12 @@
   min-width: 100%;
 }
 
-.syntax-highlighted-code pre code {
+.syntax-highlighted-code.with-line-numbers pre code {
   counter-reset: step;
   counter-increment: step 0;
 }
 
-.syntax-highlighted-code pre code .line::before {
+.syntax-highlighted-code.with-line-numbers pre code .line::before {
   content: counter(step);
   counter-increment: step;
   width: 1rem;

--- a/tests/acceptance/course-page/test-runner-card-test.js
+++ b/tests/acceptance/course-page/test-runner-card-test.js
@@ -34,17 +34,16 @@ module('Acceptance | course-page | test-runner-card', function (hooks) {
 
     assert.strictEqual(coursePage.testRunnerCard.copyableTerminalCommands.length, 1, 'only one copyable terminal command is present by default');
 
-    assert.deepEqual(coursePage.testRunnerCard.copyableTerminalCommands[0].commands, ['codecrafters test']);
+    assert.strictEqual(coursePage.testRunnerCard.copyableTerminalCommands[0].copyableText, 'codecrafters test');
 
     await coursePage.testRunnerCard.clickOnToggleAlternateClientInstructionsLink();
 
     assert.strictEqual(coursePage.testRunnerCard.copyableTerminalCommands.length, 2, 'two copyable terminal commands are present');
 
-    assert.deepEqual(coursePage.testRunnerCard.copyableTerminalCommands[1].commands, [
-      'git add .',
-      'git commit --allow-empty -m "pass stage" # any message',
-      'git push origin master',
-    ]);
+    assert.strictEqual(
+      coursePage.testRunnerCard.copyableTerminalCommands[1].copyableText,
+      ['git add .', 'git commit --allow-empty -m "pass stage" # any message', 'git push origin master'].join(' '),
+    );
 
     await coursePage.testRunnerCard.clickOnToggleAlternateClientInstructionsLink();
     assert.strictEqual(coursePage.testRunnerCard.copyableTerminalCommands.length, 1, 'only one copyable terminal command is present by default');

--- a/tests/pages/components/copyable-terminal-command.js
+++ b/tests/pages/components/copyable-terminal-command.js
@@ -1,9 +1,0 @@
-import { collection } from 'ember-cli-page-object';
-
-export default {
-  commandTexts: collection('[data-test-copyable-terminal-command-text]', {}),
-
-  get commands() {
-    return this.commandTexts.map((commandText) => commandText.text.trim());
-  },
-};

--- a/tests/pages/components/copyable-terminal-command.ts
+++ b/tests/pages/components/copyable-terminal-command.ts
@@ -1,0 +1,6 @@
+import { text } from 'ember-cli-page-object';
+
+export default {
+  copyableText: text('[data-test-copyable-text]'),
+  scope: '[data-test-copyable-terminal-command]',
+};


### PR DESCRIPTION
- add failing test
- Refactor FirstStageInstructionsCardComponent and CoursePageStateService
- Refactor SecondStageInstructionsCardComponent
- Refactor first-stage-instructions-card.ts file
- Refactor instructions and test runner cards in course-page components
- Refactor first-stage-instructions-card.hbs and submit-code-step.hbs templates
- Refactor code instructions and test runner card updates
- Refactor test to use testRunnerCard instead of firstStageInstructionsCard
- Refactor first stage instructions card and remove mark stage as complete step.
- update
- Refactor TestsPassedInstructionsComponent
- Refactor code or proceed to next step
- Refactor first-stage-instructions-card.hbs: hide code step if uncommentCodeStepIsComplete is not true
- don't mix copyable terminal command with prose


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a Glimmer component `CodeWalkthroughSnippetComponent` for displaying code snippets with customizable options.
	- Added a computed property `codeForHighlighting` to the `CopyableTerminalCommandComponent` for syntax highlighting purposes.
	- Enabled the display of line numbers in code snippets by adding the `@shouldDisplayLineNumbers={{true}}` parameter to relevant components.
	- Added a conditional class to the syntax-highlighted code container based on the `@shouldDisplayLineNumbers` value.
- **Refactor**
	- Improved the layout and text descriptions in the repository cloning step of the course setup page for better user experience and clarity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->