### PR TITLE
CC-981 Support toggling concept status

### DIFF
--- a/app/components/concept-admin/header.hbs
+++ b/app/components/concept-admin/header.hbs
@@ -11,8 +11,15 @@
           <span class="font-bold uppercase tracking-wide">Back to Concept</span>
         </LinkTo>
 
-        <div class="flex items-center mb-4">
+        <div class="flex flex-col justify-center mb-4">
           <div class="font-bold text-2xl text-gray-700">{{or @concept.title "Unnamed Concept"}}</div>
+
+          <LinkTo @route="concept-admin.basic-details" @model={{@concept.lastPersistedSlug}} class="mt-1">
+            <Pill @color="gray">
+              Draft
+              <EmberTooltip @text="This concept is only visible to staff" />
+            </Pill>
+          </LinkTo>
         </div>
       </div>
       <div>

--- a/app/components/concept-admin/header.hbs
+++ b/app/components/concept-admin/header.hbs
@@ -1,4 +1,4 @@
-<div class="border-b">
+<div class="border-b" data-test-concept-admin-header>
   <div class="container lg:max-w-screen-lg mx-auto pt-8 px-6">
     <div class="flex justify-between items-start">
       <div>
@@ -15,7 +15,7 @@
           <div class="font-bold text-2xl text-gray-700">{{or @concept.title "Unnamed Concept"}}</div>
 
           <LinkTo @route="concept-admin.basic-details" @model={{@concept.lastPersistedSlug}} class="mt-1">
-            <Pill @color="gray">
+            <Pill @color="gray" data-test-draft-label>
               Draft
               <EmberTooltip @text="This concept is only visible to staff" />
             </Pill>

--- a/app/components/concept-admin/header.hbs
+++ b/app/components/concept-admin/header.hbs
@@ -14,12 +14,14 @@
         <div class="flex flex-col justify-center mb-4">
           <div class="font-bold text-2xl text-gray-700">{{or @concept.title "Unnamed Concept"}}</div>
 
-          <LinkTo @route="concept-admin.basic-details" @model={{@concept.lastPersistedSlug}} class="mt-1">
-            <Pill @color="gray" data-test-draft-label>
-              Draft
-              <EmberTooltip @text="This concept is only visible to staff" />
-            </Pill>
-          </LinkTo>
+          {{#if @concept.statusIsDraft}}
+            <LinkTo @route="concept-admin.basic-details" @model={{@concept.lastPersistedSlug}} class="mt-1">
+              <Pill @color="gray" data-test-draft-label>
+                Draft
+                <EmberTooltip @text="This concept is only visible to staff" />
+              </Pill>
+            </LinkTo>
+          {{/if}}
         </div>
       </div>
       <div>

--- a/app/components/concepts-page/concept-card.hbs
+++ b/app/components/concepts-page/concept-card.hbs
@@ -13,6 +13,13 @@
       {{#if (current-user-is-concept-author @concept)}}
         <Pill @color="green">Yours</Pill>
       {{/if}}
+
+      {{#if (eq @concept.status "draft")}}
+        <Pill @color="gray">
+          Draft
+          <EmberTooltip @text="This concept is only visible to staff" />
+        </Pill>
+      {{/if}}
     </div>
 
     <div class="prose prose-sm mb-5">

--- a/app/components/concepts-page/concept-card.hbs
+++ b/app/components/concepts-page/concept-card.hbs
@@ -15,7 +15,7 @@
       {{/if}}
 
       {{#if (eq @concept.status "draft")}}
-        <Pill @color="gray">
+        <Pill @color="gray" data-test-draft-label>
           Draft
           <EmberTooltip @text="This concept is only visible to staff" />
         </Pill>

--- a/app/components/concepts-page/concept-card.hbs
+++ b/app/components/concepts-page/concept-card.hbs
@@ -14,7 +14,7 @@
         <Pill @color="green">Yours</Pill>
       {{/if}}
 
-      {{#if (eq @concept.status "draft")}}
+      {{#if @concept.statusIsDraft}}
         <Pill @color="gray" data-test-draft-label>
           Draft
           <EmberTooltip @text="This concept is only visible to staff" />

--- a/app/controllers/concept-admin/basic-details.ts
+++ b/app/controllers/concept-admin/basic-details.ts
@@ -11,11 +11,20 @@ import config from 'codecrafters-frontend/config/environment';
 export default class BasicDetailsController extends Controller {
   @service declare store: Store;
   @service declare router: RouterService;
+
+  @tracked isConceptPublished = false;
   @tracked wasSavedRecently = false;
 
   declare model: {
     concept: ConceptModel;
   };
+
+  @action
+  handlePublishConceptToggled() {
+    this.isConceptPublished = !this.isConceptPublished;
+    this.model.concept.status = this.isConceptPublished ? 'published' : 'draft';
+    this.updateConceptDetails.perform();
+  }
 
   @action
   handleValueUpdated() {

--- a/app/controllers/concept-admin/basic-details.ts
+++ b/app/controllers/concept-admin/basic-details.ts
@@ -12,7 +12,6 @@ export default class BasicDetailsController extends Controller {
   @service declare store: Store;
   @service declare router: RouterService;
 
-  @tracked isConceptPublished = false;
   @tracked wasSavedRecently = false;
 
   declare model: {
@@ -21,8 +20,7 @@ export default class BasicDetailsController extends Controller {
 
   @action
   handlePublishConceptToggled() {
-    this.isConceptPublished = !this.isConceptPublished;
-    this.model.concept.status = this.isConceptPublished ? 'published' : 'draft';
+    this.model.concept.status = this.model.concept.status === 'draft' ? 'published' : 'draft';
     this.updateConceptDetails.perform();
   }
 

--- a/app/controllers/concepts.ts
+++ b/app/controllers/concepts.ts
@@ -34,6 +34,7 @@ export default class ConceptsController extends Controller {
   get visibleConcepts(): ConceptModel[] {
     return this.model.concepts.filter((concept) => {
       const canViewDraft = this.currentUser.isStaff || concept.author === this.currentUser;
+
       return concept.statusIsPublished || (concept.statusIsDraft && canViewDraft);
     });
   }

--- a/app/controllers/concepts.ts
+++ b/app/controllers/concepts.ts
@@ -19,21 +19,21 @@ export default class ConceptsController extends Controller {
   @service declare router: RouterService;
   @service declare authenticator: AuthenticatorService;
 
-  get currentUser(): UserModel {
+  get currentUser(): UserModel | null {
     return this.authenticator.currentUser as UserModel;
   }
 
   get shouldShowCreateConceptButton(): boolean {
-    if (!this.authenticator.currentUser) {
+    if (!this.currentUser) {
       return false;
     }
 
-    return this.authenticator.currentUser.isConceptAuthor || this.authenticator.currentUser.isStaff;
+    return this.currentUser.isConceptAuthor || this.currentUser.isStaff;
   }
 
   get visibleConcepts(): ConceptModel[] {
     return this.model.concepts.filter((concept) => {
-      const canViewDraft = this.currentUser.isStaff || concept.author === this.currentUser;
+      const canViewDraft = this.currentUser && this.currentUser.isStaff || concept.author === this.currentUser;
 
       return concept.statusIsPublished || (concept.statusIsDraft && canViewDraft);
     });

--- a/app/controllers/concepts.ts
+++ b/app/controllers/concepts.ts
@@ -20,7 +20,7 @@ export default class ConceptsController extends Controller {
   @service declare authenticator: AuthenticatorService;
 
   get currentUser(): UserModel | null {
-    return this.authenticator.currentUser as UserModel;
+    return this.authenticator.currentUser;
   }
 
   get shouldShowCreateConceptButton(): boolean {
@@ -33,7 +33,7 @@ export default class ConceptsController extends Controller {
 
   get visibleConcepts(): ConceptModel[] {
     return this.model.concepts.filter((concept) => {
-      const canViewDraft = (this.currentUser && this.currentUser.isStaff) || concept.author === this.currentUser;
+      const canViewDraft = this.currentUser?.isStaff || concept.author === this.currentUser;
 
       return concept.statusIsPublished || (concept.statusIsDraft && canViewDraft);
     });

--- a/app/controllers/concepts.ts
+++ b/app/controllers/concepts.ts
@@ -33,7 +33,7 @@ export default class ConceptsController extends Controller {
 
   get visibleConcepts(): ConceptModel[] {
     return this.model.concepts.filter((concept) => {
-      const canViewDraft = this.currentUser && this.currentUser.isStaff || concept.author === this.currentUser;
+      const canViewDraft = (this.currentUser && this.currentUser.isStaff) || concept.author === this.currentUser;
 
       return concept.statusIsPublished || (concept.statusIsDraft && canViewDraft);
     });

--- a/app/controllers/concepts.ts
+++ b/app/controllers/concepts.ts
@@ -1,11 +1,12 @@
 import ConceptModel from 'codecrafters-frontend/models/concept';
 import Controller from '@ember/controller';
-import RouterService from '@ember/routing/router-service';
-import Store from '@ember-data/store';
 import { action } from '@ember/object';
 import { service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
-import AuthenticatorService from 'codecrafters-frontend/services/authenticator';
+import type AuthenticatorService from 'codecrafters-frontend/services/authenticator';
+import type RouterService from '@ember/routing/router-service';
+import type Store from '@ember-data/store';
+import type UserModel from 'codecrafters-frontend/models/user';
 
 export default class ConceptsController extends Controller {
   declare model: {
@@ -18,12 +19,23 @@ export default class ConceptsController extends Controller {
   @service declare router: RouterService;
   @service declare authenticator: AuthenticatorService;
 
+  get currentUser(): UserModel {
+    return this.authenticator.currentUser as UserModel;
+  }
+
   get shouldShowCreateConceptButton(): boolean {
     if (!this.authenticator.currentUser) {
       return false;
     }
 
     return this.authenticator.currentUser.isConceptAuthor || this.authenticator.currentUser.isStaff;
+  }
+
+  get visibleConcepts(): ConceptModel[] {
+    return this.model.concepts.filter((concept) => {
+      const canViewDraft = this.currentUser.isStaff || concept.author === this.currentUser;
+      return concept.statusIsPublished || (concept.statusIsDraft && canViewDraft);
+    });
   }
 
   @action

--- a/app/models/concept.ts
+++ b/app/models/concept.ts
@@ -23,6 +23,7 @@ export default class ConceptModel extends Model {
   @attr() declare blocks: Array<BlockJSON>;
   @attr('string') declare slug: string;
   @attr('string') declare title: string;
+  @attr('string') declare status: string;
   @attr('date') declare updatedAt: Date;
 
   get estimatedReadingTimeInMinutes(): number {

--- a/app/models/concept.ts
+++ b/app/models/concept.ts
@@ -20,11 +20,11 @@ export default class ConceptModel extends Model {
   @hasMany('concept-engagement', { async: false, inverse: 'concept' }) declare engagements: ConceptEngagementModel[];
   @hasMany('concept-question', { async: false, inverse: 'concept' }) declare questions: SyncHasMany<ConceptQuestion>;
 
-  @attr('string') declare descriptionMarkdown: string;
   @attr() declare blocks: Array<BlockJSON>;
+  @attr('string') declare descriptionMarkdown: string;
   @attr('string') declare slug: string;
-  @attr('string') declare title: string;
   @attr('string') declare status: 'draft' | 'published';
+  @attr('string') declare title: string;
   @attr('date') declare updatedAt: Date;
 
   @equal('status', 'draft') declare statusIsDraft: boolean;

--- a/app/models/concept.ts
+++ b/app/models/concept.ts
@@ -4,6 +4,7 @@ import Model, { belongsTo } from '@ember-data/model';
 import UserModel from 'codecrafters-frontend/models/user';
 import { MarkdownBlock, ConceptAnimationBlock, ClickToContinueBlock, ConceptQuestionBlock } from 'codecrafters-frontend/utils/blocks';
 import { attr, hasMany, type SyncHasMany } from '@ember-data/model';
+import { equal } from '@ember/object/computed'; // eslint-disable-line ember/no-computed-properties-in-native-classes
 import { memberAction } from 'ember-api-actions';
 
 export type Block = MarkdownBlock | ConceptAnimationBlock | ClickToContinueBlock | ConceptQuestionBlock;
@@ -23,8 +24,11 @@ export default class ConceptModel extends Model {
   @attr() declare blocks: Array<BlockJSON>;
   @attr('string') declare slug: string;
   @attr('string') declare title: string;
-  @attr('string') declare status: string;
+  @attr('string') declare status: 'draft' | 'published';
   @attr('date') declare updatedAt: Date;
+
+  @equal('status', 'draft') declare statusIsDraft: boolean;
+  @equal('status', 'published') declare statusIsPublished: boolean;
 
   get estimatedReadingTimeInMinutes(): number {
     if (this.blocks) {

--- a/app/templates/concept-admin/basic-details.hbs
+++ b/app/templates/concept-admin/basic-details.hbs
@@ -103,6 +103,33 @@
           />
         </:content>
       </ConceptAdmin::FormSection>
+
+      <ConceptAdmin::FormSection @title="Publish">
+        <:description>
+          <label for="concept_published">
+            Unpublished concepts aren't visible to other users.
+          </label>
+        </:description>
+
+        <:content>
+          <Toggle
+            @isOn={{this.isConceptPublished}}
+            {{on "click" this.handlePublishConceptToggled}}
+            class="mt-1"
+            data-test-publish-concept-toggle
+          />
+
+          {{#if this.isConceptPublished}}
+            <div class="text-gray-400 text-xs mt-0.5">
+              This concept is published
+            </div>
+          {{else}}
+            <div class="text-gray-400 text-xs mt-0.5">
+              This concept is currently in draft mode
+            </div>
+          {{/if}}
+        </:content>
+      </ConceptAdmin::FormSection>
     </div>
   </div>
 </div>

--- a/app/templates/concept-admin/basic-details.hbs
+++ b/app/templates/concept-admin/basic-details.hbs
@@ -112,17 +112,20 @@
         </:description>
 
         <:content>
-          <Toggle @isOn={{this.isConceptPublished}} {{on "click" this.handlePublishConceptToggled}} class="mt-1" data-test-publish-concept-toggle />
+          <Toggle
+            @isOn={{@model.concept.statusIsPublished}}
+            {{on "click" this.handlePublishConceptToggled}}
+            class="mt-1"
+            data-test-publish-concept-toggle
+          />
 
-          {{#if this.isConceptPublished}}
-            <div class="text-gray-400 text-xs mt-0.5">
+          <div class="text-gray-400 text-xs mt-0.5" data-test-publish-concept-toggle-description>
+            {{#if @model.concept.statusIsPublished}}
               This concept is published
-            </div>
-          {{else}}
-            <div class="text-gray-400 text-xs mt-0.5">
+            {{else}}
               This concept is currently in draft mode
-            </div>
-          {{/if}}
+            {{/if}}
+          </div>
         </:content>
       </ConceptAdmin::FormSection>
     </div>

--- a/app/templates/concept-admin/basic-details.hbs
+++ b/app/templates/concept-admin/basic-details.hbs
@@ -112,12 +112,7 @@
         </:description>
 
         <:content>
-          <Toggle
-            @isOn={{this.isConceptPublished}}
-            {{on "click" this.handlePublishConceptToggled}}
-            class="mt-1"
-            data-test-publish-concept-toggle
-          />
+          <Toggle @isOn={{this.isConceptPublished}} {{on "click" this.handlePublishConceptToggled}} class="mt-1" data-test-publish-concept-toggle />
 
           {{#if this.isConceptPublished}}
             <div class="text-gray-400 text-xs mt-0.5">

--- a/app/templates/concepts.hbs
+++ b/app/templates/concepts.hbs
@@ -23,7 +23,7 @@
   </div>
 
   <div class="grid grid-cols-1 gap-3 md:gap-6 md:grid-cols-2">
-    {{#each this.model.concepts as |concept|}}
+    {{#each this.visibleConcepts as |concept|}}
       <ConceptsPage::ConceptCard @concept={{concept}} />
     {{/each}}
   </div>

--- a/mirage/concept-fixtures/dummy.js
+++ b/mirage/concept-fixtures/dummy.js
@@ -15,6 +15,7 @@ export default {
       'description-markdown': 'This is used for tests.',
       slug: 'dummy',
       title: 'Dummy Concept',
+      status: 'published'
     },
     relationships: {
       author: { data: { id: '8373d847-7cea-457c-94e2-7a1769d51cd6', type: 'users' } },

--- a/mirage/concept-fixtures/dummy.js
+++ b/mirage/concept-fixtures/dummy.js
@@ -15,7 +15,7 @@ export default {
       'description-markdown': 'This is used for tests.',
       slug: 'dummy',
       title: 'Dummy Concept',
-      status: 'published'
+      status: 'published',
     },
     relationships: {
       author: { data: { id: '8373d847-7cea-457c-94e2-7a1769d51cd6', type: 'users' } },

--- a/mirage/concept-fixtures/network-protocols.js
+++ b/mirage/concept-fixtures/network-protocols.js
@@ -115,6 +115,7 @@ export default {
       'description-markdown': 'Learn about various network protocols and the TCP/IP model.',
       slug: 'network-protocols',
       title: 'Network Protocols',
+      status: 'published'
     },
     relationships: {
       author: { data: null },

--- a/mirage/concept-fixtures/network-protocols.js
+++ b/mirage/concept-fixtures/network-protocols.js
@@ -115,7 +115,7 @@ export default {
       'description-markdown': 'Learn about various network protocols and the TCP/IP model.',
       slug: 'network-protocols',
       title: 'Network Protocols',
-      status: 'published'
+      status: 'published',
     },
     relationships: {
       author: { data: null },

--- a/mirage/concept-fixtures/tcp-overview.js
+++ b/mirage/concept-fixtures/tcp-overview.js
@@ -168,6 +168,7 @@ export default {
       'description-markdown': 'Learn about the TCP protocol and how it works.',
       slug: 'tcp-overview',
       title: 'TCP: An Overview',
+      status: 'published'
     },
     relationships: {
       author: { data: null },

--- a/mirage/concept-fixtures/tcp-overview.js
+++ b/mirage/concept-fixtures/tcp-overview.js
@@ -168,7 +168,7 @@ export default {
       'description-markdown': 'Learn about the TCP protocol and how it works.',
       slug: 'tcp-overview',
       title: 'TCP: An Overview',
-      status: 'published'
+      status: 'published',
     },
     relationships: {
       author: { data: null },

--- a/mirage/utils/create-concept-from-fixture.js
+++ b/mirage/utils/create-concept-from-fixture.js
@@ -4,6 +4,7 @@ export default function createConceptFromFixture(server, conceptFixture) {
   const concept = server.create('concept', {
     title: conceptAttributes['title'],
     slug: conceptAttributes['slug'],
+    status: conceptAttributes['status'],
     descriptionMarkdown: conceptAttributes['description-markdown'],
     blocks: conceptAttributes['blocks'],
   });

--- a/tests/acceptance/concept-admin/edit-basic-details-test.js
+++ b/tests/acceptance/concept-admin/edit-basic-details-test.js
@@ -5,10 +5,10 @@ import { module, test } from 'qunit';
 import { setupApplicationTest } from 'codecrafters-frontend/tests/helpers';
 import { signInAsStaff } from 'codecrafters-frontend/tests/support/authentication-helpers';
 
-module('Acceptance | concept-admin | edit-basic-details', function(hooks) {
+module('Acceptance | concept-admin | edit-basic-details', function (hooks) {
   setupApplicationTest(hooks);
 
-  test('editing the slug updates the url of other tab links', async function(assert) {
+  test('editing the slug updates the url of other tab links', async function (assert) {
     testScenario(this.server);
     signInAsStaff(this.owner, this.server);
 
@@ -32,7 +32,7 @@ module('Acceptance | concept-admin | edit-basic-details', function(hooks) {
     assert.strictEqual(currentURL(), '/concepts/new-slug/admin/blocks');
   });
 
-  test('pasting a link automatically converts the link to markdown format', async function(assert) {
+  test('pasting a link automatically converts the link to markdown format', async function (assert) {
     testScenario(this.server);
     signInAsStaff(this.owner, this.server);
 
@@ -67,7 +67,7 @@ module('Acceptance | concept-admin | edit-basic-details', function(hooks) {
     assert.strictEqual(basicDetailsPageTextarea.selectionStart, basicDetailsPageTextarea.selectionEnd);
   });
 
-  test('toggling publish concept changes concept status from draft to published', async function(assert) {
+  test('toggling publish concept changes concept status from draft to published', async function (assert) {
     testScenario(this.server);
     signInAsStaff(this.owner, this.server);
 

--- a/tests/acceptance/concept-admin/edit-basic-details-test.js
+++ b/tests/acceptance/concept-admin/edit-basic-details-test.js
@@ -5,10 +5,10 @@ import { module, test } from 'qunit';
 import { setupApplicationTest } from 'codecrafters-frontend/tests/helpers';
 import { signInAsStaff } from 'codecrafters-frontend/tests/support/authentication-helpers';
 
-module('Acceptance | concept-admin | edit-basic-details', function (hooks) {
+module('Acceptance | concept-admin | edit-basic-details', function(hooks) {
   setupApplicationTest(hooks);
 
-  test('editing the slug updates the url of other tab links', async function (assert) {
+  test('editing the slug updates the url of other tab links', async function(assert) {
     testScenario(this.server);
     signInAsStaff(this.owner, this.server);
 
@@ -32,7 +32,7 @@ module('Acceptance | concept-admin | edit-basic-details', function (hooks) {
     assert.strictEqual(currentURL(), '/concepts/new-slug/admin/blocks');
   });
 
-  test('pasting a link automatically converts the link to markdown format', async function (assert) {
+  test('pasting a link automatically converts the link to markdown format', async function(assert) {
     testScenario(this.server);
     signInAsStaff(this.owner, this.server);
 
@@ -65,5 +65,28 @@ module('Acceptance | concept-admin | edit-basic-details', function (hooks) {
     assert.strictEqual(basicDetailsPage.form.inputFields[2].value, 'this [url](https://test.url.com) should be changed');
     assert.strictEqual(basicDetailsPageTextarea.selectionStart, 32);
     assert.strictEqual(basicDetailsPageTextarea.selectionStart, basicDetailsPageTextarea.selectionEnd);
+  });
+
+  test('toggling publish concept changes concept status from draft to published', async function(assert) {
+    testScenario(this.server);
+    signInAsStaff(this.owner, this.server);
+
+    const concept = this.server.create('concept', {
+      slug: 'dummy',
+      blocks: [
+        {
+          type: 'markdown',
+          args: {
+            markdown: `This is the first markdown block.`,
+          },
+        },
+      ],
+      status: 'draft',
+    });
+
+    await basicDetailsPage.visit({ concept_slug: 'dummy' });
+    await basicDetailsPage.publishConceptToggle.click();
+
+    assert.strictEqual(concept.reload().status, 'published', 'Concept status should be updated to published');
   });
 });

--- a/tests/acceptance/concept-admin/view-basic-details-test.js
+++ b/tests/acceptance/concept-admin/view-basic-details-test.js
@@ -19,4 +19,28 @@ module('Acceptance | concept-admin | view-basic-details', function (hooks) {
 
     await percySnapshot('Concept Admin - Basic Details');
   });
+
+  test('draft label is present in concept admin page for draft concepts', async function (assert) {
+    testScenario(this.server);
+    signInAsStaff(this.owner, this.server);
+
+    this.server.create('concept', {
+      slug: 'new-concept',
+      title: 'New Concept',
+      'description-markdown': 'This is a new concept.',
+      blocks: [
+        {
+          type: 'markdown',
+          args: {
+            markdown: `This is the first markdown block.`,
+          },
+        },
+      ],
+      status: 'draft',
+    });
+
+    await basicDetailsPage.visit({ concept_slug: 'new-concept' });
+
+    assert.ok(basicDetailsPage.header.draftLabel.isVisible, 'Expect draft label to be visible');
+  });
 });

--- a/tests/acceptance/concept-admin/view-basic-details-test.js
+++ b/tests/acceptance/concept-admin/view-basic-details-test.js
@@ -43,4 +43,28 @@ module('Acceptance | concept-admin | view-basic-details', function (hooks) {
 
     assert.ok(basicDetailsPage.header.draftLabel.isVisible, 'Expect draft label to be visible');
   });
+
+  test('draft label is not present in concept admin page for published concepts', async function (assert) {
+    testScenario(this.server);
+    signInAsStaff(this.owner, this.server);
+
+    this.server.create('concept', {
+      slug: 'new-concept',
+      title: 'New Concept',
+      'description-markdown': 'This is a new concept.',
+      blocks: [
+        {
+          type: 'markdown',
+          args: {
+            markdown: `This is the first markdown block.`,
+          },
+        },
+      ],
+      status: 'published',
+    });
+
+    await basicDetailsPage.visit({ concept_slug: 'new-concept' });
+
+    assert.notOk(basicDetailsPage.header.draftLabel.isVisible, 'Expect draft label not to be visible');
+  });
 });

--- a/tests/acceptance/concepts-test.js
+++ b/tests/acceptance/concepts-test.js
@@ -6,11 +6,12 @@ import networkProtocols from 'codecrafters-frontend/mirage/concept-fixtures/netw
 import percySnapshot from '@percy/ember';
 import tcpOverview from 'codecrafters-frontend/mirage/concept-fixtures/tcp-overview';
 import testScenario from 'codecrafters-frontend/mirage/scenarios/test';
+import { assertTooltipContent } from 'ember-tooltips/test-support';
 import { currentURL } from '@ember/test-helpers';
 import { module, test } from 'qunit';
 import { setupApplicationTest } from 'codecrafters-frontend/tests/helpers';
 import { setupWindowMock } from 'ember-window-mock/test-support';
-import { signIn, signInAsStaff } from 'codecrafters-frontend/tests/support/authentication-helpers';
+import { signIn, signInAsStaff, signInAsSubscriber } from 'codecrafters-frontend/tests/support/authentication-helpers';
 import { setupAnimationTest } from 'ember-animated/test-support';
 
 function createConcepts(server) {
@@ -583,4 +584,98 @@ module('Acceptance | concepts-test', function (hooks) {
 
     assert.strictEqual(conceptPage.questionCards[1].focusedOption.text, '1 layer');
   });
+
+  test('only published concepts are visible to users', async function (assert) {
+    testScenario(this.server);
+    createConcepts(this.server);
+
+    const concept = this.server.create('concept', {
+      slug: 'new-concept',
+      title: 'New Concept',
+      'description-markdown': 'This is a new concept.',
+      blocks: [
+        {
+          type: 'markdown',
+          args: {
+            markdown: `This is the first markdown block.`,
+          },
+        },
+      ],
+      status: 'draft',
+    });
+
+    signInAsSubscriber(this.owner, this.server);
+
+    await conceptsPage.visit();
+    assert.strictEqual(conceptsPage.conceptCards.length, 3, 'Only published concepts are visible to users');
+  });
+
+  test('draft concepts are visible to staff', async function (assert) {
+    testScenario(this.server);
+    createConcepts(this.server);
+
+    this.server.create('concept', {
+      slug: 'new-concept',
+      title: 'New Concept',
+      'description-markdown': 'This is a new concept.',
+      blocks: [
+        {
+          type: 'markdown',
+          args: {
+            markdown: `This is the first markdown block.`,
+          },
+        },
+      ],
+      status: 'draft',
+    });
+
+    signInAsStaff(this.owner, this.server);
+
+    await conceptsPage.visit();
+
+    assert.strictEqual(conceptsPage.conceptCards.length, 4, 'Draft concepts are visible to staff');
+    assert.ok(conceptsPage.conceptCards[3].draftLabel.isVisible, 'Draft label is visible for draft concepts');
+
+    await conceptsPage.conceptCards[3].draftLabel.hover();
+
+    assertTooltipContent(assert, {
+      contentString: 'This concept is only visible to staff',
+    });
+  });
+
+  test('draft concepts are visible to concept author', async function (assert) {
+    testScenario(this.server);
+    createConcepts(this.server);
+
+    const user = server.create('user', {
+      id: 'user1',
+      avatarUrl: 'https://github.com/Gufran.png',
+      createdAt: new Date(),
+      githubUsername: 'Gufran',
+      username: 'Gufran',
+    });
+
+    this.server.create('concept', {
+      slug: 'new-concept',
+      title: 'New Concept',
+      'description-markdown': 'This is a new concept.',
+      blocks: [
+        {
+          type: 'markdown',
+          args: {
+            markdown: `This is the first markdown block.`,
+          },
+        },
+      ],
+      status: 'draft',
+      author: user,
+    });
+
+    signIn(this.owner, this.server, user);
+
+    await conceptsPage.visit();
+
+    assert.strictEqual(conceptsPage.conceptCards.length, 4, 'Draft concepts are visible to concept author');
+    assert.ok(conceptsPage.conceptCards[3].draftLabel.isVisible, 'Draft label is visible for draft concepts');
+  })
 });

--- a/tests/acceptance/concepts-test.js
+++ b/tests/acceptance/concepts-test.js
@@ -589,7 +589,7 @@ module('Acceptance | concepts-test', function (hooks) {
     testScenario(this.server);
     createConcepts(this.server);
 
-    const concept = this.server.create('concept', {
+    this.server.create('concept', {
       slug: 'new-concept',
       title: 'New Concept',
       'description-markdown': 'This is a new concept.',
@@ -647,7 +647,7 @@ module('Acceptance | concepts-test', function (hooks) {
     testScenario(this.server);
     createConcepts(this.server);
 
-    const user = server.create('user', {
+    const user = this.server.create('user', {
       id: 'user1',
       avatarUrl: 'https://github.com/Gufran.png',
       createdAt: new Date(),
@@ -677,5 +677,5 @@ module('Acceptance | concepts-test', function (hooks) {
 
     assert.strictEqual(conceptsPage.conceptCards.length, 4, 'Draft concepts are visible to concept author');
     assert.ok(conceptsPage.conceptCards[3].draftLabel.isVisible, 'Draft label is visible for draft concepts');
-  })
+  });
 });

--- a/tests/acceptance/concepts-test.js
+++ b/tests/acceptance/concepts-test.js
@@ -608,6 +608,7 @@ module('Acceptance | concepts-test', function (hooks) {
 
     await conceptsPage.visit();
     assert.strictEqual(conceptsPage.conceptCards.length, 3, 'Only published concepts are visible to users');
+    assert.notOk(conceptsPage.conceptCards.map((card) => card.title).includes('New Concept'), 'Draft concepts are not visible to users');
   });
 
   test('draft concepts are visible to staff', async function (assert) {
@@ -634,6 +635,7 @@ module('Acceptance | concepts-test', function (hooks) {
     await conceptsPage.visit();
 
     assert.strictEqual(conceptsPage.conceptCards.length, 4, 'Draft concepts are visible to staff');
+    assert.strictEqual(conceptsPage.conceptCards[3].title, 'New Concept', 'Draft concepts are visible to staff');
     assert.ok(conceptsPage.conceptCards[3].draftLabel.isVisible, 'Draft label is visible for draft concepts');
 
     await conceptsPage.conceptCards[3].draftLabel.hover();
@@ -676,6 +678,7 @@ module('Acceptance | concepts-test', function (hooks) {
     await conceptsPage.visit();
 
     assert.strictEqual(conceptsPage.conceptCards.length, 4, 'Draft concepts are visible to concept author');
+    assert.strictEqual(conceptsPage.conceptCards[3].title, 'New Concept', 'Draft concepts are visible to concept author');
     assert.ok(conceptsPage.conceptCards[3].draftLabel.isVisible, 'Draft label is visible for draft concepts');
   });
 });

--- a/tests/pages/concept-admin/basic-details-page.ts
+++ b/tests/pages/concept-admin/basic-details-page.ts
@@ -14,14 +14,14 @@ export default create({
 
   header: {
     draftLabel: {
-      scope: '[data-test-draft-label]'
+      scope: '[data-test-draft-label]',
     },
 
     scope: '[data-test-concept-admin-header]',
   },
 
   publishConceptToggle: {
-    scope: '[data-test-publish-concept-toggle]'
+    scope: '[data-test-publish-concept-toggle]',
   },
 
   visit: visitable('/concepts/:concept_slug/admin/basic-details'),

--- a/tests/pages/concept-admin/basic-details-page.ts
+++ b/tests/pages/concept-admin/basic-details-page.ts
@@ -12,5 +12,17 @@ export default create({
     scope: '[data-test-basic-details-form]',
   },
 
+  header: {
+    draftLabel: {
+      scope: '[data-test-draft-label]'
+    },
+
+    scope: '[data-test-concept-admin-header]',
+  },
+
+  publishConceptToggle: {
+    scope: '[data-test-publish-concept-toggle]'
+  },
+
   visit: visitable('/concepts/:concept_slug/admin/basic-details'),
 });

--- a/tests/pages/concept-admin/basic-details-page.ts
+++ b/tests/pages/concept-admin/basic-details-page.ts
@@ -1,4 +1,4 @@
-import { clickOnText, collection, create, fillable, triggerable, visitable } from 'ember-cli-page-object';
+import { clickOnText, collection, create, fillable, text, triggerable, visitable } from 'ember-cli-page-object';
 
 export default create({
   clickOnHeaderTabLink: clickOnText(),
@@ -24,5 +24,6 @@ export default create({
     scope: '[data-test-publish-concept-toggle]',
   },
 
+  publishConceptToggleDescriptionText: text('[data-test-publish-concept-toggle-description]'),
   visit: visitable('/concepts/:concept_slug/admin/basic-details'),
 });

--- a/tests/pages/concepts-page.ts
+++ b/tests/pages/concepts-page.ts
@@ -18,6 +18,11 @@ export default createPage({
     progressText: text('[data-test-concept-card-progress-text]'),
     progressBarStyle: attribute('style', '[data-test-concept-card-progress-bar]'),
     title: text('[data-test-concept-title]'),
+
+    draftLabel: {
+      hover: triggerable('mouseenter'),
+      scope: '[data-test-draft-label]',
+    }
   }),
 
   visit: visitable('/concepts'),

--- a/tests/pages/concepts-page.ts
+++ b/tests/pages/concepts-page.ts
@@ -22,7 +22,7 @@ export default createPage({
     draftLabel: {
       hover: triggerable('mouseenter'),
       scope: '[data-test-draft-label]',
-    }
+    },
   }),
 
   visit: visitable('/concepts'),


### PR DESCRIPTION
**Checklist**:

- [x] I've thoroughly self-reviewed my changes
- [x] I've added tests for my changes, unless they affect admin-only areas (or are otherwise not worth testing)
- [ ] I've verified any visual changes using Percy (add a commit with `[percy]` in the message to trigger)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a "Draft" label with a tooltip for draft concepts visible only to staff.
  - Added a toggle switch to control concept publishing status from the "Basic Details" admin page.

- **Enhancements**
  - Improved concept visibility filtering to show only relevant concepts based on user roles and statuses.

- **Tests**
  - Added test cases to verify the correct toggling of concept publish status and the visibility of draft labels for both draft and published concepts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->