### PR TITLE
Fix handling of the `@lineSeparator` option changes in `CodeMirror` component

### DIFF
--- a/app/components/code-mirror.ts
+++ b/app/components/code-mirror.ts
@@ -349,6 +349,19 @@ export default class CodeMirrorComponent extends Component<Signature> {
     this.renderedView?.dispatch({
       effects: compartment?.reconfigure(handlerMethod ? await handlerMethod(newValue as undefined, this.args, optionName) : []),
     });
+
+    // some options need the document to be re-loaded after being applied
+    if (['lineSeparator'].includes(optionName)) {
+      this.renderedView?.dispatch(
+        this.renderedView?.state.update({
+          changes: {
+            from: 0,
+            to: this.renderedView.state.doc.length,
+            insert: this.args.document,
+          },
+        }),
+      );
+    }
   }
 
   @action async renderEditor(element: Element) {


### PR DESCRIPTION
Related to #1231 

### Brief

Reload `@document` in `CodeMirror` component when `@lineSeparator` argument changes

### Details

When toggling `@lineSeparator` option between `\n`, `\r\n`, `\r`, and `undefined`, the document was not reloaded or re-rendered, therefore toggling of the `@document` argument on and off was required to re-apply the setting to the rendered document. This fixes it.

### Demo

https://github.com/codecrafters-io/frontend/assets/493875/ca5bc9cf-d53a-4f11-9af1-5c57cce2df56

### Checklist

- [x] I've thoroughly self-reviewed my changes
- [x]  I've added tests for my changes, unless they affect admin-only areas (or are otherwise not worth testing)
- [x] I've verified any visual changes using Percy (add a commit with `[percy]` in the message to trigger)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced the `CodeMirrorComponent` to handle specific options that require the document to be reloaded, improving the overall functionality and user experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->