### PR TITLE
Refactor course leaderboard entries handler into separate file

### DIFF
--- a/mirage/config.js
+++ b/mirage/config.js
@@ -5,6 +5,7 @@ import config from 'codecrafters-frontend/config/environment';
 import syncRepositoryStageLists from './utils/sync-repository-stage-lists';
 
 import users from './handlers/users';
+import courseLeaderboardEntries from './handlers/course-leaderboard-entries';
 
 export default function (config) {
   let finalConfig = {
@@ -70,6 +71,7 @@ function routes() {
   window.server = this; // Hack! Is there a better way?
 
   users(this);
+  courseLeaderboardEntries(this);
 
   // TODO: Move everything else to separate 'handler' files too
 
@@ -374,24 +376,6 @@ function routes() {
   this.get('/course-language-requests');
   this.post('/course-language-requests');
   this.delete('/course-language-requests/:id');
-
-  this.get('/course-leaderboard-entries', function (schema, request) {
-    let result = schema.courseLeaderboardEntries.all();
-
-    if (request.queryParams.team_id) {
-      const team = schema.teams.find(request.queryParams.team_id);
-      const teamMemberships = schema.teamMemberships.where({ teamId: team.id }).models;
-      const userIds = teamMemberships.map((teamMembership) => teamMembership.user.id);
-
-      result = result.filter((leaderboardEntry) => userIds.includes(leaderboardEntry.user.id));
-    }
-
-    if (request.queryParams.course_id) {
-      result = result.filter((leaderboardEntry) => leaderboardEntry.currentCourseStage.course.id === request.queryParams.course_id);
-    }
-
-    return result;
-  });
 
   this.get('/course-stage-comments', function (schema, request) {
     let result = schema.courseStageComments.all().filter((comment) => comment.targetId.toString() === request.queryParams.target_id);

--- a/mirage/handlers/course-leaderboard-entries.js
+++ b/mirage/handlers/course-leaderboard-entries.js
@@ -1,0 +1,19 @@
+export default function (server) {
+  server.get('/course-leaderboard-entries', function (schema, request) {
+    let result = schema.courseLeaderboardEntries.all();
+
+    if (request.queryParams.team_id) {
+      const team = schema.teams.find(request.queryParams.team_id);
+      const teamMemberships = schema.teamMemberships.where({ teamId: team.id }).models;
+      const userIds = teamMemberships.map((teamMembership) => teamMembership.user.id);
+
+      result = result.filter((leaderboardEntry) => userIds.includes(leaderboardEntry.user.id));
+    }
+
+    if (request.queryParams.course_id) {
+      result = result.filter((leaderboardEntry) => leaderboardEntry.currentCourseStage.course.id === request.queryParams.course_id);
+    }
+
+    return result;
+  });
+}


### PR DESCRIPTION
Moves the "course-leaderboard-entries" handler from `mirage/config.js` to a new separate file `mirage/handlers/course-leaderboard-entries.js` and updates `mirage/config.js` to use the new handler.

- **Extracts and relocates handler**: Moves the handling logic for "course-leaderboard-entries" from `mirage/config.js` into `mirage/handlers/course-leaderboard-entries.js`, making the codebase more modular.
- **Updates `mirage/config.js`**: Removes the inline definition of the "course-leaderboard-entries" handler from `mirage/config.js` and imports the handler from its new location, maintaining the functionality while improving code organization.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/codecrafters-io/frontend?shareId=bc997998-17da-465f-acce-cf8114085ce3).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced leaderboard functionality for courses, allowing users to view and filter leaderboard entries by team and course.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->