### PR TITLE
CC-1296 Ensure tooltip is not affected by stylistic changes from button being disabled

### DIFF
--- a/app/components/settings/profile-page/username-section.hbs
+++ b/app/components/settings/profile-page/username-section.hbs
@@ -14,6 +14,7 @@
       <EmberTooltip @text="This value is synced with your GitHub account. Click on the refresh button below to update your username." />
     {{/if}}
   </div>
+
   <div class="text-gray-400 text-xs mt-1">
     {{#if @user.hasAnonymousModeEnabled}}
       Your profile has anonymous mode enabled. Your GitHub username is not visible to others.
@@ -22,21 +23,23 @@
     {{/if}}
   </div>
 
-  <TertiaryButtonWithSpinner
-    @size="extra-small"
-    class="mt-4"
-    @shouldShowSpinner={{this.isSyncingUsernameFromGitHub}}
-    @isDisabled={{this.currentUser.hasAnonymousModeEnabled}}
-    {{on "click" this.refreshFromGitHub}}
-    data-test-refresh-from-github-button
-  >
-    <div class="flex items-center gap-1">
-      {{svg-jar "refresh" class="w-4 h-4 text-gray-400"}}
-      Refresh from GitHub
-    </div>
+  <div>
+    <TertiaryButtonWithSpinner
+      @size="extra-small"
+      class="mt-4"
+      @shouldShowSpinner={{this.isSyncingUsernameFromGitHub}}
+      @isDisabled={{this.currentUser.hasAnonymousModeEnabled}}
+      {{on "click" this.refreshFromGitHub}}
+      data-test-refresh-from-github-button
+    >
+      <div class="flex items-center gap-1">
+        {{svg-jar "refresh" class="w-4 h-4 text-gray-400"}}
+        Refresh from GitHub
+      </div>
+    </TertiaryButtonWithSpinner>
 
     {{#if this.currentUser.hasAnonymousModeEnabled}}
       <EmberTooltip @text="Your profile has anonymous mode enabled. Your GitHub username is not visible to others." />
     {{/if}}
-  </TertiaryButtonWithSpinner>
+  </div>
 </Settings::FormSection>

--- a/tests/acceptance/settings-page/profile-test.js
+++ b/tests/acceptance/settings-page/profile-test.js
@@ -1,6 +1,7 @@
 import profilePage from 'codecrafters-frontend/tests/pages/settings/profile-page';
 import userPage from 'codecrafters-frontend/tests/pages/user-page';
 import testScenario from 'codecrafters-frontend/mirage/scenarios/test';
+import { assertTooltipContent } from 'ember-tooltips/test-support';
 import { module, test } from 'qunit';
 import { setupApplicationTest } from 'codecrafters-frontend/tests/helpers';
 import { signIn, signInAsSubscriber } from 'codecrafters-frontend/tests/support/authentication-helpers';
@@ -74,6 +75,12 @@ module('Acceptance | settings-page | profile-test', function (hooks) {
     assert.strictEqual(userPage.githubDetails.username, 'Anonymous');
 
     await profilePage.visit();
+    await profilePage.refreshFromGitHubButton.hover();
+
+    assertTooltipContent(assert, {
+      contentString: 'Your profile has anonymous mode enabled. Your GitHub username is not visible to others.',
+    });
+
     await profilePage.refreshFromGitHubButton.click();
     await profilePage.accountDropdown.toggle();
     await profilePage.accountDropdown.clickOnLink('Your Profile');

--- a/tests/pages/settings/profile-page.ts
+++ b/tests/pages/settings/profile-page.ts
@@ -14,6 +14,7 @@ export default createPage({
   },
 
   refreshFromGitHubButton: {
+    hover: triggerable('mouseenter'),
     scope: '[data-test-refresh-from-github-button]',
   },
 


### PR DESCRIPTION
**Checklist**:

- [x] I've thoroughly self-reviewed my changes
- [x] I've added tests for my changes, unless they affect admin-only areas (or are otherwise not worth testing)
- [ ] I've verified any visual changes using Percy (add a commit with `[percy]` in the message to trigger)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved visual hierarchy in the username section of the profile settings page.
  - Added tooltips for GitHub profile information on hover.

- **Tests**
  - Enhanced test coverage for the profile settings page by including tooltip content assertion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->