### PR TITLE
CC-1284 Add preventScroll: true to all focus method calls on an html element

### DIFF
--- a/app/components/concept-page/question-card.ts
+++ b/app/components/concept-page/question-card.ts
@@ -57,7 +57,7 @@ export default class QuestionCardComponent extends Component<Signature> {
     if (firstOptionElement instanceof HTMLElement) {
       // focus() doesn't seem to work unless it's called after the current runloop
       next(() => {
-        firstOptionElement && firstOptionElement.focus();
+        firstOptionElement && firstOptionElement.focus({ preventScroll: true });
       });
     }
   }
@@ -82,9 +82,9 @@ export default class QuestionCardComponent extends Component<Signature> {
     const currentFocusedOptionIndex = options.indexOf(currentFocusedOption);
 
     if (currentFocusedOptionIndex < options.length - 1) {
-      options[currentFocusedOptionIndex + 1]!.focus();
+      options[currentFocusedOptionIndex + 1]!.focus({ preventScroll: true })
     } else {
-      options[0]!.focus();
+      options[0]!.focus({ preventScroll: true })
     }
   }
 
@@ -108,9 +108,9 @@ export default class QuestionCardComponent extends Component<Signature> {
     const currentFocusedOptionIndex = options.indexOf(currentFocusedOption);
 
     if (currentFocusedOptionIndex > 0) {
-      options[currentFocusedOptionIndex - 1]!.focus();
+      options[currentFocusedOptionIndex - 1]!.focus({ preventScroll: true })
     } else {
-      options[options.length - 1]!.focus();
+      options[options.length - 1]!.focus({ preventScroll: true })
     }
   }
 

--- a/app/components/concept-page/question-card.ts
+++ b/app/components/concept-page/question-card.ts
@@ -82,9 +82,9 @@ export default class QuestionCardComponent extends Component<Signature> {
     const currentFocusedOptionIndex = options.indexOf(currentFocusedOption);
 
     if (currentFocusedOptionIndex < options.length - 1) {
-      options[currentFocusedOptionIndex + 1]!.focus({ preventScroll: true })
+      options[currentFocusedOptionIndex + 1]!.focus({ preventScroll: true });
     } else {
-      options[0]!.focus({ preventScroll: true })
+      options[0]!.focus({ preventScroll: true });
     }
   }
 
@@ -108,9 +108,9 @@ export default class QuestionCardComponent extends Component<Signature> {
     const currentFocusedOptionIndex = options.indexOf(currentFocusedOption);
 
     if (currentFocusedOptionIndex > 0) {
-      options[currentFocusedOptionIndex - 1]!.focus({ preventScroll: true })
+      options[currentFocusedOptionIndex - 1]!.focus({ preventScroll: true });
     } else {
-      options[options.length - 1]!.focus({ preventScroll: true })
+      options[options.length - 1]!.focus({ preventScroll: true });
     }
   }
 

--- a/app/components/concept/continue-or-step-back.hbs
+++ b/app/components/concept/continue-or-step-back.hbs
@@ -3,7 +3,8 @@
     <div class="flex flex-col items-center">
       <PrimaryButton
         {{on "click" @onContinueButtonClick}}
-        {{(if @shouldHighlightKeyboardShortcuts (modifier "focus-on-insert"))}}
+        {{! @glint-expect-error modifier helper types aren't right? }}
+        {{(if @shouldHighlightKeyboardShortcuts (modifier "focus-on-insert" preventScroll=true))}}
         data-test-continue-button
         {{did-insert this.handleDidInsertContinueButtonElement}}
         {{! @glint-expect-error on-key modifier types aren't right? }}

--- a/app/modifiers/focus-on-insert.ts
+++ b/app/modifiers/focus-on-insert.ts
@@ -6,7 +6,7 @@ type Signature = {
 
     Named: {
       preventScroll?: boolean;
-    }
+    };
   };
 };
 

--- a/app/modifiers/focus-on-insert.ts
+++ b/app/modifiers/focus-on-insert.ts
@@ -4,13 +4,15 @@ type Signature = {
   Args: {
     Positional: [];
 
-    Named: Record<string, never>;
+    Named: {
+      preventScroll?: boolean;
+    }
   };
 };
 
 export default class FocusOnInsertModifier extends Modifier<Signature> {
-  modify(element: HTMLElement, _positional: [], _named: Signature['Args']['Named']) {
-    element.focus();
+  modify(element: HTMLElement, _positional: [], named: Signature['Args']['Named']) {
+    element.focus({ preventScroll: !!named.preventScroll });
   }
 }
 


### PR DESCRIPTION
**Checklist**:

- [x] I've thoroughly self-reviewed my changes
- [x] I've added tests for my changes, unless they affect admin-only areas (or are otherwise not worth testing)
- [ ] I've verified any visual changes using Percy (add a commit with `[percy]` in the message to trigger)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced focus behavior across various components to prevent unwanted scrolling when elements are focused.
		- Applied changes to `QuestionCardComponent`, `PrimaryButton`, `RequestLanguageDropdownComponent`, `CancelSubscriptionModalComponent`, and `FocusOnInsertModifier`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->