### PR TITLE
Refactor ActionButtonListComponent: Hide view screencasts button for first course stage

### DIFF
--- a/app/components/course-page/course-stage-step/your-task-card/action-button-list.ts
+++ b/app/components/course-page/course-stage-step/your-task-card/action-button-list.ts
@@ -31,6 +31,10 @@ export default class ActionButtonListComponent extends Component<Signature> {
   }
 
   get shouldShowViewScreencastsButton() {
+    if (this.args.courseStage.isFirst) {
+      return false; // Don't expose user to too many features at once
+    }
+
     return this.args.courseStage.hasScreencasts;
   }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Updated the "View Screencasts" button to be hidden on the first course stage, simplifying the user interface and preventing feature overload for new users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->