### PR TITLE
CC-1265 Add code example confirmation modal

### DIFF
--- a/app/components/course-page/course-stage-step/community-solutions-list.hbs
+++ b/app/components/course-page/course-stage-step/community-solutions-list.hbs
@@ -1,15 +1,55 @@
-{{#each @solutions as |solution solutionIndex|}}
-  <CoursePage::CourseStageStep::CommunitySolutionCard
-    @isCollapsedByDefault={{gt solutionIndex 0}}
-    @metadataForDownvote={{hash position_in_list=(add solutionIndex 1)}}
-    @metadataForUpvote={{hash position_in_list=(add solutionIndex 1)}}
-    @onExpand={{fn this.handleSolutionExpand solution solutionIndex}}
-    @onPublishToGithubButtonClick={{fn (mut this.configureGithubIntegrationModalIsOpen) true}}
-    @solution={{solution}}
-    {{! account for the sticky menu bar }}
-    class="scroll-mt-16"
-  />
-{{/each}}
+<BlurredOverlay @isBlurred={{this.shouldShowStageIncompleteModal}} class="px-3 md:px-6 lg:px-10">
+  <:content>
+    {{#each @solutions as |solution solutionIndex|}}
+      <CoursePage::CourseStageStep::CommunitySolutionCard
+        @isCollapsedByDefault={{gt solutionIndex 0}}
+        @metadataForDownvote={{hash position_in_list=(add solutionIndex 1)}}
+        @metadataForUpvote={{hash position_in_list=(add solutionIndex 1)}}
+        @onExpand={{fn this.handleSolutionExpand solution solutionIndex}}
+        @onPublishToGithubButtonClick={{fn (mut this.configureGithubIntegrationModalIsOpen) true}}
+        @solution={{solution}}
+        {{! account for the sticky menu bar }}
+        class="scroll-mt-16"
+      />
+    {{/each}}
+  </:content>
+  <:overlay>
+    <ModalBody @allowManualClose={{false}} @onClose={{this.handleStageIncompleteModalDismissed}} class="w-full mt-8 border mx-3 md:mx-6">
+      <div class="mb-4 font-semibold text-2xl text-gray-600 mr-6">
+        Stage incomplete
+      </div>
+
+      <div class="prose mb-6">
+        <p>
+          You haven't completed this stage yet. Are you sure you want to view code examples?
+        </p>
+      </div>
+
+      <div class="flex items-center gap-x-6 gap-y-4 flex-wrap">
+        <PrimaryLinkButton
+          @route={{this.coursePageState.activeStep.routeParams.route}}
+          @models={{this.coursePageState.activeStep.routeParams.models}}
+          data-test-instructions-button
+          class="flex-shrink-0"
+        >
+          <div class="flex items-center">
+            {{svg-jar "arrow-left" class="w-4 mr-1 fill-current flex-shrink-0"}}
+            <span>No, back to instructions</span>
+          </div>
+        </PrimaryLinkButton>
+
+        <div
+          class="text-gray-500 hover:text-gray-800 text-sm pb-0.25 border-b border-gray-400 hover:border-gray-600 flex-shrink-0"
+          role="button"
+          {{on "click" this.handleStageIncompleteModalDismissed}}
+          data-test-show-code-button
+        >
+          Yes, show me the code 👀
+        </div>
+      </div>
+    </ModalBody>
+  </:overlay>
+</BlurredOverlay>
 
 {{#if this.configureGithubIntegrationModalIsOpen}}
   <ModalBackdrop>

--- a/app/components/course-page/course-stage-step/community-solutions-list.hbs
+++ b/app/components/course-page/course-stage-step/community-solutions-list.hbs
@@ -14,7 +14,12 @@
     {{/each}}
   </:content>
   <:overlay>
-    <ModalBody @allowManualClose={{false}} @onClose={{@handleStageIncompleteModalDismissed}} class="w-full mt-8 border mx-3 md:mx-6" data-test-stage-incomplete-modal>
+    <ModalBody
+      @allowManualClose={{false}}
+      @onClose={{@handleStageIncompleteModalDismissed}}
+      class="w-full mt-8 border mx-3 md:mx-6"
+      data-test-stage-incomplete-modal
+    >
       <div class="mb-4 font-semibold text-2xl text-gray-600 mr-6">
         Stage incomplete
       </div>

--- a/app/components/course-page/course-stage-step/community-solutions-list.hbs
+++ b/app/components/course-page/course-stage-step/community-solutions-list.hbs
@@ -14,7 +14,7 @@
     {{/each}}
   </:content>
   <:overlay>
-    <ModalBody @allowManualClose={{false}} @onClose={{this.handleStageIncompleteModalDismissed}} class="w-full mt-8 border mx-3 md:mx-6">
+    <ModalBody @allowManualClose={{false}} @onClose={{@handleStageIncompleteModalDismissed}} class="w-full mt-8 border mx-3 md:mx-6" data-test-stage-incomplete-modal>
       <div class="mb-4 font-semibold text-2xl text-gray-600 mr-6">
         Stage incomplete
       </div>
@@ -41,7 +41,7 @@
         <div
           class="text-gray-500 hover:text-gray-800 text-sm pb-0.25 border-b border-gray-400 hover:border-gray-600 flex-shrink-0"
           role="button"
-          {{on "click" this.handleStageIncompleteModalDismissed}}
+          {{on "click" @handleStageIncompleteModalDismissed}}
           data-test-show-code-button
         >
           Yes, show me the code 👀

--- a/app/components/course-page/course-stage-step/community-solutions-list.hbs
+++ b/app/components/course-page/course-stage-step/community-solutions-list.hbs
@@ -16,7 +16,7 @@
   <:overlay>
     <ModalBody
       @allowManualClose={{false}}
-      @onClose={{@handleStageIncompleteModalDismissed}}
+      @onClose={{fn (mut @stageIncompleteModalWasDismissed) true}}
       class="w-full mt-8 border mx-3 md:mx-6"
       data-test-stage-incomplete-modal
     >
@@ -46,7 +46,7 @@
         <div
           class="text-gray-500 hover:text-gray-800 text-sm pb-0.25 border-b border-gray-400 hover:border-gray-600 flex-shrink-0"
           role="button"
-          {{on "click" @handleStageIncompleteModalDismissed}}
+          {{on "click" (fn (mut @stageIncompleteModalWasDismissed) true)}}
           data-test-show-code-button
         >
           Yes, show me the code 👀

--- a/app/components/course-page/course-stage-step/community-solutions-list.ts
+++ b/app/components/course-page/course-stage-step/community-solutions-list.ts
@@ -11,7 +11,6 @@ type Signature = {
   Element: HTMLDivElement;
 
   Args: {
-    handleStageIncompleteModalDismissed: () => void;
     solutions: CommunityCourseStageSolutionModel[];
     stageIncompleteModalWasDismissed: boolean;
     repository: string;

--- a/app/components/course-page/course-stage-step/community-solutions-list.ts
+++ b/app/components/course-page/course-stage-step/community-solutions-list.ts
@@ -1,10 +1,11 @@
-import rippleSpinnerImage from '/assets/images/icons/ripple-spinner.svg';
 import Component from '@glimmer/component';
-import { tracked } from '@glimmer/tracking';
+import rippleSpinnerImage from '/assets/images/icons/ripple-spinner.svg';
 import { action } from '@ember/object';
 import { service } from '@ember/service';
-import type CommunityCourseStageSolutionModel from 'codecrafters-frontend/models/community-course-stage-solution';
+import { tracked } from '@glimmer/tracking';
 import type AuthenticatorService from 'codecrafters-frontend/services/authenticator';
+import type CommunityCourseStageSolutionModel from 'codecrafters-frontend/models/community-course-stage-solution';
+import type CoursePageStateService from 'codecrafters-frontend/services/course-page-state';
 
 type Signature = {
   Element: HTMLDivElement;
@@ -19,13 +20,25 @@ export default class CommunitySolutionsListComponent extends Component<Signature
   rippleSpinnerImage = rippleSpinnerImage;
 
   @service declare authenticator: AuthenticatorService;
+  @service declare coursePageState: CoursePageStateService;
 
   @tracked configureGithubIntegrationModalIsOpen = false;
+  @tracked stageIncompleteModalWasDismissed = false;
 
   @action
   handleSolutionExpand(solution: CommunityCourseStageSolutionModel, solutionIndex: number) {
     if (this.authenticator.isAuthenticated) {
       solution.createView({ position_in_list: solutionIndex + 1 });
     }
+  }
+
+  @action
+  handleStageIncompleteModalDismissed() {
+    this.stageIncompleteModalWasDismissed = true;
+  }
+
+  get shouldShowStageIncompleteModal() {
+    console.log(this.coursePageState.currentStep.globalPosition);
+    return !this.stageIncompleteModalWasDismissed && this.coursePageState.currentStep.globalPosition > 4 && this.args.solutions.length > 0;
   }
 }

--- a/app/components/course-page/course-stage-step/community-solutions-list.ts
+++ b/app/components/course-page/course-stage-step/community-solutions-list.ts
@@ -11,7 +11,9 @@ type Signature = {
   Element: HTMLDivElement;
 
   Args: {
+    handleStageIncompleteModalDismissed: () => void;
     solutions: CommunityCourseStageSolutionModel[];
+    stageIncompleteModalWasDismissed: boolean;
     repository: string;
   };
 };
@@ -23,7 +25,6 @@ export default class CommunitySolutionsListComponent extends Component<Signature
   @service declare coursePageState: CoursePageStateService;
 
   @tracked configureGithubIntegrationModalIsOpen = false;
-  @tracked stageIncompleteModalWasDismissed = false;
 
   @action
   handleSolutionExpand(solution: CommunityCourseStageSolutionModel, solutionIndex: number) {
@@ -32,13 +33,7 @@ export default class CommunitySolutionsListComponent extends Component<Signature
     }
   }
 
-  @action
-  handleStageIncompleteModalDismissed() {
-    this.stageIncompleteModalWasDismissed = true;
-  }
-
   get shouldShowStageIncompleteModal() {
-    console.log(this.coursePageState.currentStep.globalPosition);
-    return !this.stageIncompleteModalWasDismissed && this.coursePageState.currentStep.globalPosition > 4 && this.args.solutions.length > 0;
+    return !this.args.stageIncompleteModalWasDismissed && this.coursePageState.currentStep.globalPosition > 4 && this.args.solutions.length > 0 && this.coursePageState.currentStep.status !== 'complete';
   }
 }

--- a/app/components/course-page/course-stage-step/community-solutions-list.ts
+++ b/app/components/course-page/course-stage-step/community-solutions-list.ts
@@ -26,14 +26,19 @@ export default class CommunitySolutionsListComponent extends Component<Signature
 
   @tracked configureGithubIntegrationModalIsOpen = false;
 
+  get shouldShowStageIncompleteModal() {
+    return (
+      !this.args.stageIncompleteModalWasDismissed &&
+      this.coursePageState.currentStep.globalPosition > 4 &&
+      this.args.solutions.length > 0 &&
+      this.coursePageState.currentStep.status !== 'complete'
+    );
+  }
+
   @action
   handleSolutionExpand(solution: CommunityCourseStageSolutionModel, solutionIndex: number) {
     if (this.authenticator.isAuthenticated) {
       solution.createView({ position_in_list: solutionIndex + 1 });
     }
-  }
-
-  get shouldShowStageIncompleteModal() {
-    return !this.args.stageIncompleteModalWasDismissed && this.coursePageState.currentStep.globalPosition > 4 && this.args.solutions.length > 0 && this.coursePageState.currentStep.status !== 'complete';
   }
 }

--- a/app/components/course-page/course-stage-step/community-solutions-list.ts
+++ b/app/components/course-page/course-stage-step/community-solutions-list.ts
@@ -6,6 +6,7 @@ import { tracked } from '@glimmer/tracking';
 import type AuthenticatorService from 'codecrafters-frontend/services/authenticator';
 import type CommunityCourseStageSolutionModel from 'codecrafters-frontend/models/community-course-stage-solution';
 import type CoursePageStateService from 'codecrafters-frontend/services/course-page-state';
+import type RepositoryModel from 'codecrafters-frontend/models/repository';
 
 type Signature = {
   Element: HTMLDivElement;
@@ -13,7 +14,7 @@ type Signature = {
   Args: {
     solutions: CommunityCourseStageSolutionModel[];
     stageIncompleteModalWasDismissed: boolean;
-    repository: string;
+    repository: RepositoryModel;
   };
 };
 
@@ -39,5 +40,11 @@ export default class CommunitySolutionsListComponent extends Component<Signature
     if (this.authenticator.isAuthenticated) {
       solution.createView({ position_in_list: solutionIndex + 1 });
     }
+  }
+}
+
+declare module '@glint/environment-ember-loose/registry' {
+  export default interface Registry {
+    'CoursePage::CourseStageStep::CommunitySolutionsList': typeof CommunitySolutionsListComponent;
   }
 }

--- a/app/components/course-page/course-stage-step/community-solutions-list.ts
+++ b/app/components/course-page/course-stage-step/community-solutions-list.ts
@@ -1,4 +1,5 @@
 import Component from '@glimmer/component';
+import CourseStageStep from 'codecrafters-frontend/utils/course-page-step-list/course-stage-step';
 import rippleSpinnerImage from '/assets/images/icons/ripple-spinner.svg';
 import { action } from '@ember/object';
 import { service } from '@ember/service';
@@ -29,7 +30,9 @@ export default class CommunitySolutionsListComponent extends Component<Signature
   get shouldShowStageIncompleteModal() {
     return (
       !this.args.stageIncompleteModalWasDismissed &&
-      this.coursePageState.currentStep.globalPosition > 4 &&
+      this.coursePageState.currentStep.type === 'CourseStageStep' &&
+      !(this.coursePageState.currentStep as CourseStageStep).courseStage.isFirst &&
+      !(this.coursePageState.currentStep as CourseStageStep).courseStage.isSecond &&
       this.args.solutions.length > 0 &&
       this.coursePageState.currentStep.status !== 'complete'
     );

--- a/app/controllers/course/stage/code-examples.ts
+++ b/app/controllers/course/stage/code-examples.ts
@@ -20,8 +20,9 @@ export default class CodeExamplesController extends Controller {
   rippleSpinnerImage = rippleSpinnerImage;
   @tracked order: 'recommended' | 'recent' | 'affiliated' = 'recommended';
   @tracked isLoading = true;
-  @tracked solutions: CommunityCourseStageSolutionModel[] = [];
   @tracked requestedLanguage: LanguageModel | null = null; // This shouldn't be state on the controller, see if we can move it to a query param or so?
+  @tracked solutions: CommunityCourseStageSolutionModel[] = [];
+  @tracked stageIncompleteModalWasDismissed = false;
 
   get communitySolutionsAreAvailableForCurrentLanguage() {
     return this.currentLanguage && this.courseStage.hasCommunitySolutionsForLanguage(this.currentLanguage);
@@ -86,6 +87,11 @@ export default class CodeExamplesController extends Controller {
     }
 
     this.loadSolutions();
+  }
+
+  @action
+  handleStageIncompleteModalDismissed() {
+    this.stageIncompleteModalWasDismissed = true;
   }
 
   @action

--- a/app/controllers/course/stage/code-examples.ts
+++ b/app/controllers/course/stage/code-examples.ts
@@ -90,11 +90,6 @@ export default class CodeExamplesController extends Controller {
   }
 
   @action
-  handleStageIncompleteModalDismissed() {
-    this.stageIncompleteModalWasDismissed = true;
-  }
-
-  @action
   async loadSolutions() {
     if (!this.currentLanguage) {
       return;

--- a/app/templates/course/stage/code-examples.hbs
+++ b/app/templates/course/stage/code-examples.hbs
@@ -58,7 +58,7 @@
       </div>
     {{else if (gt this.sortedSolutions.length 0)}}
       {{! @glint-expect-error: not ts-ified yet }}
-      <CoursePage::CourseStageStep::CommunitySolutionsList @solutions={{this.sortedSolutions}} @repository={{@model.activeRepository}} />
+      <CoursePage::CourseStageStep::CommunitySolutionsList @solutions={{this.sortedSolutions}} @repository={{@model.activeRepository}} @stageIncompleteModalWasDismissed={{this.stageIncompleteModalWasDismissed}} @handleStageIncompleteModalDismissed={{this.handleStageIncompleteModalDismissed}} />
     {{else}}
       <div class="flex py-16 justify-center items-center w-full">
         <div class="text-sm text-gray-500 text-center max-w-lg">

--- a/app/templates/course/stage/code-examples.hbs
+++ b/app/templates/course/stage/code-examples.hbs
@@ -1,4 +1,11 @@
-<div class="pt-8 pb-32" {{did-update this.loadSolutions this.courseStage}} {{did-insert this.loadSolutions}} data-test-code-examples-tab>
+<div
+  class="pt-8 pb-32"
+  {{did-update (fn (mut this.stageIncompleteModalWasDismissed) false) this.courseStage}}
+  {{did-update this.loadSolutions this.courseStage}}
+  {{did-insert this.loadSolutions}}
+  {{will-destroy (fn (mut this.stageIncompleteModalWasDismissed) false) this.courseStage}}
+  data-test-code-examples-tab
+>
   <div class="flex items-center justify-between mb-4 pb-2 border-b">
     <div class="flex items-center gap-x-3 gap-y-2 flex-wrap">
       <h2 class="font-semibold text-lg">Code Examples using {{this.currentLanguage.name}}</h2>
@@ -62,7 +69,6 @@
         @solutions={{this.sortedSolutions}}
         @repository={{@model.activeRepository}}
         @stageIncompleteModalWasDismissed={{this.stageIncompleteModalWasDismissed}}
-        @handleStageIncompleteModalDismissed={{this.handleStageIncompleteModalDismissed}}
       />
     {{else}}
       <div class="flex py-16 justify-center items-center w-full">

--- a/app/templates/course/stage/code-examples.hbs
+++ b/app/templates/course/stage/code-examples.hbs
@@ -3,7 +3,7 @@
   {{did-update (fn (mut this.stageIncompleteModalWasDismissed) false) this.courseStage}}
   {{did-update this.loadSolutions this.courseStage}}
   {{did-insert this.loadSolutions}}
-  {{will-destroy (fn (mut this.stageIncompleteModalWasDismissed) false) this.courseStage}}
+  {{will-destroy (fn (mut this.stageIncompleteModalWasDismissed) false)}}
   data-test-code-examples-tab
 >
   <div class="flex items-center justify-between mb-4 pb-2 border-b">

--- a/app/templates/course/stage/code-examples.hbs
+++ b/app/templates/course/stage/code-examples.hbs
@@ -64,7 +64,6 @@
         <span class="ml-3 text-gray-700">Loading...</span>
       </div>
     {{else if (gt this.sortedSolutions.length 0)}}
-      {{! @glint-expect-error: not ts-ified yet }}
       <CoursePage::CourseStageStep::CommunitySolutionsList
         @solutions={{this.sortedSolutions}}
         @repository={{@model.activeRepository}}

--- a/app/templates/course/stage/code-examples.hbs
+++ b/app/templates/course/stage/code-examples.hbs
@@ -58,7 +58,12 @@
       </div>
     {{else if (gt this.sortedSolutions.length 0)}}
       {{! @glint-expect-error: not ts-ified yet }}
-      <CoursePage::CourseStageStep::CommunitySolutionsList @solutions={{this.sortedSolutions}} @repository={{@model.activeRepository}} @stageIncompleteModalWasDismissed={{this.stageIncompleteModalWasDismissed}} @handleStageIncompleteModalDismissed={{this.handleStageIncompleteModalDismissed}} />
+      <CoursePage::CourseStageStep::CommunitySolutionsList
+        @solutions={{this.sortedSolutions}}
+        @repository={{@model.activeRepository}}
+        @stageIncompleteModalWasDismissed={{this.stageIncompleteModalWasDismissed}}
+        @handleStageIncompleteModalDismissed={{this.handleStageIncompleteModalDismissed}}
+      />
     {{else}}
       <div class="flex py-16 justify-center items-center w-full">
         <div class="text-sm text-gray-500 text-center max-w-lg">

--- a/tests/acceptance/course-page/view-code-examples-test.js
+++ b/tests/acceptance/course-page/view-code-examples-test.js
@@ -10,11 +10,11 @@ import { signIn } from 'codecrafters-frontend/tests/support/authentication-helpe
 import { animationsSettled, setupAnimationTest } from 'ember-animated/test-support';
 import { module, test } from 'qunit';
 
-module('Acceptance | course-page | view-code-examples', function (hooks) {
+module('Acceptance | course-page | view-code-examples', function(hooks) {
   setupApplicationTest(hooks);
   setupAnimationTest(hooks);
 
-  test('can view solutions before starting course', async function (assert) {
+  test('can view solutions before starting course', async function(assert) {
     testScenario(this.server);
     signIn(this.owner, this.server);
 
@@ -69,7 +69,7 @@ module('Acceptance | course-page | view-code-examples', function (hooks) {
     assert.strictEqual(coursePage.codeExamplesTab.solutionCards.length, 0, 'expected no C solutions to be present');
   });
 
-  test('can view solutions after starting course', async function (assert) {
+  test('can view solutions after starting course', async function(assert) {
     testScenario(this.server);
     signIn(this.owner, this.server);
 
@@ -125,7 +125,7 @@ module('Acceptance | course-page | view-code-examples', function (hooks) {
     assert.strictEqual(coursePage.codeExamplesTab.solutionCards.length, 1, 'Solutions are visible');
   });
 
-  test('can view team-restricted solutions', async function (assert) {
+  test('can view team-restricted solutions', async function(assert) {
     testScenario(this.server);
 
     const currentUser = this.server.create('user', {
@@ -168,5 +168,266 @@ module('Acceptance | course-page | view-code-examples', function (hooks) {
 
     await coursePage.yourTaskCard.clickOnActionButton('Code Examples');
     assert.strictEqual(coursePage.codeExamplesTab.solutionCards.length, 2);
+  });
+
+  test('stage incomplete modal shows up when code examples are viewed before completing a stage', async function(assert) {
+    testScenario(this.server);
+    signIn(this.owner, this.server);
+
+    let currentUser = this.server.schema.users.first();
+
+    let redis = this.server.schema.courses.findBy({ slug: 'redis' });
+    let python = this.server.schema.languages.findBy({ slug: 'python' });
+
+    createCommunityCourseStageSolution(this.server, redis, 2, python);
+    createCommunityCourseStageSolution(this.server, redis, 3, python);
+
+    let pythonRepository = this.server.create('repository', 'withFirstStageCompleted', {
+      course: redis,
+      language: python,
+      name: 'Python #1',
+      user: currentUser,
+    });
+
+    this.server.create('course-stage-completion', {
+      repository: pythonRepository,
+      courseStage: redis.stages.models.sortBy('position').toArray()[1],
+      completedAt: new Date(new Date().getTime() - 5 * 86400000), // 5 days ago
+    });
+
+    this.server.create('submission', 'withStageCompletion', {
+      repository: pythonRepository,
+      courseStage: redis.stages.models.sortBy('position')[1],
+    });
+
+    await catalogPage.visit();
+    await catalogPage.clickOnCourse('Build your own Redis');
+    await coursePage.yourTaskCard.clickOnActionButton('Code Examples');
+
+    assert.ok(coursePage.codeExamplesTab.stageIncompleteModal.isVisible, 'stage incomplete modal is visible');
+  });
+
+  test('stage incomplete modal does not show up on stage two even if stage is not completed', async function(assert) {
+    testScenario(this.server);
+    signIn(this.owner, this.server);
+
+    let currentUser = this.server.schema.users.first();
+
+    let redis = this.server.schema.courses.findBy({ slug: 'redis' });
+    let python = this.server.schema.languages.findBy({ slug: 'python' });
+
+    createCommunityCourseStageSolution(this.server, redis, 2, python);
+
+    let pythonRepository = this.server.create('repository', 'withFirstStageCompleted', {
+      course: redis,
+      language: python,
+      name: 'Python #1',
+      user: currentUser,
+    });
+
+    await catalogPage.visit();
+    await catalogPage.clickOnCourse('Build your own Redis');
+    await coursePage.yourTaskCard.clickOnActionButton('Code Examples');
+
+    assert.notOk(coursePage.codeExamplesTab.stageIncompleteModal.isVisible, 'stage incomplete modal is not visible');
+  });
+
+  test('stage incomplete model does not show up if stage is completed', async function(assert) {
+    testScenario(this.server);
+    signIn(this.owner, this.server);
+
+    let currentUser = this.server.schema.users.first();
+
+    let redis = this.server.schema.courses.findBy({ slug: 'redis' });
+    let python = this.server.schema.languages.findBy({ slug: 'python' });
+
+    createCommunityCourseStageSolution(this.server, redis, 2, python);
+    createCommunityCourseStageSolution(this.server, redis, 3, python);
+
+    let pythonRepository = this.server.create('repository', 'withFirstStageCompleted', {
+      course: redis,
+      language: python,
+      name: 'Python #1',
+      user: currentUser,
+    });
+
+    this.server.create('course-stage-completion', {
+      repository: pythonRepository,
+      courseStage: redis.stages.models.sortBy('position').toArray()[1],
+      completedAt: new Date(new Date().getTime() - 5 * 86400000), // 5 days ago
+    });
+
+    this.server.create('submission', 'withStageCompletion', {
+      repository: pythonRepository,
+      courseStage: redis.stages.models.sortBy('position')[1],
+    });
+
+    this.server.create('submission', 'withStageCompletion', {
+      repository: pythonRepository,
+      courseStage: redis.stages.models.sortBy('position')[2],
+    });
+
+    await catalogPage.visit();
+    await catalogPage.clickOnCourse('Build your own Redis');
+    await coursePage.yourTaskCard.clickOnActionButton('Code Examples');
+
+    await coursePage.sidebar.clickOnStepListItem('Respond to multiple PINGs');
+    await animationsSettled();
+
+    await coursePage.yourTaskCard.clickOnActionButton('Code Examples');
+    assert.notOk(coursePage.codeExamplesTab.stageIncompleteModal.isVisible, 'stage incomplete modal is not visible');
+  });
+
+  test('back to instructions button in stage incomplete modal redirects to instructions', async function(assert) {
+    testScenario(this.server);
+    signIn(this.owner, this.server);
+
+    let currentUser = this.server.schema.users.first();
+
+    let redis = this.server.schema.courses.findBy({ slug: 'redis' });
+    let python = this.server.schema.languages.findBy({ slug: 'python' });
+
+    createCommunityCourseStageSolution(this.server, redis, 2, python);
+    createCommunityCourseStageSolution(this.server, redis, 3, python);
+
+    let pythonRepository = this.server.create('repository', 'withFirstStageCompleted', {
+      course: redis,
+      language: python,
+      name: 'Python #1',
+      user: currentUser,
+    });
+
+    this.server.create('course-stage-completion', {
+      repository: pythonRepository,
+      courseStage: redis.stages.models.sortBy('position').toArray()[1],
+      completedAt: new Date(new Date().getTime() - 5 * 86400000), // 5 days ago
+    });
+
+    this.server.create('submission', 'withStageCompletion', {
+      repository: pythonRepository,
+      courseStage: redis.stages.models.sortBy('position')[1],
+    });
+
+    await catalogPage.visit();
+    await catalogPage.clickOnCourse('Build your own Redis');
+    await coursePage.yourTaskCard.clickOnActionButton('Code Examples');
+    await coursePage.codeExamplesTab.stageIncompleteModal.clickOnInstructionsButton();
+
+    assert.ok(coursePage.yourTaskCard.isVisible, 'user is redirected to instructions');
+  });
+
+  test('show code button in stage incomplete modal shows code examples', async function(assert) {
+    testScenario(this.server);
+    signIn(this.owner, this.server);
+
+    let currentUser = this.server.schema.users.first();
+
+    let redis = this.server.schema.courses.findBy({ slug: 'redis' });
+    let python = this.server.schema.languages.findBy({ slug: 'python' });
+
+    createCommunityCourseStageSolution(this.server, redis, 2, python);
+    createCommunityCourseStageSolution(this.server, redis, 3, python);
+
+    let pythonRepository = this.server.create('repository', 'withFirstStageCompleted', {
+      course: redis,
+      language: python,
+      name: 'Python #1',
+      user: currentUser,
+    });
+
+    this.server.create('course-stage-completion', {
+      repository: pythonRepository,
+      courseStage: redis.stages.models.sortBy('position').toArray()[1],
+      completedAt: new Date(new Date().getTime() - 5 * 86400000), // 5 days ago
+    });
+
+    this.server.create('submission', 'withStageCompletion', {
+      repository: pythonRepository,
+      courseStage: redis.stages.models.sortBy('position')[1],
+    });
+
+    await catalogPage.visit();
+    await catalogPage.clickOnCourse('Build your own Redis');
+    await coursePage.yourTaskCard.clickOnActionButton('Code Examples');
+    await coursePage.codeExamplesTab.stageIncompleteModal.clickOnShowCodeButton();
+
+    assert.notOk(coursePage.codeExamplesTab.stageIncompleteModal.isVisible, 'stage incomplete modal is not visible');
+  });
+
+  test('stage incomplete modal does not render if no solutions for language exist', async function(assert) {
+    testScenario(this.server);
+    signIn(this.owner, this.server);
+
+    let currentUser = this.server.schema.users.first();
+
+    let redis = this.server.schema.courses.findBy({ slug: 'redis' });
+    let python = this.server.schema.languages.findBy({ slug: 'python' });
+
+    let pythonRepository = this.server.create('repository', 'withFirstStageCompleted', {
+      course: redis,
+      language: python,
+      name: 'Python #1',
+      user: currentUser,
+    });
+
+    this.server.create('course-stage-completion', {
+      repository: pythonRepository,
+      courseStage: redis.stages.models.sortBy('position').toArray()[1],
+      completedAt: new Date(new Date().getTime() - 5 * 86400000), // 5 days ago
+    });
+
+    this.server.create('submission', 'withStageCompletion', {
+      repository: pythonRepository,
+      courseStage: redis.stages.models.sortBy('position')[1],
+    });
+
+    await catalogPage.visit();
+    await catalogPage.clickOnCourse('Build your own Redis');
+    await coursePage.yourTaskCard.clickOnActionButton('Code Examples');
+
+    assert.notOk(coursePage.codeExamplesTab.stageIncompleteModal.isVisible, 'stage incomplete modal is not visible');
+  });
+
+  test('stage incomplete modal does not show up again if show code button is clicked when user switches to a different language', async function(assert) {
+    testScenario(this.server);
+    signIn(this.owner, this.server);
+
+    let currentUser = this.server.schema.users.first();
+
+    let redis = this.server.schema.courses.findBy({ slug: 'redis' });
+    let go = this.server.schema.languages.findBy({ slug: 'go' });
+    let python = this.server.schema.languages.findBy({ slug: 'python' });
+
+    createCommunityCourseStageSolution(this.server, redis, 2, python);
+    createCommunityCourseStageSolution(this.server, redis, 3, python);
+    createCommunityCourseStageSolution(this.server, redis, 3, go);
+
+    let pythonRepository = this.server.create('repository', 'withFirstStageCompleted', {
+      course: redis,
+      language: python,
+      name: 'Python #1',
+      user: currentUser,
+    });
+
+    this.server.create('course-stage-completion', {
+      repository: pythonRepository,
+      courseStage: redis.stages.models.sortBy('position').toArray()[1],
+      completedAt: new Date(new Date().getTime() - 5 * 86400000), // 5 days ago
+    });
+
+    this.server.create('submission', 'withStageCompletion', {
+      repository: pythonRepository,
+      courseStage: redis.stages.models.sortBy('position')[1],
+    });
+
+    await catalogPage.visit();
+    await catalogPage.clickOnCourse('Build your own Redis');
+    await coursePage.yourTaskCard.clickOnActionButton('Code Examples');
+    await coursePage.codeExamplesTab.stageIncompleteModal.clickOnShowCodeButton();
+
+    await coursePage.codeExamplesTab.languageDropdown.toggle();
+    await coursePage.codeExamplesTab.languageDropdown.clickOnLink('Go');
+
+    assert.notOk(coursePage.codeExamplesTab.stageIncompleteModal.isVisible, 'stage incomplete modal is not visible');
   });
 });

--- a/tests/acceptance/course-page/view-code-examples-test.js
+++ b/tests/acceptance/course-page/view-code-examples-test.js
@@ -478,7 +478,7 @@ module('Acceptance | course-page | view-code-examples', function (hooks) {
     assert.ok(coursePage.codeExamplesTab.stageIncompleteModal.isVisible, 'stage incomplete modal is visible');
   });
 
-  test('stage incomplete modal status should not change if a course stage is updated', async function (assert) {
+  test('stage incomplete modal should not show up again after being dismissed when a course stage is updated', async function (assert) {
     testScenario(this.server);
     signIn(this.owner, this.server);
 
@@ -516,10 +516,15 @@ module('Acceptance | course-page | view-code-examples', function (hooks) {
     await catalogPage.clickOnCourse('Build your own Redis');
     await coursePage.yourTaskCard.clickOnActionButton('Code Examples');
 
-    assert.ok(coursePage.codeExamplesTab.stageIncompleteModal.isVisible, 'stage incomplete modal is visible');
+    assert.ok(coursePage.codeExamplesTab.stageIncompleteModal.isVisible, 'stage incomplete modal is visible the first time');
+
+    await coursePage.codeExamplesTab.stageIncompleteModal.clickOnShowCodeButton();
+
+    assert.notOk(coursePage.codeExamplesTab.stageIncompleteModal.isVisible, 'stage incomplete modal is not visible after dismissing modal');
 
     this.server.schema.courseStages.findBy({ name: 'Respond to multiple PINGs' }).update({ marketingMarkdown: 'Updated marketing markdown' });
+    await Promise.all(window.pollerInstances.map((poller) => poller.forcePoll()));
 
-    assert.ok(coursePage.codeExamplesTab.stageIncompleteModal.isVisible, 'stage incomplete modal is visible');
+    assert.notOk(coursePage.codeExamplesTab.stageIncompleteModal.isVisible, 'stage incomplete modal is not visible after updating course stage');
   });
 });

--- a/tests/acceptance/course-page/view-code-examples-test.js
+++ b/tests/acceptance/course-page/view-code-examples-test.js
@@ -10,11 +10,11 @@ import { signIn } from 'codecrafters-frontend/tests/support/authentication-helpe
 import { animationsSettled, setupAnimationTest } from 'ember-animated/test-support';
 import { module, test } from 'qunit';
 
-module('Acceptance | course-page | view-code-examples', function(hooks) {
+module('Acceptance | course-page | view-code-examples', function (hooks) {
   setupApplicationTest(hooks);
   setupAnimationTest(hooks);
 
-  test('can view solutions before starting course', async function(assert) {
+  test('can view solutions before starting course', async function (assert) {
     testScenario(this.server);
     signIn(this.owner, this.server);
 
@@ -69,7 +69,7 @@ module('Acceptance | course-page | view-code-examples', function(hooks) {
     assert.strictEqual(coursePage.codeExamplesTab.solutionCards.length, 0, 'expected no C solutions to be present');
   });
 
-  test('can view solutions after starting course', async function(assert) {
+  test('can view solutions after starting course', async function (assert) {
     testScenario(this.server);
     signIn(this.owner, this.server);
 
@@ -125,7 +125,7 @@ module('Acceptance | course-page | view-code-examples', function(hooks) {
     assert.strictEqual(coursePage.codeExamplesTab.solutionCards.length, 1, 'Solutions are visible');
   });
 
-  test('can view team-restricted solutions', async function(assert) {
+  test('can view team-restricted solutions', async function (assert) {
     testScenario(this.server);
 
     const currentUser = this.server.create('user', {
@@ -170,7 +170,7 @@ module('Acceptance | course-page | view-code-examples', function(hooks) {
     assert.strictEqual(coursePage.codeExamplesTab.solutionCards.length, 2);
   });
 
-  test('stage incomplete modal shows up when code examples are viewed before completing a stage', async function(assert) {
+  test('stage incomplete modal shows up when code examples are viewed before completing a stage', async function (assert) {
     testScenario(this.server);
     signIn(this.owner, this.server);
 
@@ -207,7 +207,7 @@ module('Acceptance | course-page | view-code-examples', function(hooks) {
     assert.ok(coursePage.codeExamplesTab.stageIncompleteModal.isVisible, 'stage incomplete modal is visible');
   });
 
-  test('stage incomplete modal does not show up on stage two even if stage is not completed', async function(assert) {
+  test('stage incomplete modal does not show up on stage two even if stage is not completed', async function (assert) {
     testScenario(this.server);
     signIn(this.owner, this.server);
 
@@ -218,7 +218,7 @@ module('Acceptance | course-page | view-code-examples', function(hooks) {
 
     createCommunityCourseStageSolution(this.server, redis, 2, python);
 
-    let pythonRepository = this.server.create('repository', 'withFirstStageCompleted', {
+    this.server.create('repository', 'withFirstStageCompleted', {
       course: redis,
       language: python,
       name: 'Python #1',
@@ -232,7 +232,7 @@ module('Acceptance | course-page | view-code-examples', function(hooks) {
     assert.notOk(coursePage.codeExamplesTab.stageIncompleteModal.isVisible, 'stage incomplete modal is not visible');
   });
 
-  test('stage incomplete model does not show up if stage is completed', async function(assert) {
+  test('stage incomplete model does not show up if stage is completed', async function (assert) {
     testScenario(this.server);
     signIn(this.owner, this.server);
 
@@ -278,7 +278,7 @@ module('Acceptance | course-page | view-code-examples', function(hooks) {
     assert.notOk(coursePage.codeExamplesTab.stageIncompleteModal.isVisible, 'stage incomplete modal is not visible');
   });
 
-  test('back to instructions button in stage incomplete modal redirects to instructions', async function(assert) {
+  test('back to instructions button in stage incomplete modal redirects to instructions', async function (assert) {
     testScenario(this.server);
     signIn(this.owner, this.server);
 
@@ -316,7 +316,7 @@ module('Acceptance | course-page | view-code-examples', function(hooks) {
     assert.ok(coursePage.yourTaskCard.isVisible, 'user is redirected to instructions');
   });
 
-  test('show code button in stage incomplete modal shows code examples', async function(assert) {
+  test('show code button in stage incomplete modal shows code examples', async function (assert) {
     testScenario(this.server);
     signIn(this.owner, this.server);
 
@@ -354,7 +354,7 @@ module('Acceptance | course-page | view-code-examples', function(hooks) {
     assert.notOk(coursePage.codeExamplesTab.stageIncompleteModal.isVisible, 'stage incomplete modal is not visible');
   });
 
-  test('stage incomplete modal does not render if no solutions for language exist', async function(assert) {
+  test('stage incomplete modal does not render if no solutions for language exist', async function (assert) {
     testScenario(this.server);
     signIn(this.owner, this.server);
 
@@ -388,7 +388,7 @@ module('Acceptance | course-page | view-code-examples', function(hooks) {
     assert.notOk(coursePage.codeExamplesTab.stageIncompleteModal.isVisible, 'stage incomplete modal is not visible');
   });
 
-  test('stage incomplete modal does not show up again if show code button is clicked when user switches to a different language', async function(assert) {
+  test('stage incomplete modal does not show up again if show code button is clicked when user switches to a different language', async function (assert) {
     testScenario(this.server);
     signIn(this.owner, this.server);
 

--- a/tests/pages/course-page.js
+++ b/tests/pages/course-page.js
@@ -51,7 +51,7 @@ export default create({
     languageDropdown: LanguageDropdown,
 
     solutionCards: collection('[data-test-community-solution-card]', {
-      clickOnCollapseButton: async function () {
+      clickOnCollapseButton: async function() {
         await this.collapseButtons[0].click();
       },
 
@@ -73,6 +73,12 @@ export default create({
     }),
 
     scope: '[data-test-code-examples-tab]',
+
+    stageIncompleteModal: {
+      clickOnInstructionsButton: clickable('[data-test-instructions-button]'),
+      clickOnShowCodeButton: clickable('[data-test-show-code-button]'),
+      scope: '[data-test-stage-incomplete-modal]',
+    }
   },
 
   commentList: CommentList,

--- a/tests/pages/course-page.js
+++ b/tests/pages/course-page.js
@@ -51,7 +51,7 @@ export default create({
     languageDropdown: LanguageDropdown,
 
     solutionCards: collection('[data-test-community-solution-card]', {
-      clickOnCollapseButton: async function() {
+      clickOnCollapseButton: async function () {
         await this.collapseButtons[0].click();
       },
 
@@ -78,7 +78,7 @@ export default create({
       clickOnInstructionsButton: clickable('[data-test-instructions-button]'),
       clickOnShowCodeButton: clickable('[data-test-show-code-button]'),
       scope: '[data-test-stage-incomplete-modal]',
-    }
+    },
   },
 
   commentList: CommentList,


### PR DESCRIPTION
**Checklist**:

- [x] I've thoroughly self-reviewed my changes
- [x] I've added tests for my changes, unless they affect admin-only areas (or are otherwise not worth testing)
- [ ] I've verified any visual changes using Percy (add a commit with `[percy]` in the message to trigger)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a modal to notify users when they attempt to view code examples for an incomplete stage, with options to go back to instructions or view code examples.

- **Tests**
  - Added tests to ensure the stage incomplete modal displays correctly based on the completion status of course stages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->