### PR TITLE
Convert footer component to TypeScript

### DIFF
--- a/app/components/footer.ts
+++ b/app/components/footer.ts
@@ -1,10 +1,20 @@
 import Component from '@glimmer/component';
 import image from '/assets/images/logo/logomark-color.svg';
 
+interface FooterLink {
+  text: string;
+  url: string;
+}
+
+interface FooterLinkGroup {
+  heading: string;
+  links: FooterLink[];
+}
+
 export default class FooterComponent extends Component {
   image = image;
 
-  get challengeLinkGroup() {
+  get challengeLinkGroup(): FooterLinkGroup {
     return {
       heading: 'Challenges',
       links: [
@@ -44,7 +54,7 @@ export default class FooterComponent extends Component {
     };
   }
 
-  get companyLinkGroup() {
+  get companyLinkGroup(): FooterLinkGroup {
     return {
       heading: 'Company',
       links: [
@@ -60,11 +70,11 @@ export default class FooterComponent extends Component {
     };
   }
 
-  get footerLinkGroups() {
+  get footerLinkGroups(): FooterLinkGroup[] {
     return [this.challengeLinkGroup, this.supportLinkGroup, this.companyLinkGroup, this.legalLinkGroup];
   }
 
-  get legalLinkGroup() {
+  get legalLinkGroup(): FooterLinkGroup {
     return {
       heading: 'Legal',
       links: [
@@ -80,7 +90,7 @@ export default class FooterComponent extends Component {
     };
   }
 
-  get supportLinkGroup() {
+  get supportLinkGroup(): FooterLinkGroup {
     return {
       heading: 'Support',
       links: [
@@ -94,5 +104,11 @@ export default class FooterComponent extends Component {
         },
       ],
     };
+  }
+}
+
+declare module '@glint/environment-ember-loose/registry' {
+  export default interface Registry {
+    Footer: typeof FooterComponent;
   }
 }


### PR DESCRIPTION
Converts the `app/components/footer.js` component to TypeScript, enhancing type safety and consistency with other components.

- **Type Definitions**: Introduces interfaces `FooterLink` and `FooterLinkGroup` to define the structure of links and link groups within the footer, ensuring that the data structure for links is consistently enforced.
- **Typed Methods**: Updates all getter methods (`challengeLinkGroup`, `companyLinkGroup`, `footerLinkGroups`, `legalLinkGroup`, `supportLinkGroup`) to return values typed according to the newly introduced interfaces, improving code readability and maintainability.
- **Module Declaration**: Adds a `declare module` block to register the `FooterComponent` with the Ember Glint environment, facilitating its usage within Ember templates.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/codecrafters-io/frontend?shareId=803952bb-ce87-42ee-b777-c3e0651b50e3).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced the footer with organized link groups for challenges, company information, legal details, and support, improving navigation and user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->