### PR TITLE
don't allow copying comments button text

### DIFF
--- a/app/components/syntax-highlighted-diff/expandable-chunk.hbs
+++ b/app/components/syntax-highlighted-diff/expandable-chunk.hbs
@@ -29,6 +29,7 @@
         <div class="absolute right-2 -top-2 z-10">
           <SyntaxHighlightedDiff::ToggleCommentsButton
             @commentsAreExpanded={{line.commentsAreExpanded}}
+            class="select-none"
             {{on "click" (fn @handleToggleCommentsButtonClick line.number)}}
           />
         </div>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
	- Enhanced the user interface by making the toggle comments button non-selectable for improved usability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->