### PR TITLE
fix: Fix code examples width not spanning the entire width of container

### DIFF
--- a/app/components/course-page/course-stage-step/community-solutions-list.hbs
+++ b/app/components/course-page/course-stage-step/community-solutions-list.hbs
@@ -1,4 +1,4 @@
-<BlurredOverlay @isBlurred={{this.shouldShowStageIncompleteModal}} class="px-3 md:px-6 lg:px-10">
+<BlurredOverlay @isBlurred={{this.shouldShowStageIncompleteModal}}>
   <:content>
     {{#each @solutions as |solution solutionIndex|}}
       <CoursePage::CourseStageStep::CommunitySolutionCard


### PR DESCRIPTION
**Checklist**:

- [x] I've thoroughly self-reviewed my changes
- [x] I've added tests for my changes, unless they affect admin-only areas (or are otherwise not worth testing)
- [ ] I've verified any visual changes using Percy (add a commit with `[percy]` in the message to trigger)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
	- Updated the community solutions list view by removing specific CSS classes from the overlay component.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->