### PR TITLE
CC-1199 add tooltips to greyed out items in repository dropdown

### DIFF
--- a/app/components/course-page/repository-dropdown.hbs
+++ b/app/components/course-page/repository-dropdown.hbs
@@ -44,6 +44,10 @@
                 </div>
               {{/animated-if}}
             </AnimatedContainer>
+
+            {{#if @activeRepository.isNew}}
+              <EmberTooltip @text="Please select a language first" />
+            {{/if}}
           </div>
 
           {{#if @activeRepository.progressBannerUrl}}
@@ -60,6 +64,10 @@
           >
             Publish to GitHub
             {{svg-jar "github" class="w-5 ml-4 text-gray-300 group-hover:text-teal-500"}}
+
+            {{#if @activeRepository.isNew}}
+              <EmberTooltip @text="Please select a language first" />
+            {{/if}}
           </div>
 
           <div

--- a/tests/pages/components/course-page/repository-dropdown.js
+++ b/tests/pages/components/course-page/repository-dropdown.js
@@ -1,4 +1,4 @@
-import { clickable, clickOnText, collection, count, text, triggerable, } from 'ember-cli-page-object';
+import { clickable, clickOnText, collection, count, text, triggerable } from 'ember-cli-page-object';
 import { settled } from '@ember/test-helpers';
 
 export default {

--- a/tests/pages/components/course-page/repository-dropdown.js
+++ b/tests/pages/components/course-page/repository-dropdown.js
@@ -1,4 +1,4 @@
-import { clickable, clickOnText, text, count } from 'ember-cli-page-object';
+import { clickable, clickOnText, collection, count, text, triggerable, } from 'ember-cli-page-object';
 import { settled } from '@ember/test-helpers';
 
 export default {
@@ -20,6 +20,10 @@ export default {
   },
 
   content: {
+    actions: collection('[data-test-dropdown-action]', {
+      hover: triggerable('mouseenter'),
+    }),
+
     clickOnRepositoryLink: clickOnText('[data-test-repository-link]'),
     clickOnAction: clickOnText('[data-test-dropdown-action]'),
     scope: '[data-test-repository-dropdown-content]',


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced tooltips in the course page's repository dropdown to guide users in selecting a language.
- **Tests**
	- Enhanced testing for tooltip content and visibility on the course page.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->