### PR TITLE
Revert "chore: Enable maintenance mode"

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -7,11 +7,6 @@
   ],
   "redirects": [
     {
-      "source": "/(.*)",
-      "destination": "https://codecrafters.io/heroku_pages/maintenance.html",
-      "permanent": false
-    },
-    {
       "source": "/r/famous-wombat-417894",
       "destination": "/join?via=gnomezgrave"
     },


### PR DESCRIPTION
Reverts codecrafters-io/frontend#1734

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Removed outdated redirect configuration for `heroku_pages/maintenance.html` in the deployment settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->