### PR TITLE
CC-1250 Add frontend tests for upvoting and downvoting code examples

### DIFF
--- a/app/components/course-page/course-stage-step/community-solution-card/downvote-button.hbs
+++ b/app/components/course-page/course-stage-step/community-solution-card/downvote-button.hbs
@@ -1,4 +1,4 @@
-<TertiaryButton @size="extra-small" {{on "click" this.handleClick}} ...attributes>
+<TertiaryButton @size="extra-small" {{on "click" this.handleClick}} ...attributes data-test-solution-card-downvote-button>
   {{svg-jar "thumb-down" class=(concat "w-4 " (if this.currentUserHasDownvoted "text-red-600" "text-gray-500"))}}
   <EmberTooltip
     @text={{if this.currentUserHasDownvoted "Downvoted! Thank you for submitting feedback." "Downvote this example and we'll show it less often."}}

--- a/app/components/course-page/course-stage-step/community-solution-card/upvote-button.hbs
+++ b/app/components/course-page/course-stage-step/community-solution-card/upvote-button.hbs
@@ -1,4 +1,4 @@
-<TertiaryButton @size="extra-small" {{on "click" this.handleClick}} ...attributes>
+<TertiaryButton @size="extra-small" {{on "click" this.handleClick}} ...attributes data-test-solution-card-upvote-button>
   {{svg-jar "thumb-up" class=(concat "w-4 " (if this.currentUserHasUpvoted "text-teal-600" "text-gray-500"))}}
   <EmberTooltip
     @text={{if this.currentUserHasUpvoted "Upvoted! Thank you for submitting feedback." "Upvote this example and we'll show it more often."}}

--- a/tests/acceptance/course-page/vote-for-code-example-test.js
+++ b/tests/acceptance/course-page/vote-for-code-example-test.js
@@ -1,0 +1,105 @@
+import catalogPage from 'codecrafters-frontend/tests/pages/catalog-page';
+import courseOverviewPage from 'codecrafters-frontend/tests/pages/course-overview-page';
+import coursePage from 'codecrafters-frontend/tests/pages/course-page';
+import createCommunityCourseStageSolution from 'codecrafters-frontend/mirage/utils/create-community-course-stage-solution';
+import testScenario from 'codecrafters-frontend/mirage/scenarios/test';
+import { assertTooltipContent } from 'ember-tooltips/test-support';
+import { setupApplicationTest } from 'codecrafters-frontend/tests/helpers';
+import { setupAnimationTest } from 'ember-animated/test-support';
+import { signIn } from 'codecrafters-frontend/tests/support/authentication-helpers';
+import { module, test } from 'qunit';
+
+module('Acceptance | course-page | vote-for-code-examples', function (hooks) {
+  setupApplicationTest(hooks);
+  setupAnimationTest(hooks);
+
+  test('can upvote code examples', async function (assert) {
+    testScenario(this.server);
+    signIn(this.owner, this.server);
+
+    let otherUserOne = this.server.create('user', {
+      avatarUrl: 'https://github.com/sarupbanskota.png',
+      createdAt: new Date(),
+      githubUsername: 'sarupbanskota',
+      username: 'sarupbanskota',
+    });
+
+    let otherUserTwo = this.server.create('user', {
+      avatarUrl: 'https://github.com/Gufran.png',
+      createdAt: new Date(),
+      githubUsername: 'gufran',
+      username: 'gufran',
+    });
+
+    let redis = this.server.schema.courses.findBy({ slug: 'redis' });
+    let go = this.server.schema.languages.findBy({ slug: 'go' });
+
+    let otherUserOneSolution = createCommunityCourseStageSolution(this.server, redis, 2, go);
+    otherUserOneSolution.update({ user: otherUserOne });
+    let otherUserTwoSolution = createCommunityCourseStageSolution(this.server, redis, 2, go);
+    otherUserTwoSolution.update({ user: otherUserTwo });
+
+    await catalogPage.visit();
+    await catalogPage.clickOnCourse('Build your own Redis');
+    await courseOverviewPage.clickOnStartCourse();
+    await coursePage.sidebar.clickOnStepListItem('Respond to PING');
+
+    await coursePage.yourTaskCard.clickOnActionButton('Code Examples');
+
+    await coursePage.codeExamplesTab.solutionCards[0].upvoteButton.hover();
+
+    assertTooltipContent(assert, {
+      contentString: "Upvote this example and we'll show it more often.",
+    });
+
+    await coursePage.codeExamplesTab.solutionCards[0].upvoteButton.click();
+
+    let upvote = this.server.schema.upvotes.all().models[0];
+    assert.strictEqual(upvote.targetId, otherUserOneSolution.id, 'clicking on upvote button creates an upvote model');
+  });
+
+  test('can downvote code examples', async function (assert) {
+    testScenario(this.server);
+    signIn(this.owner, this.server);
+
+    let otherUserOne = this.server.create('user', {
+      avatarUrl: 'https://github.com/sarupbanskota.png',
+      createdAt: new Date(),
+      githubUsername: 'sarupbanskota',
+      username: 'sarupbanskota',
+    });
+
+    let otherUserTwo = this.server.create('user', {
+      avatarUrl: 'https://github.com/Gufran.png',
+      createdAt: new Date(),
+      githubUsername: 'gufran',
+      username: 'gufran',
+    });
+
+    let redis = this.server.schema.courses.findBy({ slug: 'redis' });
+    let go = this.server.schema.languages.findBy({ slug: 'go' });
+
+    let otherUserOneSolution = createCommunityCourseStageSolution(this.server, redis, 2, go);
+    otherUserOneSolution.update({ user: otherUserOne });
+    let otherUserTwoSolution = createCommunityCourseStageSolution(this.server, redis, 2, go);
+    otherUserTwoSolution.update({ user: otherUserTwo });
+
+    await catalogPage.visit();
+    await catalogPage.clickOnCourse('Build your own Redis');
+    await courseOverviewPage.clickOnStartCourse();
+    await coursePage.sidebar.clickOnStepListItem('Respond to PING');
+
+    await coursePage.yourTaskCard.clickOnActionButton('Code Examples');
+
+    await coursePage.codeExamplesTab.solutionCards[0].downvoteButton.hover();
+
+    assertTooltipContent(assert, {
+      contentString: "Downvote this example and we'll show it less often.",
+    });
+
+    await coursePage.codeExamplesTab.solutionCards[0].downvoteButton.click();
+
+    let downvote = this.server.schema.downvotes.all().models[0];
+    assert.strictEqual(downvote.targetId, otherUserOneSolution.id, 'clicking on downvote button creates a downvote model');
+  });
+});

--- a/tests/pages/course-page.js
+++ b/tests/pages/course-page.js
@@ -56,9 +56,20 @@ export default create({
       },
 
       clickOnExpandButton: clickable('[data-test-expand-button]'),
-      collapseButtons: collection('[data-test-collapse-button]'),
-      toggleCommentsButtons: collection('[data-test-toggle-comments-button]'),
       commentCards: collection('[data-test-comment-card]', CommentCard),
+      collapseButtons: collection('[data-test-collapse-button]'),
+
+      downvoteButton: {
+        hover: triggerable('mouseenter'),
+        scope: '[data-test-solution-card-downvote-button]',
+      },
+
+      toggleCommentsButtons: collection('[data-test-toggle-comments-button]'),
+
+      upvoteButton: {
+        hover: triggerable('mouseenter'),
+        scope: '[data-test-solution-card-upvote-button]',
+      },
     }),
 
     scope: '[data-test-code-examples-tab]',


### PR DESCRIPTION
**Checklist**:

- [x] I've thoroughly self-reviewed my changes
- [x] I've added tests for my changes, unless they affect admin-only areas (or are otherwise not worth testing)
- [ ] I've verified any visual changes using Percy (add a commit with `[percy]` in the message to trigger)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added upvote and downvote buttons to community solution cards on course pages.

- **Tests**
	- Introduced tests for upvoting and downvoting code examples on course pages.
	- Added new elements for interaction testing of voting buttons.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->