### PR TITLE
CC-1197 make concepts editor reordering arrows functional

### DIFF
--- a/app/components/concept-admin/questions-page/question-form.hbs
+++ b/app/components/concept-admin/questions-page/question-form.hbs
@@ -54,11 +54,11 @@
                 Option #{{add optionIndex 1}}
               </div>
               <div class="flex items-center gap-2 opacity-0 group-hover/option-form:opacity-100 transition-opacity">
-                <TertiaryButton @size="extra-small" class="group/trash-button" @isDisabled={{eq optionIndex 0}} data-test-move-up-button>
+                <TertiaryButton @size="extra-small" class="group/trash-button" @isDisabled={{eq optionIndex 0}} {{on "click" (fn this.moveOptionUp optionIndex)}} data-test-move-up-button>
                   {{svg-jar "arrow-up" class="w-4 h-4 text-gray-600 group-hover/trash-button:text-teal-600"}}
                   <EmberTooltip @text="Move this option up" />
                 </TertiaryButton>
-                <TertiaryButton @size="extra-small" class="group/trash-button" data-test-move-down-button>
+                <TertiaryButton @size="extra-small" class="group/trash-button" {{on "click" (fn this.moveOptionDown optionIndex)}}data-test-move-down-button>
                   {{svg-jar "arrow-down" class="w-4 h-4 text-gray-600 group-hover/trash-button:text-teal-600"}}
                   <EmberTooltip @text="Move this option down" />
                 </TertiaryButton>

--- a/app/components/concept-admin/questions-page/question-form.hbs
+++ b/app/components/concept-admin/questions-page/question-form.hbs
@@ -67,7 +67,7 @@
                 <TertiaryButton
                   @size="extra-small"
                   class="group/move-down-button"
-                  @isDisabled={{eq optionIndex (sub (length @question.options) 1)}}
+                  @isDisabled={{eq optionIndex (sub @question.options.length 1)}}
                   {{on "click" (fn this.moveOptionDown optionIndex)}}
                   data-test-move-down-button
                 >

--- a/app/components/concept-admin/questions-page/question-form.hbs
+++ b/app/components/concept-admin/questions-page/question-form.hbs
@@ -56,21 +56,21 @@
               <div class="flex items-center gap-2 opacity-0 group-hover/option-form:opacity-100 transition-opacity">
                 <TertiaryButton
                   @size="extra-small"
-                  class="group/trash-button"
+                  class="group/move-up-button"
                   @isDisabled={{eq optionIndex 0}}
                   {{on "click" (fn this.moveOptionUp optionIndex)}}
                   data-test-move-up-button
                 >
-                  {{svg-jar "arrow-up" class="w-4 h-4 text-gray-600 group-hover/trash-button:text-teal-600"}}
+                  {{svg-jar "arrow-up" class="w-4 h-4 text-gray-600 group-hover/move-up-button:text-teal-600"}}
                   <EmberTooltip @text="Move this option up" />
                 </TertiaryButton>
                 <TertiaryButton
                   @size="extra-small"
-                  class="group/trash-button"
+                  class="group/move-down-button"
                   {{on "click" (fn this.moveOptionDown optionIndex)}}
                   data-test-move-down-button
                 >
-                  {{svg-jar "arrow-down" class="w-4 h-4 text-gray-600 group-hover/trash-button:text-teal-600"}}
+                  {{svg-jar "arrow-down" class="w-4 h-4 text-gray-600 group-hover/move-down-button:text-teal-600"}}
                   <EmberTooltip @text="Move this option down" />
                 </TertiaryButton>
                 <TertiaryButton

--- a/app/components/concept-admin/questions-page/question-form.hbs
+++ b/app/components/concept-admin/questions-page/question-form.hbs
@@ -54,11 +54,22 @@
                 Option #{{add optionIndex 1}}
               </div>
               <div class="flex items-center gap-2 opacity-0 group-hover/option-form:opacity-100 transition-opacity">
-                <TertiaryButton @size="extra-small" class="group/trash-button" @isDisabled={{eq optionIndex 0}} {{on "click" (fn this.moveOptionUp optionIndex)}} data-test-move-up-button>
+                <TertiaryButton
+                  @size="extra-small"
+                  class="group/trash-button"
+                  @isDisabled={{eq optionIndex 0}}
+                  {{on "click" (fn this.moveOptionUp optionIndex)}}
+                  data-test-move-up-button
+                >
                   {{svg-jar "arrow-up" class="w-4 h-4 text-gray-600 group-hover/trash-button:text-teal-600"}}
                   <EmberTooltip @text="Move this option up" />
                 </TertiaryButton>
-                <TertiaryButton @size="extra-small" class="group/trash-button" {{on "click" (fn this.moveOptionDown optionIndex)}}data-test-move-down-button>
+                <TertiaryButton
+                  @size="extra-small"
+                  class="group/trash-button"
+                  {{on "click" (fn this.moveOptionDown optionIndex)}}
+                  data-test-move-down-button
+                >
                   {{svg-jar "arrow-down" class="w-4 h-4 text-gray-600 group-hover/trash-button:text-teal-600"}}
                   <EmberTooltip @text="Move this option down" />
                 </TertiaryButton>

--- a/app/components/concept-admin/questions-page/question-form.hbs
+++ b/app/components/concept-admin/questions-page/question-form.hbs
@@ -67,6 +67,7 @@
                 <TertiaryButton
                   @size="extra-small"
                   class="group/move-down-button"
+                  @isDisabled={{eq optionIndex (sub (length @question.options) 1)}}
                   {{on "click" (fn this.moveOptionDown optionIndex)}}
                   data-test-move-down-button
                 >

--- a/app/components/concept-admin/questions-page/question-form.ts
+++ b/app/components/concept-admin/questions-page/question-form.ts
@@ -1,7 +1,6 @@
 import Component from '@glimmer/component';
 import ConceptQuestionModel, { type Option } from 'codecrafters-frontend/models/concept-question';
 import { action } from '@ember/object';
-import { tracked } from '@glimmer/tracking';
 
 interface Signature {
   Element: HTMLDivElement;
@@ -12,7 +11,9 @@ interface Signature {
 }
 
 export default class QuestionFormComponent extends Component<Signature> {
-  @tracked options = this.args.question.options;
+  get options() {
+    return this.args.question.options;
+  }
 
   @action
   async handleCorrectOptionToggled(optionIndex: number) {
@@ -45,21 +46,25 @@ export default class QuestionFormComponent extends Component<Signature> {
 
   @action
   moveOptionDown(optionIndex: number) {
-    if (optionIndex < this.options.length - 1) {
-      let temp = this.options[optionIndex + 1];
-      this.options[optionIndex + 1] = this.options[optionIndex] as Option;
-      this.options[optionIndex] = temp as Option;
-      this.args.question.options = [...this.options];
+    let options = this.options.slice();
+
+    if (optionIndex < options.length - 1) {
+      const temp = options[optionIndex + 1];
+      options[optionIndex + 1] = options[optionIndex] as Option;
+      options[optionIndex] = temp as Option;
+      this.args.question.options = [...options];
     }
   }
 
   @action
   moveOptionUp(optionIndex: number) {
+    let options = this.options.slice();
+
     if (optionIndex > 0) {
-      let temp = this.options[optionIndex - 1];
-      this.options[optionIndex - 1] = this.options[optionIndex] as Option;
-      this.options[optionIndex] = temp as Option;
-      this.args.question.options = [...this.options];
+      const temp = options[optionIndex - 1];
+      options[optionIndex - 1] = options[optionIndex] as Option;
+      options[optionIndex] = temp as Option;
+      this.args.question.options = [...options];
     }
   }
 }

--- a/app/components/concept-admin/questions-page/question-form.ts
+++ b/app/components/concept-admin/questions-page/question-form.ts
@@ -1,6 +1,7 @@
 import Component from '@glimmer/component';
-import ConceptQuestionModel from 'codecrafters-frontend/models/concept-question';
+import ConceptQuestionModel, { type Option } from 'codecrafters-frontend/models/concept-question';
 import { action } from '@ember/object';
+import { tracked } from '@glimmer/tracking';
 
 interface Signature {
   Element: HTMLDivElement;
@@ -11,6 +12,8 @@ interface Signature {
 }
 
 export default class QuestionFormComponent extends Component<Signature> {
+  @tracked options = this.args.question.options;
+
   @action
   async handleCorrectOptionToggled(optionIndex: number) {
     const option = this.args.question.options[optionIndex]!;
@@ -38,6 +41,26 @@ export default class QuestionFormComponent extends Component<Signature> {
   @action
   async handleOptionDeleted(optionIndex: number) {
     this.args.question.options = this.args.question.options.filter((_, currentOptionIndex) => currentOptionIndex !== optionIndex);
+  }
+
+  @action
+  moveOptionDown(optionIndex: number) {
+    if (optionIndex < this.options.length - 1) {
+      let temp = this.options[optionIndex + 1];
+      this.options[optionIndex + 1] = this.options[optionIndex] as Option;
+      this.options[optionIndex] = temp as Option;
+      this.args.question.options = [...this.options];
+    }
+  }
+
+  @action
+  moveOptionUp(optionIndex: number) {
+    if (optionIndex > 0) {
+      let temp = this.options[optionIndex - 1];
+      this.options[optionIndex - 1] = this.options[optionIndex] as Option;
+      this.options[optionIndex] = temp as Option;
+      this.args.question.options = [...this.options];
+    }
   }
 }
 

--- a/app/components/concept-admin/questions-page/question-form.ts
+++ b/app/components/concept-admin/questions-page/question-form.ts
@@ -49,9 +49,7 @@ export default class QuestionFormComponent extends Component<Signature> {
     const options = this.options.slice();
 
     if (optionIndex < options.length - 1) {
-      const temp = options[optionIndex + 1];
-      options[optionIndex + 1] = options[optionIndex] as Option;
-      options[optionIndex] = temp as Option;
+      [options[optionIndex + 1], options[optionIndex]] = [options[optionIndex] as Option, options[optionIndex + 1] as Option];
       this.args.question.options = [...options];
     }
   }
@@ -61,9 +59,7 @@ export default class QuestionFormComponent extends Component<Signature> {
     const options = this.options.slice();
 
     if (optionIndex > 0) {
-      const temp = options[optionIndex - 1];
-      options[optionIndex - 1] = options[optionIndex] as Option;
-      options[optionIndex] = temp as Option;
+      [options[optionIndex - 1], options[optionIndex]] = [options[optionIndex] as Option, options[optionIndex - 1] as Option];
       this.args.question.options = [...options];
     }
   }

--- a/app/components/concept-admin/questions-page/question-form.ts
+++ b/app/components/concept-admin/questions-page/question-form.ts
@@ -46,7 +46,7 @@ export default class QuestionFormComponent extends Component<Signature> {
 
   @action
   moveOptionDown(optionIndex: number) {
-    let options = this.options.slice();
+    const options = this.options.slice();
 
     if (optionIndex < options.length - 1) {
       const temp = options[optionIndex + 1];
@@ -58,7 +58,7 @@ export default class QuestionFormComponent extends Component<Signature> {
 
   @action
   moveOptionUp(optionIndex: number) {
-    let options = this.options.slice();
+    const options = this.options.slice();
 
     if (optionIndex > 0) {
       const temp = options[optionIndex - 1];

--- a/app/components/concept-admin/questions-page/question-form.ts
+++ b/app/components/concept-admin/questions-page/question-form.ts
@@ -48,20 +48,24 @@ export default class QuestionFormComponent extends Component<Signature> {
   moveOptionDown(optionIndex: number) {
     const options = this.options.slice();
 
-    if (optionIndex < options.length - 1) {
-      [options[optionIndex + 1], options[optionIndex]] = [options[optionIndex] as Option, options[optionIndex + 1] as Option];
-      this.args.question.options = [...options];
+    if (optionIndex >= options.length - 1) {
+      return;
     }
+
+    [options[optionIndex + 1], options[optionIndex]] = [options[optionIndex] as Option, options[optionIndex + 1] as Option];
+    this.args.question.options = [...options];
   }
 
   @action
   moveOptionUp(optionIndex: number) {
     const options = this.options.slice();
 
-    if (optionIndex > 0) {
-      [options[optionIndex - 1], options[optionIndex]] = [options[optionIndex] as Option, options[optionIndex - 1] as Option];
-      this.args.question.options = [...options];
+    if (optionIndex <= 0) {
+      return;
     }
+
+    [options[optionIndex - 1], options[optionIndex]] = [options[optionIndex] as Option, options[optionIndex - 1] as Option];
+    this.args.question.options = [...options];
   }
 }
 

--- a/tests/acceptance/concept-admin/edit-questions-test.js
+++ b/tests/acceptance/concept-admin/edit-questions-test.js
@@ -91,4 +91,35 @@ module('Acceptance | concept-admin | edit-questions', function (hooks) {
 
     assert.strictEqual(question.options.length, 2);
   });
+
+  test('can move options up and down', async function (assert) {
+    testScenario(this.server);
+    signInAsStaff(this.owner, this.server);
+
+    const question = this.server.create('concept-question', {
+      concept: this.server.create('concept', { slug: 'dummy', blocks: [] }),
+      queryMarkdown: 'What is question?',
+      slug: 'question-slug',
+      options: [
+        { markdown: '42', is_correct: true, explanation_markdown: 'Explanation 1' },
+        { markdown: '24', isS_correct: false, explanation_markdown: 'Explanation 2' },
+      ],
+    });
+
+    await questionsPage.visit({ concept_slug: 'dummy' });
+    await questionsPage.clickOnQuestionCard('question-slug');
+
+    assert.strictEqual(question.options[0].markdown, '42');
+    assert.strictEqual(question.options[1].markdown, '24');
+
+    await questionPage.optionForms[1].clickOnMoveUpButton();
+    await questionPage.clickOnPublishChangesButton();
+
+    assert.strictEqual(question.options[0].markdown, '24');
+
+    await questionPage.optionForms[0].clickOnMoveDownButton();
+    await questionPage.clickOnPublishChangesButton();
+
+    assert.strictEqual(question.options[0].markdown, '42');
+  });
 });

--- a/tests/acceptance/concept-admin/edit-questions-test.js
+++ b/tests/acceptance/concept-admin/edit-questions-test.js
@@ -109,8 +109,12 @@ module('Acceptance | concept-admin | edit-questions', function (hooks) {
     await questionsPage.visit({ concept_slug: 'dummy' });
     await questionsPage.clickOnQuestionCard('question-slug');
 
-    assert.strictEqual(question.options[0].markdown, '42');
-    assert.strictEqual(question.options[1].markdown, '24');
+    assert.strictEqual(question.options[0].markdown, '42', 'markdown for the first option is correct');
+    assert.strictEqual(question.options[1].markdown, '24', 'markdown for the second option is correct');
+
+    await questionPage.optionForms[0].clickOnMoveUpButton();
+
+    assert.strictEqual(question.options[0].markdown, '42', 'clicking on move up button for the first option does not change the order');
 
     await questionPage.optionForms[1].clickOnMoveUpButton();
     await questionPage.clickOnPublishChangesButton();
@@ -121,5 +125,9 @@ module('Acceptance | concept-admin | edit-questions', function (hooks) {
     await questionPage.clickOnPublishChangesButton();
 
     assert.strictEqual(question.options[0].markdown, '42');
+
+    await questionPage.optionForms[1].clickOnMoveDownButton();
+
+    assert.strictEqual(question.options[1].markdown, '24', 'clicking on move down button for the last option does not change the order');
   });
 });

--- a/tests/pages/concept-admin/question-page.ts
+++ b/tests/pages/concept-admin/question-page.ts
@@ -8,8 +8,10 @@ export default create({
 
   optionForms: collection('[data-test-option-form]', {
     clickOnDeleteButton: clickable('[data-test-delete-button]'),
-    fillInMarkdown: fillable('#option_markdown'),
     clickOnIsCorrectToggle: clickable('[data-test-is-correct-toggle]'),
+    clickOnMoveDownButton: clickable('[data-test-move-down-button]'),
+    clickOnMoveUpButton: clickable('[data-test-move-up-button]'),
+    fillInMarkdown: fillable('#option_markdown'),
   }),
 
   visit: visitable('/concepts/:concept_slug/admin/questions/:question_slug'),

--- a/types/glint.d.ts
+++ b/types/glint.d.ts
@@ -21,6 +21,7 @@ declare module '@glint/environment-ember-loose/registry' {
     gte: HelperLike<{ Args: { Positional: [unknown, unknown] }; Return: boolean }>;
     'html-safe': HelperLike<{ Return: string; Args: { Positional: [string | undefined] } }>;
     join: HelperLike<{ Return: string; Args: { Positional: [string, string[]] } }>;
+    length: HelperLike<{ Return: number; Args: { Positional: [unknown[]] } }>;
     lt: HelperLike<{ Args: { Positional: [unknown, unknown] }; Return: boolean }>;
     mult: HelperLike<{ Args: { Positional: [number, number] }; Return: number }>;
     'on-click-outside': ModifierLike<{ Args: { Positional: [(event: MouseEvent) => void] } }>;

--- a/types/glint.d.ts
+++ b/types/glint.d.ts
@@ -21,7 +21,6 @@ declare module '@glint/environment-ember-loose/registry' {
     gte: HelperLike<{ Args: { Positional: [unknown, unknown] }; Return: boolean }>;
     'html-safe': HelperLike<{ Return: string; Args: { Positional: [string | undefined] } }>;
     join: HelperLike<{ Return: string; Args: { Positional: [string, string[]] } }>;
-    length: HelperLike<{ Return: number; Args: { Positional: [unknown[]] } }>;
     lt: HelperLike<{ Args: { Positional: [unknown, unknown] }; Return: boolean }>;
     mult: HelperLike<{ Args: { Positional: [number, number] }; Return: number }>;
     'on-click-outside': ModifierLike<{ Args: { Positional: [(event: MouseEvent) => void] } }>;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Added functionality to reorder options in question forms within the admin section using "Move Up" and "Move Down" buttons.

- **Tests**
	- Implemented tests to ensure the new reordering functionality works as expected in the admin question editing interface.

- **Documentation**
	- Updated component and test documentation to reflect new functionalities and interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->