### PR TITLE
CC-1296 add refresh from github button

### DIFF
--- a/app/components/settings/profile-page/username-section.hbs
+++ b/app/components/settings/profile-page/username-section.hbs
@@ -26,6 +26,7 @@
     @size="extra-small"
     class="mt-4"
     @shouldShowSpinner={{this.isSyncingUsernameFromGitHub}}
+    @isDisabled={{this.currentUser.hasAnonymousModeEnabled}}
     {{on "click" this.refreshFromGitHub}}
     data-test-refresh-from-github-button
   >

--- a/app/components/settings/profile-page/username-section.hbs
+++ b/app/components/settings/profile-page/username-section.hbs
@@ -22,7 +22,13 @@
     {{/if}}
   </div>
 
-  <TertiaryButtonWithSpinner @size="extra-small" class="mt-4" @shouldShowSpinner={{this.isSyncingGitHubUsername}} {{on "click" this.refreshFromGitHub}} data-test-refresh-from-github-button>
+  <TertiaryButtonWithSpinner
+    @size="extra-small"
+    class="mt-4"
+    @shouldShowSpinner={{this.isSyncingGitHubUsername}}
+    {{on "click" this.refreshFromGitHub}}
+    data-test-refresh-from-github-button
+  >
     <div class="flex items-center gap-1">
       {{svg-jar "refresh" class="w-4 h-4 text-gray-400"}}
       Refresh from GitHub

--- a/app/components/settings/profile-page/username-section.hbs
+++ b/app/components/settings/profile-page/username-section.hbs
@@ -34,5 +34,9 @@
       {{svg-jar "refresh" class="w-4 h-4 text-gray-400"}}
       Refresh from GitHub
     </div>
+
+    {{#if this.currentUser.hasAnonymousModeEnabled}}
+      <EmberTooltip @text="Your profile has anonymous mode enabled. Your GitHub username is not visible to others." />
+    {{/if}}
   </TertiaryButtonWithSpinner>
 </Settings::FormSection>

--- a/app/components/settings/profile-page/username-section.hbs
+++ b/app/components/settings/profile-page/username-section.hbs
@@ -11,24 +11,21 @@
     {{#if @user.hasAnonymousModeEnabled}}
       <EmberTooltip @text="Your profile has anonymous mode enabled. Your GitHub username is not visible to others." />
     {{else}}
-      {{! activate this once implemented }}
-      {{! <EmberTooltip @text="This value is synced with your GitHub account. Click on the refresh button below to update your username." /> }}
-      <EmberTooltip @text="This value is synced with your GitHub account." />
+      <EmberTooltip @text="This value is synced with your GitHub account. Click on the refresh button below to update your username." />
     {{/if}}
   </div>
   <div class="text-gray-400 text-xs mt-1">
     {{#if @user.hasAnonymousModeEnabled}}
       Your profile has anonymous mode enabled. Your GitHub username is not visible to others.
     {{else}}
-      This value is synced with your GitHub account.
+      This value is synced with your GitHub account. Click on the refresh button below to update your username.
     {{/if}}
   </div>
 
-  {{!-- TODO: Bring this back once implemented }}
-  {{!-- <TertiaryButtonWithSpinner @size="extra-small" class="mt-4" @shouldShowSpinner={{false}}>
+  <TertiaryButtonWithSpinner @size="extra-small" class="mt-4" @shouldShowSpinner={{this.isSyncingGitHubUsername}} {{on "click" this.refreshFromGitHub}} data-test-refresh-from-github-button>
     <div class="flex items-center gap-1">
       {{svg-jar "refresh" class="w-4 h-4 text-gray-400"}}
       Refresh from GitHub
     </div>
-  </TertiaryButtonWithSpinner> --}}
+  </TertiaryButtonWithSpinner>
 </Settings::FormSection>

--- a/app/components/settings/profile-page/username-section.hbs
+++ b/app/components/settings/profile-page/username-section.hbs
@@ -25,7 +25,7 @@
   <TertiaryButtonWithSpinner
     @size="extra-small"
     class="mt-4"
-    @shouldShowSpinner={{this.isSyncingGitHubUsername}}
+    @shouldShowSpinner={{this.isSyncingUsernameFromGitHub}}
     {{on "click" this.refreshFromGitHub}}
     data-test-refresh-from-github-button
   >

--- a/app/components/settings/profile-page/username-section.ts
+++ b/app/components/settings/profile-page/username-section.ts
@@ -16,13 +16,13 @@ interface Signature {
 export default class UsernameSectionComponent extends Component<Signature> {
   @service declare authenticator: AuthenticatorService;
 
-  @tracked isSyncingGitHubUsername = false;
+  @tracked isSyncingUsernameFromGitHub = false;
 
   @action
   async refreshFromGitHub() {
-    this.isSyncingGitHubUsername = true;
-    await this.authenticator.currentUser?.syncGitHubUsername(null);
-    this.isSyncingGitHubUsername = false;
+    this.isSyncingUsernameFromGitHub = true;
+    await this.authenticator.currentUser?.syncUsernameFromGitHub(null);
+    this.isSyncingUsernameFromGitHub = false;
   }
 }
 

--- a/app/components/settings/profile-page/username-section.ts
+++ b/app/components/settings/profile-page/username-section.ts
@@ -25,7 +25,7 @@ export default class UsernameSectionComponent extends Component<Signature> {
   @action
   async refreshFromGitHub() {
     if (this.currentUser.hasAnonymousModeEnabled) {
-      return
+      return;
     }
 
     this.isSyncingUsernameFromGitHub = true;

--- a/app/components/settings/profile-page/username-section.ts
+++ b/app/components/settings/profile-page/username-section.ts
@@ -18,10 +18,18 @@ export default class UsernameSectionComponent extends Component<Signature> {
 
   @tracked isSyncingUsernameFromGitHub = false;
 
+  get currentUser() {
+    return this.authenticator.currentUser as UserModel;
+  }
+
   @action
   async refreshFromGitHub() {
+    if (this.currentUser.hasAnonymousModeEnabled) {
+      return
+    }
+
     this.isSyncingUsernameFromGitHub = true;
-    await this.authenticator.currentUser?.syncUsernameFromGitHub(null);
+    await this.currentUser.syncUsernameFromGitHub(null);
     this.isSyncingUsernameFromGitHub = false;
   }
 }

--- a/app/components/settings/profile-page/username-section.ts
+++ b/app/components/settings/profile-page/username-section.ts
@@ -1,5 +1,9 @@
 import Component from '@glimmer/component';
+import type AuthenticatorService from 'codecrafters-frontend/services/authenticator';
 import type UserModel from 'codecrafters-frontend/models/user';
+import { action } from '@ember/object';
+import { inject as service } from '@ember/service';
+import { tracked } from '@glimmer/tracking';
 
 interface Signature {
   Element: HTMLDivElement;
@@ -9,7 +13,18 @@ interface Signature {
   };
 }
 
-export default class UsernameSectionComponent extends Component<Signature> {}
+export default class UsernameSectionComponent extends Component<Signature> {
+  @service declare authenticator: AuthenticatorService;
+
+  @tracked isSyncingGitHubUsername = false;
+
+  @action
+  async refreshFromGitHub() {
+    this.isSyncingGitHubUsername = true;
+    await this.authenticator.currentUser?.syncGitHubUsername(null);
+    this.isSyncingGitHubUsername = false;
+  }
+}
 
 declare module '@glint/environment-ember-loose/registry' {
   export default interface Registry {

--- a/app/models/user.ts
+++ b/app/models/user.ts
@@ -260,4 +260,4 @@ UserModel.prototype.syncGitHubUsername = memberAction({
   after(response) {
     this.store.pushPayload(response);
   },
-})
+});

--- a/app/models/user.ts
+++ b/app/models/user.ts
@@ -210,16 +210,8 @@ export default class UserModel extends Model {
   declare fetchCurrent: (this: Model, payload: unknown) => Promise<UserModel | null>;
   declare fetchNextInvoicePreview: (this: Model, payload: unknown) => Promise<InvoiceModel | null>;
   declare syncFeatureFlags: (this: Model, payload: unknown) => Promise<void>;
+  declare syncGitHubUsername: (this: Model, payload: unknown) => Promise<void>;
 }
-
-UserModel.prototype.syncFeatureFlags = memberAction({
-  path: 'sync-feature-flags',
-  type: 'post',
-
-  after(response) {
-    this.store.pushPayload(response);
-  },
-});
 
 UserModel.prototype.fetchNextInvoicePreview = memberAction({
   path: 'next-invoice-preview',
@@ -251,3 +243,21 @@ UserModel.prototype.fetchCurrent = collectionAction({
     }
   },
 });
+
+UserModel.prototype.syncFeatureFlags = memberAction({
+  path: 'sync-feature-flags',
+  type: 'post',
+
+  after(response) {
+    this.store.pushPayload(response);
+  },
+});
+
+UserModel.prototype.syncGitHubUsername = memberAction({
+  path: 'sync-github-username',
+  type: 'post',
+
+  after(response) {
+    this.store.pushPayload(response);
+  },
+})

--- a/app/models/user.ts
+++ b/app/models/user.ts
@@ -210,7 +210,7 @@ export default class UserModel extends Model {
   declare fetchCurrent: (this: Model, payload: unknown) => Promise<UserModel | null>;
   declare fetchNextInvoicePreview: (this: Model, payload: unknown) => Promise<InvoiceModel | null>;
   declare syncFeatureFlags: (this: Model, payload: unknown) => Promise<void>;
-  declare syncGitHubUsername: (this: Model, payload: unknown) => Promise<void>;
+  declare syncUsernameFromGitHub: (this: Model, payload: unknown) => Promise<void>;
 }
 
 UserModel.prototype.fetchNextInvoicePreview = memberAction({
@@ -253,8 +253,8 @@ UserModel.prototype.syncFeatureFlags = memberAction({
   },
 });
 
-UserModel.prototype.syncGitHubUsername = memberAction({
-  path: 'sync-github-username',
+UserModel.prototype.syncUsernameFromGitHub = memberAction({
+  path: 'sync-username-from-github',
   type: 'post',
 
   after(response) {

--- a/mirage/handlers/users.js
+++ b/mirage/handlers/users.js
@@ -25,6 +25,13 @@ export default function (server) {
     });
   });
 
+  server.post('/users/:id/sync-github-username', function (schema, request) {
+    let user = schema.users.find(request.params.id);
+    user.update({ username: 'updated-username' });
+
+    return user
+  })
+
   server.patch('/users/:id', function (schema, request) {
     const { id } = request.params;
     const attrs = this.normalizedRequestAttrs();

--- a/mirage/handlers/users.js
+++ b/mirage/handlers/users.js
@@ -25,7 +25,7 @@ export default function (server) {
     });
   });
 
-  server.post('/users/:id/sync-github-username', function (schema, request) {
+  server.post('/users/:id/sync-username-from-github', function (schema, request) {
     let user = schema.users.find(request.params.id);
     user.update({ username: 'updated-username' });
 

--- a/mirage/handlers/users.js
+++ b/mirage/handlers/users.js
@@ -29,8 +29,8 @@ export default function (server) {
     let user = schema.users.find(request.params.id);
     user.update({ username: 'updated-username' });
 
-    return user
-  })
+    return user;
+  });
 
   server.patch('/users/:id', function (schema, request) {
     const { id } = request.params;

--- a/tests/acceptance/settings-page/profile-test.js
+++ b/tests/acceptance/settings-page/profile-test.js
@@ -53,14 +53,14 @@ module('Acceptance | settings-page | profile-test', function (hooks) {
     testScenario(this.server);
     signInAsSubscriber(this.owner, this.server);
 
-    let currentUser = this.server.schema.users.first()
+    let currentUser = this.server.schema.users.first();
 
     assert.strictEqual(currentUser.username, 'rohitpaulk');
 
     await profilePage.visit();
     await profilePage.refreshFromGitHubButton.click();
-    await settled()
+    await settled();
 
     assert.strictEqual(currentUser.reload().username, 'updated-username');
-  })
+  });
 });

--- a/tests/acceptance/settings-page/profile-test.js
+++ b/tests/acceptance/settings-page/profile-test.js
@@ -2,7 +2,6 @@ import profilePage from 'codecrafters-frontend/tests/pages/settings/profile-page
 import userPage from 'codecrafters-frontend/tests/pages/user-page';
 import testScenario from 'codecrafters-frontend/mirage/scenarios/test';
 import { module, test } from 'qunit';
-import { settled } from '@ember/test-helpers';
 import { setupApplicationTest } from 'codecrafters-frontend/tests/helpers';
 import { signIn, signInAsSubscriber } from 'codecrafters-frontend/tests/support/authentication-helpers';
 
@@ -80,5 +79,5 @@ module('Acceptance | settings-page | profile-test', function (hooks) {
     await profilePage.accountDropdown.clickOnLink('Your Profile');
 
     assert.strictEqual(userPage.githubDetails.username, 'Anonymous', 'should not have updated username');
-  })
+  });
 });

--- a/tests/acceptance/settings-page/profile-test.js
+++ b/tests/acceptance/settings-page/profile-test.js
@@ -62,4 +62,23 @@ module('Acceptance | settings-page | profile-test', function (hooks) {
 
     assert.strictEqual(currentUser.reload().username, 'updated-username');
   });
+
+  test('users with anonymous mode toggled should not be able to refresh github username', async function (assert) {
+    testScenario(this.server);
+    signInAsSubscriber(this.owner, this.server);
+
+    await profilePage.visit();
+    await profilePage.anonymousModeToggle.toggle();
+    await profilePage.accountDropdown.toggle();
+    await profilePage.accountDropdown.clickOnLink('Your Profile');
+
+    assert.strictEqual(userPage.githubDetails.username, 'Anonymous');
+
+    await profilePage.visit();
+    await profilePage.refreshFromGitHubButton.click();
+    await profilePage.accountDropdown.toggle();
+    await profilePage.accountDropdown.clickOnLink('Your Profile');
+
+    assert.strictEqual(userPage.githubDetails.username, 'Anonymous', 'should not have updated username');
+  })
 });

--- a/tests/acceptance/settings-page/profile-test.js
+++ b/tests/acceptance/settings-page/profile-test.js
@@ -59,7 +59,6 @@ module('Acceptance | settings-page | profile-test', function (hooks) {
 
     await profilePage.visit();
     await profilePage.refreshFromGitHubButton.click();
-    await settled();
 
     assert.strictEqual(currentUser.reload().username, 'updated-username');
   });

--- a/tests/acceptance/settings-page/profile-test.js
+++ b/tests/acceptance/settings-page/profile-test.js
@@ -2,6 +2,7 @@ import profilePage from 'codecrafters-frontend/tests/pages/settings/profile-page
 import userPage from 'codecrafters-frontend/tests/pages/user-page';
 import testScenario from 'codecrafters-frontend/mirage/scenarios/test';
 import { module, test } from 'qunit';
+import { settled } from '@ember/test-helpers';
 import { setupApplicationTest } from 'codecrafters-frontend/tests/helpers';
 import { signIn, signInAsSubscriber } from 'codecrafters-frontend/tests/support/authentication-helpers';
 
@@ -47,4 +48,19 @@ module('Acceptance | settings-page | profile-test', function (hooks) {
     assert.strictEqual(userPage.githubDetails.username, 'rohitpaulk');
     assert.strictEqual(userPage.githubDetails.link, 'https://github.com/rohitpaulk');
   });
+
+  test('can refresh github username', async function (assert) {
+    testScenario(this.server);
+    signInAsSubscriber(this.owner, this.server);
+
+    let currentUser = this.server.schema.users.first()
+
+    assert.strictEqual(currentUser.username, 'rohitpaulk');
+
+    await profilePage.visit();
+    await profilePage.refreshFromGitHubButton.click();
+    await settled()
+
+    assert.strictEqual(currentUser.reload().username, 'updated-username');
+  })
 });

--- a/tests/pages/settings/profile-page.ts
+++ b/tests/pages/settings/profile-page.ts
@@ -13,5 +13,9 @@ export default createPage({
     },
   },
 
+  refreshFromGitHubButton: {
+    scope: '[data-test-refresh-from-github-button]',
+  },
+
   visit: visitable('/settings/profile'),
 });


### PR DESCRIPTION
**Checklist**:

- [x] I've thoroughly self-reviewed my changes
- [x] I've added tests for my changes, unless they affect admin-only areas (or are otherwise not worth testing)
- [ ] I've verified any visual changes using Percy (add a commit with `[percy]` in the message to trigger)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a tooltip for syncing GitHub account username.
  - Enabled the refresh button functionality to update the username from GitHub.

- **Bug Fixes**
  - Improved GitHub username synchronization mechanism.

- **Tests**
  - Added tests to verify the functionality of refreshing GitHub usernames.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->