### PR TITLE
Don't use media queries in `DarkMode` service when running under FastBoot

### DIFF
--- a/app/services/dark-mode.ts
+++ b/app/services/dark-mode.ts
@@ -5,6 +5,7 @@ import { registerDestructor } from '@ember/destroyable';
 import type RouterService from '@ember/routing/router-service';
 import type RouteInfo from '@ember/routing/route-info';
 import type LocalStorageService from 'codecrafters-frontend/services/local-storage';
+import FastBootService from 'ember-cli-fastboot/services/fastboot';
 import RouteInfoMetadata, { RouteColorScheme } from 'codecrafters-frontend/utils/route-info-metadata';
 
 const LOCAL_STORAGE_KEY = 'dark-mode-preference';
@@ -15,6 +16,7 @@ export type SystemPreference = 'dark' | 'light';
 export default class DarkModeService extends Service {
   @service declare router: RouterService;
   @service declare localStorage: LocalStorageService;
+  @service declare fastboot: FastBootService;
 
   /**
    * Currently loaded localStorage preference value
@@ -31,6 +33,11 @@ export default class DarkModeService extends Service {
 
     // Load the localStorage preference from localStorage service
     this.localStoragePreference = this.localStorage.getItem(LOCAL_STORAGE_KEY) as LocalStoragePreference;
+
+    // There are no media queries when running under FastBoot
+    if (this.fastboot.isFastBoot) {
+      return;
+    }
 
     // Create a media query to load current system Dark Mode preference
     const mediaQuery = window.matchMedia('(prefers-color-scheme: dark)');


### PR DESCRIPTION
### Brief

Pre-rendering of some pages using `prember` has become broken after the [Dark Mode PR](https://github.com/codecrafters-io/frontend/pull/1774), because there are no Media Queries in FastBoot mode. This fixes it.

![Знімок екрана 2024-06-21 о 10 28 13](https://github.com/codecrafters-io/frontend/assets/493875/9829474d-c2b7-446b-835b-73c36a1f2b1e)


### Checklist

- [x] I've thoroughly self-reviewed my changes
- [x] I've added tests for my changes, unless they affect admin-only areas (or are otherwise not worth testing)
- [x] I've verified any visual changes using Percy (add a commit with `[percy]` in the message to trigger)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved dark mode functionality to ensure it works correctly in FastBoot environments, enhancing reliability and user experience when using server-side rendering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->