### PR TITLE
CC-1285 Allow challenge deprecation language card in tracks

### DIFF
--- a/app/components/tracks-page/track-card.ts
+++ b/app/components/tracks-page/track-card.ts
@@ -43,6 +43,7 @@ export default class TrackCardComponent extends Component<Signature> {
     return this.store
       .peekAll('course')
       .rejectBy('releaseStatusIsAlpha')
+      .rejectBy('releaseStatusIsDeprecated')
       .filter((course) => course.betaOrLiveLanguages.includes(this.args.language))
       .mapBy('stages.length')
       .reduce((a, b) => a + b, 0);

--- a/tests/acceptance/view-tracks-test.js
+++ b/tests/acceptance/view-tracks-test.js
@@ -14,7 +14,7 @@ module('Acceptance | view-tracks', function (hooks) {
     signIn(this.owner, this.server);
 
     await catalogPage.visit();
-    assert.strictEqual(catalogPage.trackCards.length, 19, 'expected 19 track cards to be present');
+    assert.strictEqual(catalogPage.trackCards.length, 20, 'expected 20 track cards to be present');
 
     await percySnapshot('Tracks Page');
 
@@ -47,7 +47,7 @@ module('Acceptance | view-tracks', function (hooks) {
     assert.strictEqual(catalogPage.trackCards[3].actionText, 'Start', 'expected fourth track to have start action');
 
     assert.true(catalogPage.trackCards[0].hasProgressBar, 'expected first track to have progress bar');
-    assert.strictEqual(catalogPage.trackCards[0].progressText, '1/81 stages');
+    assert.strictEqual(catalogPage.trackCards[0].progressText, '1/123 stages');
     assert.strictEqual(catalogPage.trackCards[0].progressBarStyle, 'width:1%');
   });
 
@@ -129,7 +129,7 @@ module('Acceptance | view-tracks', function (hooks) {
     testScenario(this.server);
 
     await catalogPage.visit();
-    assert.strictEqual(catalogPage.trackCards.length, 19, 'expected 19 track cards to be present');
+    assert.strictEqual(catalogPage.trackCards.length, 20, 'expected 20 track cards to be present');
 
     assert.strictEqual(catalogPage.trackCards[0].name, 'Rust');
     assert.strictEqual(catalogPage.trackCards[1].name, 'Go');
@@ -145,7 +145,7 @@ module('Acceptance | view-tracks', function (hooks) {
 
     assert.ok(find('[data-test-loading]'), 'loader should be present');
     await settled();
-    assert.strictEqual(catalogPage.trackCards.length, 19, 'expected 19 track cards to be present');
+    assert.strictEqual(catalogPage.trackCards.length, 20, 'expected 20 track cards to be present');
   });
 
   test('second time visit with local repository data has no loading page', async function (assert) {
@@ -177,7 +177,7 @@ module('Acceptance | view-tracks', function (hooks) {
     });
 
     assert.notOk(loadingIndicatorWasRendered, 'loading indicator was not rendered');
-    assert.strictEqual(catalogPage.trackCards.length, 19, 'expected 19 track cards to be present');
+    assert.strictEqual(catalogPage.trackCards.length, 20, 'expected 20 track cards to be present');
   });
 
   test('second time visit without local repository data has no loading page ', async function (assert) {
@@ -199,6 +199,19 @@ module('Acceptance | view-tracks', function (hooks) {
     });
 
     assert.notOk(loadingIndicatorWasRendered, 'loading indicator was not rendered');
-    assert.strictEqual(catalogPage.trackCards.length, 19, 'expected 19 track cards to be present');
+    assert.strictEqual(catalogPage.trackCards.length, 20, 'expected 20 track cards to be present');
+  });
+
+  test('deprecated challenges do not count towards the number of stages on a language card', async function (assert) {
+    testScenario(this.server);
+    signIn(this.owner, this.server);
+
+    const docker = this.server.schema.courses.findBy({ slug: 'docker' });
+    docker.update({ releaseStatus: 'deprecated' });
+
+    await catalogPage.visit();
+
+    assert.ok(catalogPage.trackCards[0].hasPopularLabel, 'go should have popular label');
+    assert.ok(catalogPage.trackCards[0].text.includes('117 stages'), 'number of stages should not include deprecated stages count');
   });
 });

--- a/tests/acceptance/view-tracks-test.js
+++ b/tests/acceptance/view-tracks-test.js
@@ -14,7 +14,7 @@ module('Acceptance | view-tracks', function (hooks) {
     signIn(this.owner, this.server);
 
     await catalogPage.visit();
-    assert.strictEqual(catalogPage.trackCards.length, 20, 'expected 20 track cards to be present');
+    assert.strictEqual(catalogPage.trackCards.length, 19, 'expected 19 track cards to be present');
 
     await percySnapshot('Tracks Page');
 
@@ -47,7 +47,7 @@ module('Acceptance | view-tracks', function (hooks) {
     assert.strictEqual(catalogPage.trackCards[3].actionText, 'Start', 'expected fourth track to have start action');
 
     assert.true(catalogPage.trackCards[0].hasProgressBar, 'expected first track to have progress bar');
-    assert.strictEqual(catalogPage.trackCards[0].progressText, '1/123 stages');
+    assert.strictEqual(catalogPage.trackCards[0].progressText, '1/81 stages');
     assert.strictEqual(catalogPage.trackCards[0].progressBarStyle, 'width:1%');
   });
 
@@ -61,14 +61,14 @@ module('Acceptance | view-tracks', function (hooks) {
     let redis = this.server.schema.courses.findBy({ slug: 'redis' });
 
     this.server.create('repository', 'withFirstStageCompleted', {
-      createdAt: new Date('2022-01-01'),
+      createdAt: new Date('1922-01-01'),
       course: redis,
       language: go,
       user: currentUser,
     });
 
     this.server.create('repository', 'withFirstStageCompleted', {
-      createdAt: new Date('2022-02-02'),
+      createdAt: new Date('1922-02-02'),
       course: redis,
       language: python,
       user: currentUser,
@@ -99,14 +99,14 @@ module('Acceptance | view-tracks', function (hooks) {
     dummy.update({ releaseStatus: 'live' });
 
     this.server.create('repository', 'withAllStagesCompleted', {
-      createdAt: new Date('2022-01-01'),
+      createdAt: new Date('1922-01-01'),
       course: dummy,
       language: go,
       user: currentUser,
     });
 
     this.server.create('repository', 'withAllStagesCompleted', {
-      createdAt: new Date('2022-02-02'),
+      createdAt: new Date('1922-02-02'),
       course: sqlite,
       language: go,
       user: currentUser,
@@ -129,7 +129,7 @@ module('Acceptance | view-tracks', function (hooks) {
     testScenario(this.server);
 
     await catalogPage.visit();
-    assert.strictEqual(catalogPage.trackCards.length, 20, 'expected 20 track cards to be present');
+    assert.strictEqual(catalogPage.trackCards.length, 19, 'expected 19 track cards to be present');
 
     assert.strictEqual(catalogPage.trackCards[0].name, 'Rust');
     assert.strictEqual(catalogPage.trackCards[1].name, 'Go');
@@ -145,7 +145,7 @@ module('Acceptance | view-tracks', function (hooks) {
 
     assert.ok(find('[data-test-loading]'), 'loader should be present');
     await settled();
-    assert.strictEqual(catalogPage.trackCards.length, 20, 'expected 20 track cards to be present');
+    assert.strictEqual(catalogPage.trackCards.length, 19, 'expected 19 track cards to be present');
   });
 
   test('second time visit with local repository data has no loading page', async function (assert) {
@@ -177,7 +177,7 @@ module('Acceptance | view-tracks', function (hooks) {
     });
 
     assert.notOk(loadingIndicatorWasRendered, 'loading indicator was not rendered');
-    assert.strictEqual(catalogPage.trackCards.length, 20, 'expected 20 track cards to be present');
+    assert.strictEqual(catalogPage.trackCards.length, 19, 'expected 19 track cards to be present');
   });
 
   test('second time visit without local repository data has no loading page ', async function (assert) {
@@ -199,7 +199,7 @@ module('Acceptance | view-tracks', function (hooks) {
     });
 
     assert.notOk(loadingIndicatorWasRendered, 'loading indicator was not rendered');
-    assert.strictEqual(catalogPage.trackCards.length, 20, 'expected 20 track cards to be present');
+    assert.strictEqual(catalogPage.trackCards.length, 19, 'expected 19 track cards to be present');
   });
 
   test('deprecated challenges do not count towards the number of stages on a language card', async function (assert) {
@@ -212,6 +212,6 @@ module('Acceptance | view-tracks', function (hooks) {
     await catalogPage.visit();
 
     assert.ok(catalogPage.trackCards[0].hasPopularLabel, 'go should have popular label');
-    assert.ok(catalogPage.trackCards[0].text.includes('117 stages'), 'number of stages should not include deprecated stages count');
+    assert.ok(catalogPage.trackCards[0].text.includes('75 stages'), 'number of stages should not include deprecated stages count');
   });
 });


### PR DESCRIPTION
**Checklist**:

- [x] I've thoroughly self-reviewed my changes
- [x] I've added tests for my changes, unless they affect admin-only areas (or are otherwise not worth testing)
- [ ] I've verified any visual changes using Percy (add a commit with `[percy]` in the message to trigger)
