### PR TITLE
CC-1194 allow admins to pin code examples

### DIFF
--- a/app/components/course-page/course-stage-step/community-solution-card/content.hbs
+++ b/app/components/course-page/course-stage-step/community-solution-card/content.hbs
@@ -29,8 +29,7 @@
             {{svg-jar "github" class="w-3.5 h-3.5 text-gray-600"}}
           </a>
         {{else if this.shouldShowPublishToGithubButton}}
-          {{! @glint-expect-error onPublishToGithubButton is not null }}
-          <button type="button" {{on "click" @onPublishToGithubButtonClick}} class="flex gap-x-1 items-center group">
+          <button type="button" {{on "click" this.handlePublishToGithubButtonClick}} class="flex gap-x-1 items-center group">
             <span class="text-[10px] text-gray-700 group-hover:underline">
               Publish to GitHub
             </span>

--- a/app/components/course-page/course-stage-step/community-solution-card/content.ts
+++ b/app/components/course-page/course-stage-step/community-solution-card/content.ts
@@ -17,7 +17,7 @@ type Signature = {
   Args: {
     solution: CommunityCourseStageSolutionModel;
     fileComparisons: FileComparison[];
-    onPublishToGithubButtonClick?: (event: MouseEvent) => void;
+    onPublishToGithubButtonClick?: () => void;
   };
 };
 
@@ -101,9 +101,9 @@ export default class CommunitySolutionCardContentComponent extends Component<Sig
   }
 
   @action
-  handlePublishToGithubButtonClick(event: MouseEvent) {
+  handlePublishToGithubButtonClick() {
     if (typeof this.args.onPublishToGithubButtonClick === 'function') {
-      this.args.onPublishToGithubButtonClick(event);
+      this.args.onPublishToGithubButtonClick();
     }
   }
 }

--- a/app/components/course-page/course-stage-step/community-solution-card/content.ts
+++ b/app/components/course-page/course-stage-step/community-solution-card/content.ts
@@ -102,7 +102,7 @@ export default class CommunitySolutionCardContentComponent extends Component<Sig
 
   @action
   handlePublishToGithubButtonClick() {
-    if (typeof this.args.onPublishToGithubButtonClick === 'function') {
+    if (this.args.onPublishToGithubButtonClick) {
       this.args.onPublishToGithubButtonClick();
     }
   }

--- a/app/components/course-page/course-stage-step/community-solution-card/content.ts
+++ b/app/components/course-page/course-stage-step/community-solution-card/content.ts
@@ -17,7 +17,7 @@ type Signature = {
   Args: {
     solution: CommunityCourseStageSolutionModel;
     fileComparisons: FileComparison[];
-    onPublishToGithubButtonClick?: () => void;
+    onPublishToGithubButtonClick?: (event: MouseEvent) => void;
   };
 };
 
@@ -97,6 +97,13 @@ export default class CommunitySolutionCardContentComponent extends Component<Sig
   handleExpandUnchangedFile(filePath: string) {
     if (!this.expandedUnchangedFilePaths.includes(filePath)) {
       this.expandedUnchangedFilePaths = [...this.expandedUnchangedFilePaths, filePath];
+    }
+  }
+
+  @action
+  handlePublishToGithubButtonClick(event: MouseEvent) {
+    if (typeof this.args.onPublishToGithubButtonClick === 'function') {
+      this.args.onPublishToGithubButtonClick(event);
     }
   }
 }

--- a/app/controllers/course-admin/code-example.ts
+++ b/app/controllers/course-admin/code-example.ts
@@ -1,4 +1,5 @@
 import Controller from '@ember/controller';
+import { action } from '@ember/object';
 import type CommunityCourseStageSolutionModel from 'codecrafters-frontend/models/community-course-stage-solution';
 import type SolutionComparisonModel from 'codecrafters-frontend/models/solution-comparison';
 
@@ -7,4 +8,10 @@ export default class CodeExampleController extends Controller {
     solution: CommunityCourseStageSolutionModel;
     comparisons: SolutionComparisonModel[];
   };
+
+  @action
+  handlePinCodeExampleToggled() {
+    this.model.solution.isPinned = !this.model.solution.isPinned;
+    this.model.solution.save();
+  }
 }

--- a/app/templates/course-admin/code-example.hbs
+++ b/app/templates/course-admin/code-example.hbs
@@ -25,6 +25,17 @@
             {{@model.solution.courseStage.name}}
           </h3>
         </div>
+
+        <div class="flex flex-col items-end">
+          <Toggle
+            @isOn={{@model.solution.isPinned}}
+            {{on "click" this.handlePinCodeExampleToggled}}
+          />
+
+          <div class="text-xs text-gray-400 mt-2">
+            Editor's choice
+          </div>
+        </div>
       </div>
     </div>
 

--- a/app/templates/course-admin/code-example.hbs
+++ b/app/templates/course-admin/code-example.hbs
@@ -27,11 +27,7 @@
         </div>
 
         <div class="flex flex-col items-end">
-          <Toggle
-            @isOn={{@model.solution.isPinned}}
-            {{on "click" this.handlePinCodeExampleToggled}}
-            data-test-pin-code-example-toggle
-          />
+          <Toggle @isOn={{@model.solution.isPinned}} {{on "click" this.handlePinCodeExampleToggled}} data-test-pin-code-example-toggle />
 
           <div class="text-xs text-gray-400 mt-2">
             Editor's choice

--- a/app/templates/course-admin/code-example.hbs
+++ b/app/templates/course-admin/code-example.hbs
@@ -30,6 +30,7 @@
           <Toggle
             @isOn={{@model.solution.isPinned}}
             {{on "click" this.handlePinCodeExampleToggled}}
+            data-test-pin-code-example-toggle
           />
 
           <div class="text-xs text-gray-400 mt-2">

--- a/mirage/config.js
+++ b/mirage/config.js
@@ -623,7 +623,7 @@ function routes() {
     return new Response(200, {}, {});
   });
 
-  this.get('/solution-comparisons')
+  this.get('/solution-comparisons');
 
   this.post('/subscriptions/:id/cancel-trial', function (schema, request) {
     const subscription = schema.subscriptions.find(request.params.id);

--- a/mirage/config.js
+++ b/mirage/config.js
@@ -227,6 +227,9 @@ function routes() {
     return result;
   });
 
+  this.get('/community-course-stage-solutions/:id');
+  this.patch('/community-course-stage-solutions/:id');
+
   this.get('/community-course-stage-solutions/:id/file-comparisons', function (schema, request) {
     const solution = schema.communityCourseStageSolutions.find(request.params.id);
 
@@ -619,6 +622,8 @@ function routes() {
   this.post('/sessions/logout', function () {
     return new Response(200, {}, {});
   });
+
+  this.get('/solution-comparisons')
 
   this.post('/subscriptions/:id/cancel-trial', function (schema, request) {
     const subscription = schema.subscriptions.find(request.params.id);

--- a/tests/acceptance/course-admin/pin-code-example-test.js
+++ b/tests/acceptance/course-admin/pin-code-example-test.js
@@ -1,16 +1,17 @@
 import { module, test } from 'qunit';
 import { setupApplicationTest } from 'codecrafters-frontend/tests/helpers';
-import { signInAsCourseAuthor, signInAsStaff } from 'codecrafters-frontend/tests/support/authentication-helpers';
+import { signInAsStaff } from 'codecrafters-frontend/tests/support/authentication-helpers';
 import catalogPage from 'codecrafters-frontend/tests/pages/catalog-page';
-import codeExamplePage from 'codecrafters-frontend/tests/pages/course-admin/code-example-page'
+import codeExamplePage from 'codecrafters-frontend/tests/pages/course-admin/code-example-page';
+import courseOverviewPage from 'codecrafters-frontend/tests/pages/course-overview-page';
 import coursePage from 'codecrafters-frontend/tests/pages/course-page';
 import createCommunityCourseStageSolution from 'codecrafters-frontend/mirage/utils/create-community-course-stage-solution';
 import testScenario from 'codecrafters-frontend/mirage/scenarios/test';
 
-module('Acceptance | course-admin | pin-code-example', function(hooks) {
+module('Acceptance | course-admin | pin-code-example', function (hooks) {
   setupApplicationTest(hooks);
 
-  test('can pin code example', async function(assert) {
+  test('can pin code example', async function (assert) {
     testScenario(this.server);
     signInAsStaff(this.owner, this.server);
 

--- a/tests/acceptance/course-admin/pin-code-example-test.js
+++ b/tests/acceptance/course-admin/pin-code-example-test.js
@@ -1,0 +1,51 @@
+import { module, test } from 'qunit';
+import { setupApplicationTest } from 'codecrafters-frontend/tests/helpers';
+import { signInAsCourseAuthor, signInAsStaff } from 'codecrafters-frontend/tests/support/authentication-helpers';
+import catalogPage from 'codecrafters-frontend/tests/pages/catalog-page';
+import codeExamplePage from 'codecrafters-frontend/tests/pages/course-admin/code-example-page'
+import coursePage from 'codecrafters-frontend/tests/pages/course-page';
+import createCommunityCourseStageSolution from 'codecrafters-frontend/mirage/utils/create-community-course-stage-solution';
+import testScenario from 'codecrafters-frontend/mirage/scenarios/test';
+
+module('Acceptance | course-admin | pin-code-example', function(hooks) {
+  setupApplicationTest(hooks);
+
+  test('can pin code example', async function(assert) {
+    testScenario(this.server);
+    signInAsStaff(this.owner, this.server);
+
+    this.server.create('user', {
+      avatarUrl: 'https://github.com/sarupbanskota.png',
+      createdAt: new Date(),
+      githubUsername: 'sarupbanskota',
+      username: 'sarupbanskota',
+    });
+
+    this.server.create('user', {
+      avatarUrl: 'https://github.com/Gufran.png',
+      createdAt: new Date(),
+      githubUsername: 'gufran',
+      username: 'gufran',
+    });
+
+    let redis = this.server.schema.courses.findBy({ slug: 'redis' });
+    let go = this.server.schema.languages.findBy({ slug: 'go' });
+    let python = this.server.schema.languages.findBy({ slug: 'python' });
+
+    createCommunityCourseStageSolution(this.server, redis, 2, python);
+    const solution = createCommunityCourseStageSolution(this.server, redis, 2, go);
+
+    await codeExamplePage.visit({ course_slug: 'redis', code_example_id: solution.id });
+    await codeExamplePage.clickOnPinCodeExampleToggle();
+
+    await catalogPage.visit();
+    await catalogPage.clickOnCourse('Build your own Redis');
+    await courseOverviewPage.clickOnStartCourse();
+    await coursePage.sidebar.clickOnStepListItem('Respond to PING');
+
+    await coursePage.yourTaskCard.clickOnActionButton('Code Examples');
+    await coursePage.codeExamplesTab.solutionCards[0].clickOnExpandButton();
+
+    assert.true(coursePage.codeExamplesTab.solutionCards[0].text.includes("Editor's choice"));
+  });
+});

--- a/tests/pages/course-admin/code-example-page.js
+++ b/tests/pages/course-admin/code-example-page.js
@@ -1,0 +1,9 @@
+import { clickable, create, visitable } from 'ember-cli-page-object';
+
+export default create({
+  pinCodeExampleToggle: {
+    scope: '[data-test-pin-code-example-toggle]'
+  },
+
+  visit: visitable('/courses/:course_slug/admin/code-examples/:code_example_id'),
+});

--- a/tests/pages/course-admin/code-example-page.js
+++ b/tests/pages/course-admin/code-example-page.js
@@ -1,9 +1,6 @@
 import { clickable, create, visitable } from 'ember-cli-page-object';
 
 export default create({
-  pinCodeExampleToggle: {
-    scope: '[data-test-pin-code-example-toggle]'
-  },
-
+  clickOnPinCodeExampleToggle: clickable('[data-test-pin-code-example-toggle]'),
   visit: visitable('/courses/:course_slug/admin/code-examples/:code_example_id'),
 });


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Added a toggle button in the course admin section to pin code examples as editor's choice.
	- Introduced new API routes for fetching and updating course stage solutions and for solution comparisons.
	- Replaced the function in the `community-solution-card` component for publishing to GitHub.

- **Bug Fixes**
	- Ensured that pinning functionality correctly toggles and saves the pin status of code examples.

- **Tests**
	- Added acceptance tests for the new pinning functionality in the course admin section.
	- Created page object definitions for the course admin code example page to facilitate testing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->