### PR TITLE
Remove Google Tag Manager script from index.html

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -24,14 +24,15 @@
     <script type="text/javascript">window.Beacon('init', 'bb089ae9-a4ae-4114-8f7a-b660f6310158')</script>
     <script async src="https://metabase.codecrafters.io/app/iframeResizer.js"></script>
 
-    <script async src="https://www.googletagmanager.com/gtag/js?id=G-N8D6K4M2HE"></script>
-    <script>
+    <!-- Don't think we need this anymore? -->
+    <!-- <script async src="https://www.googletagmanager.com/gtag/js?id=G-N8D6K4M2HE"></script> -->
+    <!-- <script>
       window.dataLayer = window.dataLayer || [];
       function gtag(){dataLayer.push(arguments);}
       gtag('js', new Date());
 
       gtag('config', 'G-N8D6K4M2HE');
-    </script>
+    </script> -->
   </head>
   <body style="margin: 0; background-color: rgb(248 250 252)">
     <div class="ember-load-indicator">


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Commented out the Google Tag Manager script in `index.html`, indicating it is no longer active on the page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->