### PR TITLE
Add .vscode/tasks.json and update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,6 @@
 
 # broccoli-debug
 /DEBUG/
+
+# tasks
+.vscode/tasks/*

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,21 @@
+{
+  // https://code.visualstudio.com/docs/editor/tasks-appendix
+  "version": "2.0.0",
+  "tasks": [
+    {
+      "type": "process",
+      "command": "sh",
+      "args": [
+        ".vscode/tasks/js-component-to-ts.sh",
+        "${file}"
+      ],
+      "label": "Convert JS component to TS",
+      "problemMatcher": [],
+      "options": {
+        "env": {
+          "OPENAI_API_KEY": "bar"
+        }
+      }
+    }
+  ]
+}


### PR DESCRIPTION
This commit adds a new file .vscode/tasks.json and updates .gitignore to exclude .vscode/tasks/* from version control. The tasks.json file contains a task named "Convert JS component to
TS" that runs a shell script and passes the current file as an argument. It also sets the environment variable OPENAI_API_KEY to "bar".


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated `.gitignore` to exclude `.vscode/tasks/*` files.
  - Added a new task configuration for converting JavaScript components to TypeScript in Visual Studio Code.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->