### PR TITLE
Don't run sentry/codecov in vercel build

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -124,3 +124,20 @@ jobs:
       - run: npm ci --prefer-offline --ignore-scripts --no-audit --no-fund
       - run: npm run tailwind:build
       - run: npm run lint
+
+  build_production_bundle:
+    runs-on: depot-ubuntu-22.04-16
+
+    if: "github.ref == 'refs/heads/main'"
+
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: '18'
+          cache: 'npm'
+      - run: npm ci --prefer-offline --ignore-scripts --no-audit --no-fund
+      - run: npm run build
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -8,7 +8,9 @@ const { Webpack } = require('@embroider/webpack');
 const { BundleAnalyzerPlugin } = require('webpack-bundle-analyzer');
 const { codecovWebpackPlugin } = require('@codecov/webpack-plugin');
 const { sentryWebpackPlugin } = require('@sentry/webpack-plugin');
+
 const shouldSpawnBundleAnalyzer = process.env.ANALYZE_BUNDLE === 'true';
+const shouldUploadSentrySourcemaps = !!process.env.CI;
 
 const fetch = require('node-fetch');
 const customFilePlugin = require('./lib/custom-file-plugin');
@@ -103,14 +105,16 @@ module.exports = function (defaults) {
             uploadToken: process.env.CODECOV_TOKEN,
           }),
 
-          sentryWebpackPlugin({
-            org: 'codecrafters',
-            project: 'frontend',
-            authToken: process.env.CI ? process.env.SENTRY_AUTH_TOKEN : undefined,
-            release: {
-              name: config.x.version,
-            },
-          }),
+          shouldUploadSentrySourcemaps
+            ? sentryWebpackPlugin({
+                org: 'codecrafters',
+                project: 'frontend',
+                authToken: process.env.SENTRY_AUTH_TOKEN,
+                release: {
+                  name: config.x.version,
+                },
+              })
+            : null,
 
           shouldSpawnBundleAnalyzer ? new BundleAnalyzerPlugin() : null,
         ],

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -10,7 +10,7 @@ const { codecovWebpackPlugin } = require('@codecov/webpack-plugin');
 const { sentryWebpackPlugin } = require('@sentry/webpack-plugin');
 
 const shouldSpawnBundleAnalyzer = process.env.ANALYZE_BUNDLE === 'true';
-const shouldUploadSentrySourcemaps = !!process.env.CI;
+const shouldUploadSentrySourcemaps = !!process.env.CI && !process.env.VERCEL;
 
 const fetch = require('node-fetch');
 const customFilePlugin = require('./lib/custom-file-plugin');

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -104,9 +104,9 @@ module.exports = function (defaults) {
           }),
 
           sentryWebpackPlugin({
-            org: process.env.SENTRY_ORG,
-            project: process.env.SENTRY_PROJECT,
-            authToken: process.env.SENTRY_AUTH_TOKEN,
+            org: 'codecrafters',
+            project: 'frontend',
+            authToken: process.env.CI ? process.env.SENTRY_AUTH_TOKEN : undefined,
             release: {
               name: config.x.version,
             },


### PR DESCRIPTION
- Add accuracy section and recent evaluations section to code example evaluator page.
- Add generic statistic component to accuracy section in code example evaluator page.
- failing test
- Add trusted evaluation functionality to code example evaluator.
- Fix trusted evaluation selection bug and add view for existing trusted evaluation.
- Refactor code example evaluator page components and models
- Add "Trusted Evaluation" tab to EvaluationCard component.
- Refactor AccuracySection in code-example-evaluator-page and add limit to CodeExampleEvaluatorRoute
- Refactor trusted evaluation tab in code example page and update tests
- Add copy to clipboard functionality and handle button click in evaluation-tab component.
- Refactor import statement in evaluation-card.ts
- Refactor evaluation-tab component and add regeneration functionality
- Update evaluation sorting and display in code example evaluator page and evaluation card components.
- Update Sentry configuration in ember-cli-build.js for the frontend project in the codecrafters organization. Use process.env.CI to conditionally set the authToken based on the environment.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Added a new job `build_production_bundle` to the workflow for building the project on the `main` branch.
  
- **Configuration Updates**
  - Updated `sentryWebpackPlugin` configuration for better integration with Sentry, including conditional assignment of `SENTRY_AUTH_TOKEN` based on the `CI` environment variable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->