### PR TITLE
Add staticEmberSource to ember-cli-build.js

### DIFF
--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -89,6 +89,7 @@ module.exports = function (defaults) {
   const compiledApp = require('@embroider/compat').compatBuild(app, Webpack, {
     staticAddonTestSupportTrees: true,
     staticAddonTrees: true,
+    staticEmberSource: true,
     staticHelpers: true,
     staticModifiers: true,
     staticComponents: true,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enabled static ember source configuration for improved build performance and stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->