### PR TITLE
Update sortPositionForTrack in CourseModel

### DIFF
--- a/app/models/course.ts
+++ b/app/models/course.ts
@@ -139,7 +139,7 @@ export default class CourseModel extends Model {
   }
 
   get sortPositionForTrack() {
-    const orderedSlugs = ['redis', 'http-server', 'shell', 'git', 'interpreter', 'dns-server', 'grep', 'bittorrent', 'sqlite'];
+    const orderedSlugs = ['redis', 'http-server', 'interpreter', 'shell', 'git', 'dns-server', 'grep', 'bittorrent', 'sqlite'];
     const index = orderedSlugs.indexOf(this.slug);
 
     return index === -1 ? 100 : index;


### PR DESCRIPTION
The sortPositionForTrack method in CourseModel has been updated to reorder the slugs array. The 'shell' slug has been moved to a different position.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Adjusted the course position calculation to ensure accurate sorting based on slug index.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->