### PR TITLE
add sig type standard

### DIFF
--- a/.prompts/js-to-ts-component.md
+++ b/.prompts/js-to-ts-component.md
@@ -21,7 +21,7 @@ import Component from "@glimmer/component";
 import UserModel from "codecrafters-frontend/models/user";
 import { action } from "@ember/object";
 
-type Signature = {
+interface Signature {
   Element: HTMLDivElement;
 
   Args: {

--- a/app/components/affiliate-link-page/accept-referral-button.ts
+++ b/app/components/affiliate-link-page/accept-referral-button.ts
@@ -8,7 +8,7 @@ import type RouterService from '@ember/routing/router-service';
 import type AuthenticatorService from 'codecrafters-frontend/services/authenticator';
 
 interface Signature {
-  Element: HTMLElement;
+  Element: HTMLButtonElement;
 
   Args: {
     affiliateLink: AffiliateLinkModel;

--- a/app/components/affiliate-link-page/accept-referral-container.ts
+++ b/app/components/affiliate-link-page/accept-referral-container.ts
@@ -3,7 +3,7 @@ import logoImage from '/assets/images/logo/logomark-color.svg';
 import type AffiliateLinkModel from 'codecrafters-frontend/models/affiliate-link';
 
 interface Signature {
-  Element: HTMLElement;
+  Element: HTMLDivElement;
 
   Args: {
     affiliateLink: AffiliateLinkModel;

--- a/app/components/affiliate-link-page/testimonial-list-item.ts
+++ b/app/components/affiliate-link-page/testimonial-list-item.ts
@@ -1,7 +1,7 @@
 import Component from '@glimmer/component';
 
 interface Signature {
-  Element: HTMLElement;
+  Element: HTMLDivElement;
 
   Args: {
     testimonial: {

--- a/app/components/avatar-image.ts
+++ b/app/components/avatar-image.ts
@@ -3,13 +3,13 @@ import UserModel from 'codecrafters-frontend/models/user';
 import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
 
-type Signature = {
+interface Signature {
   Element: HTMLImageElement;
 
   Args: {
     user: UserModel;
   };
-};
+}
 
 export default class AvatarImageComponent extends Component<Signature> {
   @tracked avatarImageFailedToLoad = false;

--- a/app/components/blocks/concept-question-block.ts
+++ b/app/components/blocks/concept-question-block.ts
@@ -7,7 +7,7 @@ import Prism from 'prismjs';
 import 'prismjs/components/prism-rust'; // This is the only one we use in concepts at the moment
 import { tracked } from '@glimmer/tracking';
 
-type Signature = {
+interface Signature {
   Element: HTMLDivElement;
 
   Args: {
@@ -16,7 +16,7 @@ type Signature = {
     onStepBackButtonClick: () => void;
     isCurrentBlock: boolean;
   };
-};
+}
 
 export default class ConceptQuestionBlockComponent extends Component<Signature> {
   @tracked isSubmitted = false;

--- a/app/components/blocks/markdown-block.ts
+++ b/app/components/blocks/markdown-block.ts
@@ -2,16 +2,15 @@ import Component from '@glimmer/component';
 import { MarkdownBlock } from 'codecrafters-frontend/utils/blocks';
 import { action } from '@ember/object';
 import Prism from 'prismjs';
-
 import 'prismjs/components/prism-rust'; // This is the only one we use in concepts at the moment
 
-type Signature = {
+interface Signature {
   Element: HTMLDivElement;
 
   Args: {
     model: MarkdownBlock;
   };
-};
+}
 
 export default class MarkdownBlockComponent extends Component<Signature> {
   @action

--- a/app/components/code-walkthrough-snippet.ts
+++ b/app/components/code-walkthrough-snippet.ts
@@ -10,10 +10,6 @@ interface Signature {
     filePath: string;
     highlightedLines: string;
   };
-
-  Blocks: {
-    default: [];
-  };
 }
 
 export default class CodeWalkthroughSnippetComponent extends Component<Signature> {}

--- a/app/components/comment-form.ts
+++ b/app/components/comment-form.ts
@@ -13,7 +13,7 @@ import type AuthenticatorService from 'codecrafters-frontend/services/authentica
 import type AnalyticsEventTrackerService from 'codecrafters-frontend/services/analytics-event-tracker';
 import type LanguageModel from 'codecrafters-frontend/models/language';
 
-type Signature = {
+interface Signature {
   Element: HTMLDivElement;
 
   Args: {
@@ -25,7 +25,7 @@ type Signature = {
     onSubmit?: () => void;
     target: CourseStageModel | CommunityCourseStageSolutionModel;
   };
-};
+}
 
 export default class CommentFormComponent extends Component<Signature> {
   @service declare authenticator: AuthenticatorService;

--- a/app/components/concept-admin/blocks-page.ts
+++ b/app/components/concept-admin/blocks-page.ts
@@ -5,13 +5,13 @@ import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
 import type Transition from '@ember/routing/transition';
 
-type Signature = {
+interface Signature {
   Element: HTMLDivElement;
 
   Args: {
     concept: ConceptModel;
   };
-};
+}
 
 type BlockWithMetadata = {
   id: string;

--- a/app/components/concept-admin/blocks-page/editable-block.ts
+++ b/app/components/concept-admin/blocks-page/editable-block.ts
@@ -4,7 +4,7 @@ import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
 import { ClickToContinueBlock, ConceptQuestionBlock, MarkdownBlock } from 'codecrafters-frontend/utils/blocks';
 
-type Signature = {
+interface Signature {
   Element: HTMLDivElement;
 
   Args: {
@@ -22,7 +22,7 @@ type Signature = {
   Blocks: {
     dragHandler: [];
   };
-};
+}
 
 export default class EditableBlockComponent extends Component<Signature> {
   @tracked mutableBlock: Block | null = null;

--- a/app/components/concept-admin/blocks-page/insert-block-marker-dropdown-item.ts
+++ b/app/components/concept-admin/blocks-page/insert-block-marker-dropdown-item.ts
@@ -4,9 +4,9 @@ interface Signature {
   Element: HTMLDivElement;
 
   Args: {
+    description: string;
     icon: string;
     title: string;
-    description: string;
   };
 }
 

--- a/app/components/concept-admin/blocks-page/insert-block-marker.ts
+++ b/app/components/concept-admin/blocks-page/insert-block-marker.ts
@@ -7,8 +7,8 @@ interface Signature {
   Element: HTMLDivElement;
 
   Args: {
-    onBlockAdded: (block: Block) => void;
     isVisibleWithoutHover: boolean;
+    onBlockAdded: (block: Block) => void;
   };
 }
 

--- a/app/components/concept-admin/delete-concept-modal.ts
+++ b/app/components/concept-admin/delete-concept-modal.ts
@@ -5,14 +5,14 @@ import type RouterService from '@ember/routing/router-service';
 import type Store from '@ember-data/store';
 import type ConceptModel from 'codecrafters-frontend/models/concept';
 
-type Signature = {
+interface Signature {
   Element: HTMLDivElement;
 
   Args: {
     onClose?: () => void;
     concept: ConceptModel;
   };
-};
+}
 
 export default class DeleteConceptModalComponent extends Component<Signature> {
   @service router!: RouterService;

--- a/app/components/concept-admin/delete-concept-modal.ts
+++ b/app/components/concept-admin/delete-concept-modal.ts
@@ -15,8 +15,8 @@ interface Signature {
 }
 
 export default class DeleteConceptModalComponent extends Component<Signature> {
-  @service router!: RouterService;
-  @service store!: Store;
+  @service declare router: RouterService;
+  @service declare store: Store;
 
   @action
   async deleteConcept() {

--- a/app/components/concept-admin/delete-concept-modal.ts
+++ b/app/components/concept-admin/delete-concept-modal.ts
@@ -9,8 +9,8 @@ interface Signature {
   Element: HTMLDivElement;
 
   Args: {
-    onClose?: () => void;
     concept: ConceptModel;
+    onClose?: () => void;
   };
 }
 

--- a/app/components/concept-admin/header.ts
+++ b/app/components/concept-admin/header.ts
@@ -3,13 +3,13 @@ import RouterService from '@ember/routing/router-service';
 import { inject as service } from '@ember/service';
 import ConceptModel from 'codecrafters-frontend/models/concept';
 
-type Signature = {
+interface Signature {
   Element: HTMLDivElement;
 
   Args: {
     concept: ConceptModel;
   };
-};
+}
 
 type Tab = {
   icon: string;

--- a/app/components/concept-page/question-card.ts
+++ b/app/components/concept-page/question-card.ts
@@ -5,14 +5,14 @@ import type ConceptQuestionModel from 'codecrafters-frontend/models/concept-ques
 import type { Option } from 'codecrafters-frontend/models/concept-question';
 import { next } from '@ember/runloop';
 
-type Signature = {
+interface Signature {
   Element: HTMLDivElement;
 
   Args: {
     question: ConceptQuestionModel;
     onSubmit: () => void;
   };
-};
+}
 
 export default class QuestionCardComponent extends Component<Signature> {
   @tracked selectedOptionIndex: number | null = null;

--- a/app/components/concept.ts
+++ b/app/components/concept.ts
@@ -19,7 +19,7 @@ interface Signature {
     latestConceptEngagement: ConceptEngagementModel;
   };
 
-  Element: HTMLElement;
+  Element: HTMLDivElement;
 }
 
 interface BlockGroup {

--- a/app/components/concept/continue-or-step-back.ts
+++ b/app/components/concept/continue-or-step-back.ts
@@ -6,12 +6,12 @@ interface Signature {
   Element: HTMLDivElement;
 
   Args: {
+    continueButtonText: string;
     onContinueButtonClick: () => void;
     onStepBackButtonClick: () => void;
     shouldHighlightKeyboardShortcuts: boolean;
-    shouldShowStepBackButton: boolean;
     shouldShowContinueButton: boolean;
-    continueButtonText: string;
+    shouldShowStepBackButton: boolean;
   };
 }
 

--- a/app/components/contest-page/header.ts
+++ b/app/components/contest-page/header.ts
@@ -5,14 +5,14 @@ import { formatDistanceStrict } from 'date-fns';
 import { formatInTimeZone } from 'date-fns-tz';
 import { inject as service } from '@ember/service';
 
-type Signature = {
+interface Signature {
   Element: HTMLDivElement;
 
   Args: {
     allContests: ContestModel[];
     contest: ContestModel;
   };
-};
+}
 
 export default class ContestPageHeaderComponent extends Component<Signature> {
   @service declare date: DateService;

--- a/app/components/contest-page/how-it-works-card.ts
+++ b/app/components/contest-page/how-it-works-card.ts
@@ -1,13 +1,13 @@
 import Component from '@glimmer/component';
 import ContestModel from 'codecrafters-frontend/models/contest';
 
-type Signature = {
+interface Signature {
   Element: HTMLDivElement;
 
   Args: {
     contest: ContestModel;
   };
-};
+}
 
 export default class ContestPageHowItWorksCardComponent extends Component<Signature> {}
 

--- a/app/components/contest-page/leaderboard-card.ts
+++ b/app/components/contest-page/leaderboard-card.ts
@@ -6,7 +6,7 @@ import type LanguageModel from 'codecrafters-frontend/models/language';
 import type LeaderboardEntryModel from 'codecrafters-frontend/models/leaderboard-entry';
 import type UserModel from 'codecrafters-frontend/models/user';
 
-type Signature = {
+interface Signature {
   Element: HTMLDivElement;
 
   Args: {
@@ -15,7 +15,7 @@ type Signature = {
     topEntries: LeaderboardEntryModel[];
     surroundingEntries: LeaderboardEntryModel[];
   };
-};
+}
 
 export default class ContestPageLeaderboardCardComponent extends Component<Signature> {
   @service declare authenticator: AuthenticatorService;

--- a/app/components/contest-page/leaderboard-entry.ts
+++ b/app/components/contest-page/leaderboard-entry.ts
@@ -4,14 +4,14 @@ import type LanguageModel from 'codecrafters-frontend/models/language';
 import type LeaderboardEntryModel from 'codecrafters-frontend/models/leaderboard-entry';
 import { inject as service } from '@ember/service';
 
-type Signature = {
+interface Signature {
   Element: HTMLAnchorElement;
 
   Args: {
     entry: LeaderboardEntryModel;
     languages: LanguageModel[];
   };
-};
+}
 
 export default class ContestPageLeaderboardEntryComponent extends Component<Signature> {
   @service declare authenticator: AuthenticatorService;

--- a/app/components/contest-page/navigation.ts
+++ b/app/components/contest-page/navigation.ts
@@ -3,14 +3,14 @@ import ContestModel from 'codecrafters-frontend/models/contest';
 import DateService from 'codecrafters-frontend/services/date';
 import { inject as service } from '@ember/service';
 
-type Signature = {
+interface Signature {
   Element: HTMLDivElement;
 
   Args: {
     allContests: ContestModel[];
     contest: ContestModel;
   };
-};
+}
 
 export default class ContestPageNavigationComponent extends Component<Signature> {
   @service declare date: DateService;

--- a/app/components/contest-page/prize-details-card.ts
+++ b/app/components/contest-page/prize-details-card.ts
@@ -1,14 +1,14 @@
 import Component from '@glimmer/component';
 import ContestModel from 'codecrafters-frontend/models/contest';
 
-type Signature = {
+interface Signature {
   Element: HTMLDivElement;
 
   Args: {
     allContests: ContestModel[];
     contest: ContestModel;
   };
-};
+}
 
 export default class ContestPagePrizeDetailsCardComponent extends Component<Signature> {}
 

--- a/app/components/copyable-code.ts
+++ b/app/components/copyable-code.ts
@@ -5,7 +5,7 @@ import { later } from '@ember/runloop';
 import { tracked } from '@glimmer/tracking';
 
 interface Signature {
-  Element: HTMLElement;
+  Element: HTMLDivElement;
 
   Args: {
     backgroundColor?: 'gray' | 'white';

--- a/app/components/copyable-terminal-command-with-variants.ts
+++ b/app/components/copyable-terminal-command-with-variants.ts
@@ -8,7 +8,7 @@ export type CopyableTerminalCommandVariant = {
 };
 
 interface Signature {
-  Element: HTMLElement;
+  Element: HTMLDivElement;
 
   Args: {
     onCopyButtonClick?: () => void;

--- a/app/components/copyable-terminal-command.ts
+++ b/app/components/copyable-terminal-command.ts
@@ -6,7 +6,7 @@ import { tracked } from '@glimmer/tracking';
 import fade from 'ember-animated/transitions/fade';
 
 interface Signature {
-  Element: HTMLElement;
+  Element: HTMLDivElement;
 
   Args: {
     commands: string[];

--- a/app/components/course-admin/buildpacks-page/buildpack-item.ts
+++ b/app/components/course-admin/buildpacks-page/buildpack-item.ts
@@ -3,13 +3,13 @@ import { inject as service } from '@ember/service';
 import RouterService from '@ember/routing/router-service';
 import BuildpackModel from 'codecrafters-frontend/models/buildpack';
 
-type Signature = {
+interface Signature {
   Element: HTMLDivElement;
 
   Args: {
     buildpack: BuildpackModel;
   };
-};
+}
 
 export default class BuildpackComponent extends Component<Signature> {
   @service declare router: RouterService;

--- a/app/components/course-admin/code-example-evaluator-page/accuracy-section.ts
+++ b/app/components/course-admin/code-example-evaluator-page/accuracy-section.ts
@@ -6,13 +6,13 @@ import type { Tab } from 'codecrafters-frontend/components/tabs';
 import type CommunitySolutionEvaluatorModel from 'codecrafters-frontend/models/community-solution-evaluator';
 import type { CourseStageParticipationAnalysisStatistic } from 'codecrafters-frontend/models/course-stage-participation-analysis';
 
-export type Signature = {
+export interface Signature {
   Element: HTMLDivElement;
 
   Args: {
     evaluator: CommunitySolutionEvaluatorModel;
   };
-};
+}
 
 export default class AccuracySection extends Component<Signature> {
   @tracked activeTabSlug: 'false_positives' | 'false_negatives' | 'matches' = 'false_positives';

--- a/app/components/course-admin/code-example-evaluator-page/evaluations-section.ts
+++ b/app/components/course-admin/code-example-evaluator-page/evaluations-section.ts
@@ -5,7 +5,7 @@ import type { Tab } from 'codecrafters-frontend/components/tabs';
 import type CommunitySolutionEvaluationModel from 'codecrafters-frontend/models/community-solution-evaluation';
 import type CommunitySolutionEvaluatorModel from 'codecrafters-frontend/models/community-solution-evaluator';
 
-export type Signature = {
+export interface Signature {
   Element: HTMLDivElement;
 
   Args: {
@@ -14,7 +14,7 @@ export type Signature = {
     failEvaluations: CommunitySolutionEvaluationModel[];
     unsureEvaluations: CommunitySolutionEvaluationModel[];
   };
-};
+}
 
 export default class EvaluationsSection extends Component<Signature> {
   @tracked activeTabSlug: 'fail' | 'pass' | 'unsure' = 'fail';

--- a/app/components/course-admin/code-example-evaluator-page/prompt-template-section.ts
+++ b/app/components/course-admin/code-example-evaluator-page/prompt-template-section.ts
@@ -1,13 +1,13 @@
 import Component from '@glimmer/component';
 import type CommunitySolutionEvaluatorModel from 'codecrafters-frontend/models/community-solution-evaluator';
 
-export type Signature = {
+export interface Signature {
   Element: HTMLDivElement;
 
   Args: {
     evaluator: CommunitySolutionEvaluatorModel;
   };
-};
+}
 
 export default class PromptTemplateSection extends Component<Signature> {}
 

--- a/app/components/course-admin/code-example-page/comparison-card.ts
+++ b/app/components/course-admin/code-example-page/comparison-card.ts
@@ -5,14 +5,14 @@ import { tracked } from '@glimmer/tracking';
 import type SolutionComparisonModel from 'codecrafters-frontend/models/solution-comparison';
 import type UserModel from 'codecrafters-frontend/models/user';
 
-export type Signature = {
+export interface Signature {
   Element: HTMLDivElement;
 
   Args: {
     comparison: SolutionComparisonModel;
     firstUser: UserModel;
   };
-};
+}
 
 export default class ComparisonCard extends Component<Signature> {
   @tracked isExpanded = false;

--- a/app/components/course-admin/code-example-page/evaluation-card.ts
+++ b/app/components/course-admin/code-example-page/evaluation-card.ts
@@ -7,13 +7,13 @@ import type { Signature as TabsComponentSignature } from 'codecrafters-frontend/
 import type CommunitySolutionEvaluationModel from 'codecrafters-frontend/models/community-solution-evaluation';
 import type AuthenticatorService from 'codecrafters-frontend/services/authenticator';
 
-export type Signature = {
+export interface Signature {
   Element: HTMLDivElement;
 
   Args: {
     evaluation: CommunitySolutionEvaluationModel;
   };
-};
+}
 
 export default class EvaluationCard extends Component<Signature> {
   @service declare authenticator: AuthenticatorService;

--- a/app/components/course-admin/code-example-page/evaluation-card/evaluation-tab.ts
+++ b/app/components/course-admin/code-example-page/evaluation-card/evaluation-tab.ts
@@ -4,14 +4,14 @@ import type CommunitySolutionEvaluationModel from 'codecrafters-frontend/models/
 import { task, timeout } from 'ember-concurrency';
 import { tracked } from 'tracked-built-ins';
 
-export type Signature = {
+export interface Signature {
   Element: HTMLDivElement;
 
   Args: {
     evaluation: CommunitySolutionEvaluationModel;
     onRegenerate: () => void;
   };
-};
+}
 
 export default class EvaluationTabComponent extends Component<Signature> {
   @tracked wasRecentlyCopied = false;

--- a/app/components/course-admin/code-example-page/evaluation-card/header.ts
+++ b/app/components/course-admin/code-example-page/evaluation-card/header.ts
@@ -1,7 +1,7 @@
 import Component from '@glimmer/component';
 import type CommunitySolutionEvaluationModel from 'codecrafters-frontend/models/community-solution-evaluation';
 
-export type Signature = {
+export interface Signature {
   Element: HTMLDivElement;
 
   Args: {
@@ -9,7 +9,7 @@ export type Signature = {
     isExpanded: boolean;
     onCloseButtonClick: () => void;
   };
-};
+}
 
 export default class EvaluationCardHeaderComponent extends Component<Signature> {}
 

--- a/app/components/course-admin/code-example-page/evaluation-card/prompt-tab.ts
+++ b/app/components/course-admin/code-example-page/evaluation-card/prompt-tab.ts
@@ -1,13 +1,13 @@
 import Component from '@glimmer/component';
 import type CommunitySolutionEvaluationModel from 'codecrafters-frontend/models/community-solution-evaluation';
 
-export type Signature = {
+export interface Signature {
   Element: HTMLDivElement;
 
   Args: {
     evaluation: CommunitySolutionEvaluationModel;
   };
-};
+}
 
 export default class PromptTabComponent extends Component<Signature> {}
 

--- a/app/components/course-admin/code-example-page/evaluation-card/trusted-evaluation-tab.ts
+++ b/app/components/course-admin/code-example-page/evaluation-card/trusted-evaluation-tab.ts
@@ -4,13 +4,13 @@ import type CommunitySolutionEvaluationModel from 'codecrafters-frontend/models/
 import { action } from '@ember/object';
 import { service } from '@ember/service';
 
-export type Signature = {
+export interface Signature {
   Element: HTMLDivElement;
 
   Args: {
     evaluation: CommunitySolutionEvaluationModel;
   };
-};
+}
 
 export default class TrustedEvaluationTabComponent extends Component<Signature> {
   @service declare store: Store;

--- a/app/components/course-admin/feedback-page/feedback-submission-list-item.ts
+++ b/app/components/course-admin/feedback-page/feedback-submission-list-item.ts
@@ -2,11 +2,11 @@ import { action } from '@ember/object';
 import Component from '@glimmer/component';
 import CourseStageFeedbackSubmissionModel from 'codecrafters-frontend/models/course-stage-feedback-submission';
 
-type Signature = {
+interface Signature {
   Args: {
     feedbackSubmission: CourseStageFeedbackSubmissionModel; // Replace 'any' with the actual type of feedbackSubmission
   };
-};
+}
 
 export default class FeedbackSubmissionListItemComponent extends Component<Signature> {
   @action

--- a/app/components/course-admin/feedback-page/feedback-submission-list-item.ts
+++ b/app/components/course-admin/feedback-page/feedback-submission-list-item.ts
@@ -4,7 +4,7 @@ import CourseStageFeedbackSubmissionModel from 'codecrafters-frontend/models/cou
 
 interface Signature {
   Args: {
-    feedbackSubmission: CourseStageFeedbackSubmissionModel; // Replace 'any' with the actual type of feedbackSubmission
+    feedbackSubmission: CourseStageFeedbackSubmissionModel;
   };
 }
 

--- a/app/components/course-admin/feedback-page/feedback-submission-list-item.ts
+++ b/app/components/course-admin/feedback-page/feedback-submission-list-item.ts
@@ -3,6 +3,8 @@ import Component from '@glimmer/component';
 import CourseStageFeedbackSubmissionModel from 'codecrafters-frontend/models/course-stage-feedback-submission';
 
 interface Signature {
+  Element: HTMLDivElement;
+
   Args: {
     feedbackSubmission: CourseStageFeedbackSubmissionModel;
   };

--- a/app/components/course-admin/header.ts
+++ b/app/components/course-admin/header.ts
@@ -3,13 +3,13 @@ import RouterService from '@ember/routing/router-service';
 import { inject as service } from '@ember/service';
 import type CourseModel from 'codecrafters-frontend/models/course';
 
-type Signature = {
+interface Signature {
   Element: HTMLDivElement;
 
   Args: {
     course: CourseModel;
   };
-};
+}
 
 type Tab = {
   icon: string;

--- a/app/components/course-admin/stage-insights-index-page/stage-list-item.ts
+++ b/app/components/course-admin/stage-insights-index-page/stage-list-item.ts
@@ -1,13 +1,13 @@
 import Component from '@glimmer/component';
 import type CourseStageModel from 'codecrafters-frontend/models/course-stage';
 
-type Signature = {
+interface Signature {
   Element: HTMLAnchorElement;
 
   Args: {
     stage: CourseStageModel;
   };
-};
+}
 
 export default class StageListItemComponent extends Component<Signature> {
   get participationAnalysis() {

--- a/app/components/course-admin/stage-insights-index-page/stage-list-item/statistic.ts
+++ b/app/components/course-admin/stage-insights-index-page/stage-list-item/statistic.ts
@@ -1,13 +1,13 @@
 import Component from '@glimmer/component';
 import { type CourseStageParticipationAnalysisStatistic } from 'codecrafters-frontend/models/course-stage-participation-analysis';
 
-type Signature = {
+interface Signature {
   Element: HTMLDivElement;
 
   Args: {
     statistic: CourseStageParticipationAnalysisStatistic;
   };
-};
+}
 
 export default class StatisticComponent extends Component<Signature> {
   get valueColorClasses(): string {

--- a/app/components/course-admin/stage-insights-page/header.ts
+++ b/app/components/course-admin/stage-insights-page/header.ts
@@ -1,13 +1,13 @@
 import Component from '@glimmer/component';
 import type CourseStageModel from 'codecrafters-frontend/models/course-stage';
 
-type Signature = {
+interface Signature {
   Element: HTMLDivElement;
 
   Args: {
     stage: CourseStageModel;
   };
-};
+}
 
 export default class HeaderComponent extends Component<Signature> {}
 

--- a/app/components/course-admin/stage-insights-page/participation-list-item.ts
+++ b/app/components/course-admin/stage-insights-page/participation-list-item.ts
@@ -1,13 +1,13 @@
 import Component from '@glimmer/component';
 import type CourseStageParticipationModel from 'codecrafters-frontend/models/course-stage-participation';
 
-type Signature = {
+interface Signature {
   Element: HTMLAnchorElement;
 
   Args: {
     participation: CourseStageParticipationModel;
   };
-};
+}
 
 export default class ParticipationListItemComponent extends Component<Signature> {}
 

--- a/app/components/course-admin/stage-insights-page/participation-list-section.ts
+++ b/app/components/course-admin/stage-insights-page/participation-list-section.ts
@@ -3,7 +3,7 @@ import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 import type CourseStageParticipationModel from 'codecrafters-frontend/models/course-stage-participation';
 
-type Signature = {
+interface Signature {
   Element: HTMLDivElement;
 
   Args: {
@@ -11,7 +11,7 @@ type Signature = {
     tooltipText: string;
     participations: CourseStageParticipationModel[];
   };
-};
+}
 
 export default class ParticipationListSectionComponent extends Component<Signature> {
   @tracked shouldShowParticipationsWithSingleAttempt = false;

--- a/app/components/course-admin/stage-insights-page/participation-list.ts
+++ b/app/components/course-admin/stage-insights-page/participation-list.ts
@@ -3,13 +3,13 @@ import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 import type CourseStageParticipationModel from 'codecrafters-frontend/models/course-stage-participation';
 
-type Signature = {
+interface Signature {
   Element: HTMLDivElement;
 
   Args: {
     participations: CourseStageParticipationModel[];
   };
-};
+}
 
 export default class ParticipationListComponent extends Component<Signature> {
   @tracked visibleParticipationsCount = 10;

--- a/app/components/course-admin/stage-insights-page/statistic-card.ts
+++ b/app/components/course-admin/stage-insights-page/statistic-card.ts
@@ -1,13 +1,13 @@
 import Component from '@glimmer/component';
 import type { CourseStageParticipationAnalysisStatistic } from 'codecrafters-frontend/models/course-stage-participation-analysis';
 
-type Signature = {
+interface Signature {
   Element: HTMLDivElement;
 
   Args: {
     statistic: CourseStageParticipationAnalysisStatistic;
   };
-};
+}
 
 export default class StatisticCardComponent extends Component<Signature> {
   get valueColorClasses(): string {

--- a/app/components/course-admin/submissions-page/submission-details/header-container-row.ts
+++ b/app/components/course-admin/submissions-page/submission-details/header-container-row.ts
@@ -2,9 +2,11 @@ import Component from '@glimmer/component';
 
 interface Signature {
   Element: HTMLTableRowElement;
+
   Args: {
     title: string;
   };
+
   Blocks: {
     default: [];
   };

--- a/app/components/course-admin/submissions-page/submission-details/header-container.ts
+++ b/app/components/course-admin/submissions-page/submission-details/header-container.ts
@@ -7,11 +7,11 @@ import type AuthenticatorService from 'codecrafters-frontend/services/authentica
 import type RouterService from '@ember/routing/router-service';
 import type SubmissionModel from 'codecrafters-frontend/models/submission';
 
-export type Signature = {
+export interface Signature {
   Args: {
     submission: SubmissionModel;
   };
-};
+}
 
 export default class HeaderContainerComponent extends Component<Signature> {
   @tracked isUpdatingTesterVersion = false;

--- a/app/components/course-admin/tester-versions-page/version-list-item.ts
+++ b/app/components/course-admin/tester-versions-page/version-list-item.ts
@@ -6,13 +6,13 @@ import { action } from '@ember/object';
 import { inject as service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 
-type Signature = {
+interface Signature {
   Element: HTMLDivElement;
 
   Args: {
     courseTesterVersion: CourseTesterVersionModel;
   };
-};
+}
 
 export default class VersionListItemComponent extends Component<Signature> {
   @service declare router: RouterService;

--- a/app/components/course-admin/updates-page/update-list-item.ts
+++ b/app/components/course-admin/updates-page/update-list-item.ts
@@ -4,13 +4,13 @@ import { action } from '@ember/object';
 import { inject as service } from '@ember/service';
 import RouterService from '@ember/routing/router-service';
 
-type Signature = {
+interface Signature {
   Element: HTMLDivElement;
 
   Args: {
     update: CourseDefinitionUpdateModel;
   };
-};
+}
 
 export default class UpdateListItemComponent extends Component<Signature> {
   @service declare router: RouterService;

--- a/app/components/course-leaderboard-team-dropdown.ts
+++ b/app/components/course-leaderboard-team-dropdown.ts
@@ -2,14 +2,14 @@ import Component from '@glimmer/component';
 import TeamModel from 'codecrafters-frontend/models/team';
 import { action } from '@ember/object';
 
-type Signature = {
+interface Signature {
   Element: HTMLDivElement;
   Args: {
     team: TeamModel | null;
     teams: TeamModel[];
     onChange: (team: TeamModel | null) => void;
   };
-};
+}
 
 export default class CourseLeaderboardTeamDropdownComponent extends Component<Signature> {
   @action

--- a/app/components/course-logo.ts
+++ b/app/components/course-logo.ts
@@ -2,7 +2,7 @@ import Component from '@glimmer/component';
 import type CourseModel from 'codecrafters-frontend/models/course';
 
 interface Signature {
-  Element: HTMLElement;
+  Element: HTMLDivElement;
 
   Args: {
     course: CourseModel;

--- a/app/components/course-overview-page/stage-list.ts
+++ b/app/components/course-overview-page/stage-list.ts
@@ -1,10 +1,10 @@
 import Component from '@glimmer/component';
 import CourseModel from 'codecrafters-frontend/models/course';
 
-type Signature = {
+interface Signature {
   Args: {
     course: CourseModel;
   };
-};
+}
 
 export default class CourseOverviewPageStageListItemComponent extends Component<Signature> {}

--- a/app/components/course-page/base-stages-completed-card.ts
+++ b/app/components/course-page/base-stages-completed-card.ts
@@ -3,13 +3,13 @@ import Component from '@glimmer/component';
 import congratulationsImage from '/assets/images/icons/congratulations.png';
 import RepositoryModel from 'codecrafters-frontend/models/repository';
 
-type Signature = {
+interface Signature {
   Element: HTMLDivElement;
 
   Args: {
     repository: RepositoryModel;
   };
-};
+}
 
 export default class BaseStagesCompletedCardComponent extends Component<Signature> {
   congratulationsImage = congratulationsImage;

--- a/app/components/course-page/comment-list.ts
+++ b/app/components/course-page/comment-list.ts
@@ -10,13 +10,13 @@ import type AuthenticatorService from 'codecrafters-frontend/services/authentica
 import type Store from '@ember-data/store';
 import type UserModel from 'codecrafters-frontend/models/user';
 
-type Signature = {
+interface Signature {
   Args: {
     courseStage: CourseStageModel;
     language?: LanguageModel;
     shouldFilterByLanguage: boolean;
   };
-};
+}
 
 export default class CommentListComponent extends Component<Signature> {
   rippleSpinnerImage = rippleSpinnerImage;

--- a/app/components/course-page/comment-timeline-item.ts
+++ b/app/components/course-page/comment-timeline-item.ts
@@ -1,7 +1,7 @@
 import Component from '@glimmer/component';
 import type UserModel from 'codecrafters-frontend/models/user';
 
-type Signature = {
+interface Signature {
   Element: HTMLDivElement;
 
   Args: {
@@ -11,7 +11,7 @@ type Signature = {
   Blocks: {
     default: [];
   };
-};
+}
 
 export default class CommentTimelineItemComponent extends Component<Signature> {}
 

--- a/app/components/course-page/completed-step-notice.ts
+++ b/app/components/course-page/completed-step-notice.ts
@@ -7,14 +7,14 @@ import { action } from '@ember/object';
 import { service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 
-type Signature = {
+interface Signature {
   Element: HTMLDivElement;
 
   Args: {
     repository: RepositoryModel;
     step: Step;
   };
-};
+}
 
 export default class CompletedStepNoticeComponent extends Component<Signature> {
   @service declare analyticsEventTracker: AnalyticsEventTrackerService;

--- a/app/components/course-page/configure-extensions-modal.ts
+++ b/app/components/course-page/configure-extensions-modal.ts
@@ -6,14 +6,14 @@ import { action } from '@ember/object';
 import { inject as service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 
-type Signature = {
+interface Signature {
   Element: HTMLDivElement;
 
   Args: {
     repository: RepositoryModel;
     onClose: () => void;
   };
-};
+}
 
 export default class ConfigureExtensionsModalComponent extends Component<Signature> {
   @service declare store: Store;

--- a/app/components/course-page/configure-extensions-modal/extension-card.ts
+++ b/app/components/course-page/configure-extensions-modal/extension-card.ts
@@ -21,8 +21,8 @@ interface Signature {
 }
 
 export default class ExtensionCardComponent extends Component<Signature> {
-  @service store!: Store;
-  @service coursePageState!: CoursePageStateService;
+  @service declare store: Store;
+  @service declare coursePageState: CoursePageStateService;
 
   @tracked unsavedIsActivatedValue: boolean | null = null;
 

--- a/app/components/course-page/configure-extensions-modal/extension-card.ts
+++ b/app/components/course-page/configure-extensions-modal/extension-card.ts
@@ -11,14 +11,14 @@ import { service } from '@ember/service';
 import { task } from 'ember-concurrency';
 import { tracked } from '@glimmer/tracking';
 
-type Signature = {
+interface Signature {
   Element: HTMLDivElement;
 
   Args: {
     repository: RepositoryModel;
     extension: CourseExtensionModel;
   };
-};
+}
 
 export default class ExtensionCardComponent extends Component<Signature> {
   @service store!: Store;

--- a/app/components/course-page/course-stage-step/community-solution-card.ts
+++ b/app/components/course-page/course-stage-step/community-solution-card.ts
@@ -9,7 +9,7 @@ import type AnalyticsEventTrackerService from 'codecrafters-frontend/services/an
 import type AuthenticatorService from 'codecrafters-frontend/services/authenticator';
 import { type FileComparison } from 'codecrafters-frontend/utils/file-comparison';
 
-type Signature = {
+interface Signature {
   Element: HTMLDivElement;
 
   Args: {
@@ -20,7 +20,7 @@ type Signature = {
     metadataForDownvote?: Record<string, unknown>;
     isCollapsedByDefault?: boolean;
   };
-};
+}
 
 export default class CommunitySolutionCardComponent extends Component<Signature> {
   @tracked containerElement: HTMLDivElement | null = null;

--- a/app/components/course-page/course-stage-step/community-solution-card/content.ts
+++ b/app/components/course-page/course-stage-step/community-solution-card/content.ts
@@ -11,7 +11,7 @@ import type CommunityCourseStageSolutionCommentModel from 'codecrafters-frontend
 import { type FileComparison, IsUnchangedFileComparison, type UnchangedFileComparison } from 'codecrafters-frontend/utils/file-comparison';
 import { tracked } from '@glimmer/tracking';
 
-type Signature = {
+interface Signature {
   Element: HTMLDivElement;
 
   Args: {
@@ -19,7 +19,7 @@ type Signature = {
     fileComparisons: FileComparison[];
     onPublishToGithubButtonClick?: () => void;
   };
-};
+}
 
 export default class CommunitySolutionCardContentComponent extends Component<Signature> {
   @tracked expandedUnchangedFilePaths: string[] = [];

--- a/app/components/course-page/course-stage-step/community-solution-card/downvote-button.ts
+++ b/app/components/course-page/course-stage-step/community-solution-card/downvote-button.ts
@@ -4,14 +4,14 @@ import Component from '@glimmer/component';
 import type CommunityCourseStageSolutionModel from 'codecrafters-frontend/models/community-course-stage-solution';
 import type AuthenticatorService from 'codecrafters-frontend/services/authenticator';
 
-type Signature = {
+interface Signature {
   Element: HTMLButtonElement;
 
   Args: {
     metadata?: Record<string, unknown>;
     solution: CommunityCourseStageSolutionModel;
   };
-};
+}
 
 export default class DownvoteButtonComponent extends Component<Signature> {
   @service declare authenticator: AuthenticatorService;

--- a/app/components/course-page/course-stage-step/community-solution-card/header-label.ts
+++ b/app/components/course-page/course-stage-step/community-solution-card/header-label.ts
@@ -3,13 +3,13 @@ import Component from '@glimmer/component';
 import type CommunityCourseStageSolutionModel from 'codecrafters-frontend/models/community-course-stage-solution';
 import type AuthenticatorService from 'codecrafters-frontend/services/authenticator';
 
-type Signature = {
+interface Signature {
   Element: HTMLDivElement;
 
   Args: {
     solution: CommunityCourseStageSolutionModel;
   };
-};
+}
 
 export default class CommunitySolutionCardHeaderLabelComponent extends Component<Signature> {
   @service declare authenticator: AuthenticatorService;

--- a/app/components/course-page/course-stage-step/community-solution-card/header.ts
+++ b/app/components/course-page/course-stage-step/community-solution-card/header.ts
@@ -3,7 +3,7 @@ import Component from '@glimmer/component';
 import type CommunityCourseStageSolutionModel from 'codecrafters-frontend/models/community-course-stage-solution';
 import type AuthenticatorService from 'codecrafters-frontend/services/authenticator';
 
-type Signature = {
+interface Signature {
   Element: HTMLDivElement;
 
   Args: {
@@ -11,7 +11,7 @@ type Signature = {
     metadataForUpvote?: Record<string, unknown>;
     solution: CommunityCourseStageSolutionModel;
   };
-};
+}
 
 export default class CommunitySolutionCardHeaderComponent extends Component<Signature> {
   @service declare authenticator: AuthenticatorService;

--- a/app/components/course-page/course-stage-step/community-solution-card/upvote-button.ts
+++ b/app/components/course-page/course-stage-step/community-solution-card/upvote-button.ts
@@ -4,14 +4,14 @@ import Component from '@glimmer/component';
 import type CommunityCourseStageSolutionModel from 'codecrafters-frontend/models/community-course-stage-solution';
 import type AuthenticatorService from 'codecrafters-frontend/services/authenticator';
 
-type Signature = {
+interface Signature {
   Element: HTMLButtonElement;
 
   Args: {
     metadata?: Record<string, unknown>;
     solution: CommunityCourseStageSolutionModel;
   };
-};
+}
 
 export default class UpvoteButtonComponent extends Component<Signature> {
   @service declare authenticator: AuthenticatorService;

--- a/app/components/course-page/course-stage-step/community-solutions-list.ts
+++ b/app/components/course-page/course-stage-step/community-solutions-list.ts
@@ -10,7 +10,7 @@ import type CoursePageStateService from 'codecrafters-frontend/services/course-p
 import type CourseStageModel from 'codecrafters-frontend/models/course-stage';
 import type RepositoryModel from 'codecrafters-frontend/models/repository';
 
-type Signature = {
+interface Signature {
   Element: HTMLDivElement;
 
   Args: {
@@ -19,7 +19,7 @@ type Signature = {
     stageIncompleteModalWasDismissed: boolean;
     repository: RepositoryModel;
   };
-};
+}
 
 export default class CommunitySolutionsListComponent extends Component<Signature> {
   rippleSpinnerImage = rippleSpinnerImage;

--- a/app/components/course-page/course-stage-step/feedback-prompt-option.ts
+++ b/app/components/course-page/course-stage-step/feedback-prompt-option.ts
@@ -1,6 +1,6 @@
 import Component from '@glimmer/component';
 
-type Signature = {
+interface Signature {
   Element: HTMLDivElement;
 
   Args: {
@@ -8,7 +8,7 @@ type Signature = {
     isSelected: boolean;
     colorOnHoverAndSelect: 'green' | 'red';
   };
-};
+}
 
 export default class FeedbackPromptOptionComponent extends Component<Signature> {}
 

--- a/app/components/course-page/course-stage-step/feedback-prompt.ts
+++ b/app/components/course-page/course-stage-step/feedback-prompt.ts
@@ -8,7 +8,7 @@ import type RepositoryModel from 'codecrafters-frontend/models/repository';
 import type CourseStageModel from 'codecrafters-frontend/models/course-stage';
 import type Store from '@ember-data/store';
 
-type Signature = {
+interface Signature {
   Element: HTMLDivElement;
 
   Args: {
@@ -16,7 +16,7 @@ type Signature = {
     repository: RepositoryModel;
     onSubmit: () => void;
   };
-};
+}
 
 export default class FeedbackPromptComponent extends Component<Signature> {
   @tracked isEditingClosedSubmission = false;

--- a/app/components/course-page/course-stage-step/inaccessible-community-solutions-list.ts
+++ b/app/components/course-page/course-stage-step/inaccessible-community-solutions-list.ts
@@ -1,13 +1,13 @@
 import Component from '@glimmer/component';
 import type CommunityCourseStageSolutionModel from 'codecrafters-frontend/models/community-course-stage-solution';
 
-type Signature = {
+interface Signature {
   Element: HTMLDivElement;
 
   Args: {
     inaccessibleSolutions: CommunityCourseStageSolutionModel[];
   };
-};
+}
 
 export default class InaccessibleCommunitySolutionsListComponent extends Component<Signature> {}
 

--- a/app/components/course-page/course-stage-step/test-runner-card.ts
+++ b/app/components/course-page/course-stage-step/test-runner-card.ts
@@ -8,7 +8,7 @@ import type RepositoryModel from 'codecrafters-frontend/models/repository';
 import type CoursePageStateService from 'codecrafters-frontend/services/course-page-state';
 import type CourseStageStep from 'codecrafters-frontend/utils/course-page-step-list/course-stage-step';
 
-type Signature = {
+interface Signature {
   Element: HTMLDivElement;
 
   Args: {
@@ -17,7 +17,7 @@ type Signature = {
     repository: RepositoryModel;
     stage: CourseStageModel;
   };
-};
+}
 
 export default class TestRunnerCardComponent extends Component<Signature> {
   @service declare coursePageState: CoursePageStateService;

--- a/app/components/course-page/course-stage-step/your-task-card/action-button-list.ts
+++ b/app/components/course-page/course-stage-step/your-task-card/action-button-list.ts
@@ -7,14 +7,14 @@ import type CourseStageModel from 'codecrafters-frontend/models/course-stage';
 import type FeatureFlagsService from 'codecrafters-frontend/services/feature-flags';
 import type RouterService from '@ember/routing/router-service';
 
-type Signature = {
+interface Signature {
   Element: HTMLDivElement;
 
   Args: {
     courseStage: CourseStageModel;
     repository: RepositoryModel;
   };
-};
+}
 
 export default class ActionButtonListComponent extends Component<Signature> {
   @service declare featureFlags: FeatureFlagsService;

--- a/app/components/course-page/course-stage-step/your-task-card/action-button.ts
+++ b/app/components/course-page/course-stage-step/your-task-card/action-button.ts
@@ -1,13 +1,13 @@
 import Component from '@glimmer/component';
 
-type Signature = {
+interface Signature {
   Element: HTMLButtonElement;
 
   Args: {
     text: string;
     icon: string;
   };
-};
+}
 
 export default class ActionButtonComponent extends Component<Signature> {}
 

--- a/app/components/course-page/delete-repository-modal.ts
+++ b/app/components/course-page/delete-repository-modal.ts
@@ -16,8 +16,8 @@ interface Signature {
 }
 
 export default class DeleteRepositoryModalComponent extends Component<Signature> {
-  @service router!: RouterService;
-  @service store!: Store;
+  @service declare router: RouterService;
+  @service declare store: Store;
 
   @action
   async deleteRepository() {

--- a/app/components/course-page/extension-completed-card.ts
+++ b/app/components/course-page/extension-completed-card.ts
@@ -4,14 +4,14 @@ import congratulationsImage from '/assets/images/icons/congratulations.png';
 import RepositoryModel from 'codecrafters-frontend/models/repository';
 import type CourseExtensionModel from 'codecrafters-frontend/models/course-extension';
 
-type Signature = {
+interface Signature {
   Element: HTMLDivElement;
 
   Args: {
     repository: RepositoryModel;
     extension: CourseExtensionModel;
   };
-};
+}
 
 export default class ExtensionCompletedCardComponent extends Component<Signature> {
   congratulationsImage = congratulationsImage;

--- a/app/components/course-page/header/main-section.ts
+++ b/app/components/course-page/header/main-section.ts
@@ -4,7 +4,7 @@ import Step from 'codecrafters-frontend/utils/course-page-step-list/step';
 import { StepList } from 'codecrafters-frontend/utils/course-page-step-list';
 import type CourseStageStep from 'codecrafters-frontend/utils/course-page-step-list/course-stage-step';
 
-type Signature = {
+interface Signature {
   Element: HTMLDivElement;
 
   Args: {
@@ -15,7 +15,7 @@ type Signature = {
     onMobileSidebarButtonClick: () => void;
     stepList: StepList;
   };
-};
+}
 
 export default class MainSectionComponent extends Component<Signature> {
   get currentStepAsCourseStageStep(): CourseStageStep {

--- a/app/components/course-page/header/navigation-controls.ts
+++ b/app/components/course-page/header/navigation-controls.ts
@@ -8,7 +8,7 @@ import { inject as service } from '@ember/service';
 import CourseStageStep from 'codecrafters-frontend/utils/course-page-step-list/course-stage-step';
 import type AuthenticatorService from 'codecrafters-frontend/services/authenticator';
 
-type Signature = {
+interface Signature {
   Element: HTMLDivElement;
 
   Args: {
@@ -19,7 +19,7 @@ type Signature = {
     onMobileSidebarButtonClick: () => void;
     stepList: StepList;
   };
-};
+}
 
 export default class NavigationControlsComponent extends Component<Signature> {
   @service declare authenticator: AuthenticatorService;

--- a/app/components/course-page/header/sticky-section.ts
+++ b/app/components/course-page/header/sticky-section.ts
@@ -6,7 +6,7 @@ import { StepList } from 'codecrafters-frontend/utils/course-page-step-list';
 import { tracked } from '@glimmer/tracking';
 import CourseStageStep from 'codecrafters-frontend/utils/course-page-step-list/course-stage-step';
 
-type Signature = {
+interface Signature {
   Element: HTMLDivElement;
 
   Args: {
@@ -16,7 +16,7 @@ type Signature = {
     nextStep: Step | null;
     stepList: StepList;
   };
-};
+}
 
 export default class StickySectionComponent extends Component<Signature> {
   @tracked scrollMarkerIsInViewport = true;

--- a/app/components/course-page/header/tab-list.ts
+++ b/app/components/course-page/header/tab-list.ts
@@ -5,7 +5,7 @@ import Step from 'codecrafters-frontend/utils/course-page-step-list/step';
 import { StepList } from 'codecrafters-frontend/utils/course-page-step-list';
 import { inject as service } from '@ember/service';
 
-type Signature = {
+interface Signature {
   Element: HTMLDivElement;
 
   Args: {
@@ -15,7 +15,7 @@ type Signature = {
     nextStep: Step | null;
     stepList: StepList;
   };
-};
+}
 
 type Tab = {
   icon: string;

--- a/app/components/course-page/introduction-step/create-repository-card.ts
+++ b/app/components/course-page/introduction-step/create-repository-card.ts
@@ -10,13 +10,13 @@ import { action } from '@ember/object';
 import { service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 
-type Signature = {
+interface Signature {
   Element: HTMLDivElement;
 
   Args: {
     repository: RepositoryModel;
   };
-};
+}
 
 export default class CreateRepositoryCardComponent extends Component<Signature> {
   @service declare router: RouterService;

--- a/app/components/course-page/introduction-step/create-repository-card/select-expected-activity-frequency-section.ts
+++ b/app/components/course-page/introduction-step/create-repository-card/select-expected-activity-frequency-section.ts
@@ -2,7 +2,7 @@ import Component from '@glimmer/component';
 import RepositoryModel from 'codecrafters-frontend/models/repository';
 import { action } from '@ember/object';
 
-type Signature = {
+interface Signature {
   Element: HTMLDivElement;
 
   Args: {
@@ -10,7 +10,7 @@ type Signature = {
     repository: RepositoryModel;
     onSelect: () => void;
   };
-};
+}
 
 export default class SelectExpectedActivityFrequencySectionComponent extends Component<Signature> {
   @action

--- a/app/components/course-page/introduction-step/create-repository-card/select-language-proficiency-level-section.ts
+++ b/app/components/course-page/introduction-step/create-repository-card/select-language-proficiency-level-section.ts
@@ -3,14 +3,14 @@ import fade from 'ember-animated/transitions/fade';
 import RepositoryModel from 'codecrafters-frontend/models/repository';
 import { action } from '@ember/object';
 
-type Signature = {
+interface Signature {
   Element: HTMLDivElement;
 
   Args: {
     isDisabled: boolean;
     repository: RepositoryModel;
   };
-};
+}
 
 export default class SelectLanguageProficiencyLevelSectionComponent extends Component<Signature> {
   transition = fade;

--- a/app/components/course-page/introduction-step/create-repository-card/select-reminders-preference-section.ts
+++ b/app/components/course-page/introduction-step/create-repository-card/select-reminders-preference-section.ts
@@ -2,14 +2,14 @@ import Component from '@glimmer/component';
 import RepositoryModel from 'codecrafters-frontend/models/repository';
 import { action } from '@ember/object';
 
-type Signature = {
+interface Signature {
   Element: HTMLDivElement;
 
   Args: {
     isDisabled: boolean;
     repository: RepositoryModel;
   };
-};
+}
 
 export default class SelectRemindersPreferenceSectionComponent extends Component<Signature> {
   @action

--- a/app/components/course-page/setup-step/repository-setup-card.ts
+++ b/app/components/course-page/setup-step/repository-setup-card.ts
@@ -3,13 +3,13 @@ import { inject as service } from '@ember/service';
 import type RepositoryModel from 'codecrafters-frontend/models/repository';
 import type CoursePageStateService from 'codecrafters-frontend/services/course-page-state';
 
-export type Signature = {
+export interface Signature {
   Element: HTMLDivElement;
 
   Args: {
     repository: RepositoryModel;
   };
-};
+}
 
 export default class RepositorySetupCardComponent extends Component<Signature> {
   @service declare coursePageState: CoursePageStateService;

--- a/app/components/course-page/setup-step/repository-setup-card/clone-repository-step.ts
+++ b/app/components/course-page/setup-step/repository-setup-card/clone-repository-step.ts
@@ -1,14 +1,14 @@
 import Component from '@glimmer/component';
 import type RepositoryModel from 'codecrafters-frontend/models/repository';
 
-export type Signature = {
+export interface Signature {
   Element: HTMLDivElement;
 
   Args: {
     repository: RepositoryModel;
     isComplete: boolean;
   };
-};
+}
 
 export default class CloneRepositoryStepComponent extends Component<Signature> {}
 

--- a/app/components/course-page/share-progress-modal/icon.ts
+++ b/app/components/course-page/share-progress-modal/icon.ts
@@ -5,7 +5,7 @@ import linkedinLogoImage from 'codecrafters-frontend/images/social-icons/linkedi
 import slackLogoImage from 'codecrafters-frontend/images/social-icons/slack.svg';
 import twitterLogoImage from 'codecrafters-frontend/images/social-icons/twitter.svg';
 
-type Signature = {
+interface Signature {
   Element: HTMLDivElement;
 
   Args: {
@@ -13,7 +13,7 @@ type Signature = {
     platform: 'twitter' | 'discord' | 'linkedin' | 'slack';
     selectedSocialPlatform: string;
   };
-};
+}
 
 type SocialPlatform = 'twitter' | 'slack' | 'discord' | 'linkedin';
 

--- a/app/components/course-page/step-switcher-container.ts
+++ b/app/components/course-page/step-switcher-container.ts
@@ -1,14 +1,14 @@
 import Component from '@glimmer/component';
 import { Step, StepList } from 'codecrafters-frontend/utils/course-page-step-list';
 
-type Signature = {
+interface Signature {
   Element: HTMLDivElement;
 
   Args: {
     currentStep: Step;
     stepList: StepList;
   };
-};
+}
 
 export default class StepSwitcherComponent extends Component<Signature> {
   get nextStep() {

--- a/app/components/course-page/test-results-bar.ts
+++ b/app/components/course-page/test-results-bar.ts
@@ -10,7 +10,7 @@ import type CoursePageStateService from 'codecrafters-frontend/services/course-p
 import type CourseStageStep from 'codecrafters-frontend/utils/course-page-step-list/course-stage-step';
 import type RepositoryModel from 'codecrafters-frontend/models/repository';
 
-type Signature = {
+interface Signature {
   Element: HTMLDivElement;
 
   Args: {
@@ -18,7 +18,7 @@ type Signature = {
     currentStep: Step;
     repository: RepositoryModel;
   };
-};
+}
 
 export default class TestResultsBarComponent extends Component<Signature> {
   @service declare coursePageState: CoursePageStateService;

--- a/app/components/course-page/test-results-bar/autofix-section.ts
+++ b/app/components/course-page/test-results-bar/autofix-section.ts
@@ -7,7 +7,7 @@ import type AutofixRequestModel from 'codecrafters-frontend/models/autofix-reque
 import type RepositoryModel from 'codecrafters-frontend/models/repository';
 import { tracked } from '@glimmer/tracking';
 
-type Signature = {
+interface Signature {
   Element: HTMLDivElement;
 
   Args: {
@@ -15,7 +15,7 @@ type Signature = {
     currentStep: Step;
     repository: RepositoryModel;
   };
-};
+}
 
 export default class AutofixSectionComponent extends Component<Signature> {
   @service declare store: Store;

--- a/app/components/course-page/test-results-bar/autofix-section/autofix-result.ts
+++ b/app/components/course-page/test-results-bar/autofix-section/autofix-result.ts
@@ -8,13 +8,13 @@ import Logstream from 'codecrafters-frontend/utils/logstream';
 import type AutofixRequestModel from 'codecrafters-frontend/models/autofix-request';
 import type ActionCableConsumerService from 'codecrafters-frontend/services/action-cable-consumer';
 
-type Signature = {
+interface Signature {
   Element: HTMLDivElement;
 
   Args: {
     autofixRequest: AutofixRequestModel;
   };
-};
+}
 
 export default class AutofixResultComponent extends Component<Signature> {
   @service declare store: Store;

--- a/app/components/course-page/test-results-bar/autofix-section/create-autofix-prompt.ts
+++ b/app/components/course-page/test-results-bar/autofix-section/create-autofix-prompt.ts
@@ -6,13 +6,13 @@ import { task } from 'ember-concurrency';
 import { tracked } from '@glimmer/tracking';
 import type SubmissionModel from 'codecrafters-frontend/models/submission';
 
-type Signature = {
+interface Signature {
   Element: HTMLDivElement;
 
   Args: {
     submission: SubmissionModel;
   };
-};
+}
 
 export default class CreateAutofixPromptComponent extends Component<Signature> {
   @service declare store: Store;

--- a/app/components/course-page/test-results-bar/bottom-section.ts
+++ b/app/components/course-page/test-results-bar/bottom-section.ts
@@ -2,7 +2,7 @@ import Component from '@glimmer/component';
 import { Step } from 'codecrafters-frontend/utils/course-page-step-list';
 import type CourseStageStep from 'codecrafters-frontend/utils/course-page-step-list/course-stage-step';
 
-type Signature = {
+interface Signature {
   Element: HTMLDivElement;
 
   Args: {
@@ -11,7 +11,7 @@ type Signature = {
     onCollapseButtonClick: () => void;
     onExpandButtonClick: () => void;
   };
-};
+}
 
 export default class BottomSectionComponent extends Component<Signature> {
   get activeStepAsCourseStageStep() {

--- a/app/components/course-page/test-results-bar/bottom-section/expand-or-collapse-indicator.ts
+++ b/app/components/course-page/test-results-bar/bottom-section/expand-or-collapse-indicator.ts
@@ -1,12 +1,12 @@
 import Component from '@glimmer/component';
 
-type Signature = {
+interface Signature {
   Element: HTMLDivElement;
 
   Args: {
     barIsExpanded: boolean;
   };
-};
+}
 
 export default class ExpandOrCollapseIndicatorComponent extends Component<Signature> {}
 

--- a/app/components/course-page/test-results-bar/logs-section.ts
+++ b/app/components/course-page/test-results-bar/logs-section.ts
@@ -3,7 +3,7 @@ import { Step } from 'codecrafters-frontend/utils/course-page-step-list';
 import type CourseStageStep from 'codecrafters-frontend/utils/course-page-step-list/course-stage-step';
 import type RepositoryModel from 'codecrafters-frontend/models/repository';
 
-type Signature = {
+interface Signature {
   Element: HTMLDivElement;
 
   Args: {
@@ -11,7 +11,7 @@ type Signature = {
     currentStep: Step;
     repository: RepositoryModel;
   };
-};
+}
 
 export default class LogsSectionComponent extends Component<Signature> {
   get activeCourseStage() {

--- a/app/components/course-page/test-results-bar/top-section.ts
+++ b/app/components/course-page/test-results-bar/top-section.ts
@@ -1,7 +1,7 @@
 import { action } from '@ember/object';
 import Component from '@glimmer/component';
 
-type Signature = {
+interface Signature {
   Element: HTMLDivElement;
 
   Args: {
@@ -10,7 +10,7 @@ type Signature = {
     onCollapseButtonClick: () => void;
     onActiveTabSlugChange: (slug: string) => void;
   };
-};
+}
 
 export default class TopSectionComponent extends Component<Signature> {
   get tabs() {

--- a/app/components/expandable-step-list/step.ts
+++ b/app/components/expandable-step-list/step.ts
@@ -4,7 +4,7 @@ import { action } from '@ember/object';
 import { next } from '@ember/runloop';
 import { tracked } from '@glimmer/tracking';
 
-type Signature = {
+interface Signature {
   Element: HTMLDivElement;
 
   Args: {
@@ -20,7 +20,7 @@ type Signature = {
   Blocks: {
     default: [];
   };
-};
+}
 
 export default class StepComponent extends Component<Signature> {
   @tracked previousIsComplete: boolean | null = null;

--- a/app/components/faq-item.ts
+++ b/app/components/faq-item.ts
@@ -2,7 +2,7 @@ import Component from '@glimmer/component';
 import { action } from '@ember/object';
 import type { Faq } from './faq-list';
 
-type Signature = {
+interface Signature {
   Element: HTMLElement;
 
   Args: {
@@ -10,7 +10,7 @@ type Signature = {
     onToggle: (faq: Faq) => void;
     isOpen: boolean;
   };
-};
+}
 
 export default class FaqItemComponent extends Component<Signature> {
   @action

--- a/app/components/faq-item.ts
+++ b/app/components/faq-item.ts
@@ -3,7 +3,7 @@ import { action } from '@ember/object';
 import type { Faq } from './faq-list';
 
 interface Signature {
-  Element: HTMLElement;
+  Element: HTMLDivElement;
 
   Args: {
     faq: Faq;

--- a/app/components/faq-list.ts
+++ b/app/components/faq-list.ts
@@ -8,7 +8,7 @@ export type Faq = {
 };
 
 interface Signature {
-  Element: HTMLElement;
+  Element: HTMLDivElement;
 }
 
 export default class FaqListComponent extends Component<Signature> {

--- a/app/components/faq-list.ts
+++ b/app/components/faq-list.ts
@@ -7,9 +7,9 @@ export type Faq = {
   answer: string;
 };
 
-type Signature = {
+interface Signature {
   Element: HTMLElement;
-};
+}
 
 export default class FaqListComponent extends Component<Signature> {
   @tracked openItem: Faq | null = null;

--- a/app/components/feedback-button.ts
+++ b/app/components/feedback-button.ts
@@ -7,7 +7,7 @@ import Component from '@glimmer/component';
 import type RouterService from '@ember/routing/router-service';
 import Store from '@ember-data/store';
 
-type Signature = {
+interface Signature {
   Element: HTMLDivElement;
 
   Args: {
@@ -20,7 +20,7 @@ type Signature = {
   Blocks: {
     default: [{ isOpen: boolean; actions: { close: () => void } }];
   };
-};
+}
 
 export default class FeedbackButtonComponent extends Component<Signature> {
   @service declare router: RouterService;

--- a/app/components/header/account-dropdown-link.ts
+++ b/app/components/header/account-dropdown-link.ts
@@ -1,13 +1,13 @@
 import Component from '@glimmer/component';
 
-type Signature = {
+interface Signature {
   Element: HTMLDivElement;
 
   Args: {
     text: string;
     icon: string;
   };
-};
+}
 
 export default class HeaderAccountDropdownLinkComponent extends Component<Signature> {}
 

--- a/app/components/header/free-weeks-left-button.ts
+++ b/app/components/header/free-weeks-left-button.ts
@@ -8,7 +8,7 @@ interface Signature {
 }
 
 export default class FreeWeeksLeftButtonComponent extends Component<Signature> {
-  @service authenticator!: AuthenticatorService;
+  @service declare authenticator: AuthenticatorService;
 
   get currentUser() {
     return this.authenticator.currentUser;

--- a/app/components/modal-backdrop.ts
+++ b/app/components/modal-backdrop.ts
@@ -1,13 +1,13 @@
 import Component from '@glimmer/component';
 import { action } from '@ember/object';
 
-type Signature = {
+interface Signature {
   Element: HTMLDivElement;
 
   Blocks: {
     default: [];
   };
-};
+}
 
 export default class ModalBackdropComponent extends Component<Signature> {
   get containerElement() {

--- a/app/components/modal-body.ts
+++ b/app/components/modal-body.ts
@@ -1,7 +1,7 @@
 import Component from '@glimmer/component';
 import { action } from '@ember/object';
 
-type Signature = {
+interface Signature {
   Element: HTMLDivElement;
 
   Args: {
@@ -14,7 +14,7 @@ type Signature = {
   Blocks: {
     default: [];
   };
-};
+}
 
 export default class ModalBodyComponent extends Component<Signature> {
   @action

--- a/app/components/outdated-client-badge.ts
+++ b/app/components/outdated-client-badge.ts
@@ -1,7 +1,7 @@
 import Component from '@glimmer/component';
 
 interface Signature {
-  Element: HTMLElement;
+  Element: HTMLDivElement;
 }
 
 export default class OutdatedClientBadgeComponent extends Component<Signature> {

--- a/app/components/page-section.ts
+++ b/app/components/page-section.ts
@@ -1,7 +1,7 @@
 import Component from '@glimmer/component';
 
 interface Signature {
-  Element: HTMLElement;
+  Element: HTMLDivElement;
 
   Args: {
     title: string;

--- a/app/components/pay-page/pricing-card.ts
+++ b/app/components/pay-page/pricing-card.ts
@@ -4,7 +4,7 @@ import type AuthenticatorService from 'codecrafters-frontend/services/authentica
 import Store from '@ember-data/store';
 import type RegionalDiscountModel from 'codecrafters-frontend/models/regional-discount';
 
-type Signature = {
+interface Signature {
   Element: HTMLDivElement;
 
   Args: {
@@ -19,7 +19,7 @@ type Signature = {
     shouldShowAmortizedMonthlyPrice: boolean;
     title: string;
   };
-};
+}
 
 export default class PricingCardComponent extends Component<Signature> {
   @service declare authenticator: AuthenticatorService;

--- a/app/components/pill.ts
+++ b/app/components/pill.ts
@@ -1,6 +1,6 @@
 import Component from '@glimmer/component';
 
-type Signature = {
+interface Signature {
   Element: HTMLDivElement;
 
   Args: {
@@ -10,7 +10,7 @@ type Signature = {
   Blocks: {
     default: [];
   };
-};
+}
 
 export default class PillComponent extends Component<Signature> {
   get colorClasses() {

--- a/app/components/product-walkthrough-feature-suggestion.ts
+++ b/app/components/product-walkthrough-feature-suggestion.ts
@@ -7,13 +7,13 @@ import { action } from '@ember/object';
 import { inject as service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 
-export type Signature = {
+export interface Signature {
   Element: HTMLDivElement;
 
   Args: {
     featureSuggestion?: FeatureSuggestionModel;
   };
-};
+}
 
 export default class ProductWalkthroughFeatureSuggestion extends Component<Signature> {
   @service declare analyticsEventTracker: AnalyticsEventTrackerService;

--- a/app/components/referral-link-page/accept-referral-container.ts
+++ b/app/components/referral-link-page/accept-referral-container.ts
@@ -11,7 +11,7 @@ import { inject as service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 
 interface Signature {
-  Element: HTMLElement;
+  Element: HTMLDivElement;
 
   Args: {
     acceptedReferralOfferFreeUsageGrant: FreeUsageGrantModel | null;

--- a/app/components/referral-link-page/accept-referral-container.ts
+++ b/app/components/referral-link-page/accept-referral-container.ts
@@ -22,9 +22,9 @@ interface Signature {
 export default class AcceptReferralContainerComponent extends Component<Signature> {
   logoImage = logoImage;
 
-  @service authenticator!: AuthenticatorService;
-  @service store!: Store;
-  @service router!: RouterService;
+  @service declare authenticator: AuthenticatorService;
+  @service declare store: Store;
+  @service declare router: RouterService;
 
   @tracked isAccepted: boolean = this.args.acceptedReferralOfferFreeUsageGrant ? true : false;
   @tracked isCreatingReferralActivation: boolean = false;

--- a/app/components/referral-link-page/testimonial-list-item.ts
+++ b/app/components/referral-link-page/testimonial-list-item.ts
@@ -1,7 +1,7 @@
 import Component from '@glimmer/component';
 
 interface Signature {
-  Element: HTMLElement;
+  Element: HTMLAnchorElement;
 
   Args: {
     testimonial: {

--- a/app/components/referrals-page/join-referral-program-container.ts
+++ b/app/components/referrals-page/join-referral-program-container.ts
@@ -16,9 +16,10 @@ import slackImage from '/assets/images/company-logos/slack-company-logo.svg';
 import stripeImage from '/assets/images/company-logos/stripe-company-logo.svg';
 
 export default class JoinReferralProgramContainerComponent extends Component {
-  @service authenticator!: AuthenticatorService;
+  @service declare authenticator: AuthenticatorService;
+  @service declare store: Store;
+
   @tracked isCreatingReferralLink = false;
-  @service store!: Store;
 
   get companies() {
     return [

--- a/app/components/referrals-page/referral-feature-cards.ts
+++ b/app/components/referrals-page/referral-feature-cards.ts
@@ -4,7 +4,7 @@ import getOneYearFreeImage from '/assets/images/referral-program-features/get-on
 import giftOneWeekFreeImage from '/assets/images/referral-program-features/gift-one-week-free.png';
 
 interface Signature {
-  Element: HTMLElement;
+  Element: HTMLDivElement;
 
   Blocks: {
     default: [];

--- a/app/components/referrals-page/referral-link-stat-container.ts
+++ b/app/components/referrals-page/referral-link-stat-container.ts
@@ -1,7 +1,7 @@
 import Component from '@glimmer/component';
 
 interface Signature {
-  Element: HTMLElement;
+  Element: HTMLDivElement;
 
   Args: {
     helpText: string;

--- a/app/components/referrals-page/referral-link-stats-container.ts
+++ b/app/components/referrals-page/referral-link-stats-container.ts
@@ -15,7 +15,7 @@ interface Signature {
 }
 
 export default class ReferralLinkStatsContainerComponent extends Component<Signature> {
-  @service authenticator!: AuthenticatorService;
+  @service declare authenticator: AuthenticatorService;
 
   get activeFreeUsageGrantsCount() {
     return this.args.freeUsageGrants.filter((grant: FreeUsageGrantModel) => !grant.isExpired).length;

--- a/app/components/referrals-page/referral-link-stats-container.ts
+++ b/app/components/referrals-page/referral-link-stats-container.ts
@@ -6,7 +6,7 @@ import { inject as service } from '@ember/service';
 import { format } from 'date-fns';
 
 interface Signature {
-  Element: HTMLElement;
+  Element: HTMLDivElement;
 
   Args: {
     freeUsageGrants: FreeUsageGrantModel[];

--- a/app/components/referrals-page/referral-links-container.ts
+++ b/app/components/referrals-page/referral-links-container.ts
@@ -3,7 +3,7 @@ import Component from '@glimmer/component';
 import { inject as service } from '@ember/service';
 
 interface Signature {
-  Element: HTMLElement;
+  Element: HTMLDivElement;
 }
 
 export default class ReferralLinksContainerComponent extends Component<Signature> {

--- a/app/components/referrals-page/referral-links-container.ts
+++ b/app/components/referrals-page/referral-links-container.ts
@@ -7,7 +7,7 @@ interface Signature {
 }
 
 export default class ReferralLinksContainerComponent extends Component<Signature> {
-  @service authenticator!: AuthenticatorService;
+  @service declare authenticator: AuthenticatorService;
 
   get currentUser() {
     return this.authenticator.currentUser;

--- a/app/components/referrals-page/referral-referred-user-item.ts
+++ b/app/components/referrals-page/referral-referred-user-item.ts
@@ -4,7 +4,7 @@ import ReferralActivationModel from 'codecrafters-frontend/models/referral-activ
 import { format } from 'date-fns';
 
 interface Signature {
-  Element: HTMLElement;
+  Element: HTMLDivElement;
 
   Args: {
     activation: ReferralActivationModel;

--- a/app/components/referrals-page/referral-referred-users-container.ts
+++ b/app/components/referrals-page/referral-referred-users-container.ts
@@ -3,7 +3,7 @@ import FreeUsageGrantModel from 'codecrafters-frontend/models/free-usage-grant';
 import ReferralLinkModel from 'codecrafters-frontend/models/referral-link';
 
 interface Signature {
-  Element: HTMLElement;
+  Element: HTMLDivElement;
 
   Args: {
     freeUsageGrants: FreeUsageGrantModel[];

--- a/app/components/settings/form-section.ts
+++ b/app/components/settings/form-section.ts
@@ -4,8 +4,8 @@ interface Signature {
   Element: HTMLDivElement;
 
   Args: {
-    title: string;
     description: string;
+    title: string;
   };
 
   Blocks: {

--- a/app/components/syntax-highlighted-code.ts
+++ b/app/components/syntax-highlighted-code.ts
@@ -6,7 +6,7 @@ import { tracked } from '@glimmer/tracking';
 import { transformerCompactLineOptions } from '@shikijs/transformers';
 import { task } from 'ember-concurrency';
 
-export type Signature = {
+export interface Signature {
   Element: HTMLDivElement;
 
   Args: {
@@ -16,7 +16,7 @@ export type Signature = {
     theme: string;
     highlightedLines?: string;
   };
-};
+}
 
 export default class SyntaxHighlightedCodeComponent extends Component<Signature> {
   @tracked asyncHighlightedCode: string | null = null;

--- a/app/components/syntax-highlighted-diff.ts
+++ b/app/components/syntax-highlighted-diff.ts
@@ -17,7 +17,7 @@ import type DarkModeService from 'codecrafters-frontend/services/dark-mode';
  */
 const DELAY_BETWEEN_HIGHLIGHT_CODE_TASKS_IN_MS: number = 100;
 
-type Signature = {
+interface Signature {
   Element: HTMLDivElement;
 
   Args: {
@@ -28,7 +28,7 @@ type Signature = {
     forceDarkTheme?: boolean;
     onCommentView?: (comment: CommunityCourseStageSolutionCommentModel) => void;
   };
-};
+}
 
 interface HighlightCodeParams {
   isDarkMode?: boolean;

--- a/app/components/tab-header.ts
+++ b/app/components/tab-header.ts
@@ -1,6 +1,6 @@
 import Component from '@glimmer/component';
 
-type Signature = {
+interface Signature {
   Element: HTMLDivElement;
 
   Args: {
@@ -10,7 +10,7 @@ type Signature = {
     isActive: boolean;
     size?: 'small' | 'regular';
   };
-};
+}
 
 export default class TabHeaderComponent extends Component<Signature> {}
 

--- a/app/components/tabs.ts
+++ b/app/components/tabs.ts
@@ -8,7 +8,7 @@ export type Tab = {
   icon?: string;
 };
 
-export type Signature = {
+export interface Signature {
   Element: HTMLDivElement;
 
   Args: {
@@ -23,7 +23,7 @@ export type Signature = {
   Blocks: {
     default: [string];
   };
-};
+}
 
 export default class TabsComponent extends Component<Signature> {
   @tracked uncontrolledActiveTabSlug = this.args.tabs[0]!.slug;

--- a/app/components/track-page/card.ts
+++ b/app/components/track-page/card.ts
@@ -1,7 +1,7 @@
 import Component from '@glimmer/component';
 import UserModel from 'codecrafters-frontend/models/user';
 
-type Signature = {
+interface Signature {
   Element: HTMLDivElement;
 
   Args: {
@@ -17,7 +17,7 @@ type Signature = {
     default: [];
     afterTitle?: [];
   };
-};
+}
 
 export default class TrackPageCardComponent extends Component<Signature> {
   get titleForDisplay() {

--- a/app/components/track-page/course-card.ts
+++ b/app/components/track-page/course-card.ts
@@ -9,7 +9,7 @@ import { service } from '@ember/service';
 import { action } from '@ember/object';
 import type CourseStageModel from 'codecrafters-frontend/models/course-stage';
 
-type Signature = {
+interface Signature {
   Element: HTMLDivElement;
 
   Args: {
@@ -17,7 +17,7 @@ type Signature = {
     activeRepository?: RepositoryModel;
     language: LanguageModel;
   };
-};
+}
 
 export default class CourseCardComponent extends Component<Signature> {
   @service declare authenticator: AuthenticatorService;

--- a/app/components/track-page/course-card/stage-list-item.ts
+++ b/app/components/track-page/course-card/stage-list-item.ts
@@ -3,14 +3,14 @@ import Component from '@glimmer/component';
 import type CourseStageModel from 'codecrafters-frontend/models/course-stage';
 import type AuthenticatorService from 'codecrafters-frontend/services/authenticator';
 
-type Signature = {
+interface Signature {
   Element: HTMLAnchorElement;
 
   Args: {
     isComplete: boolean;
     stage: CourseStageModel;
   };
-};
+}
 
 export default class StageListItemComponent extends Component<Signature> {
   @service declare authenticator: AuthenticatorService;

--- a/app/components/track-page/course-card/stage-list.ts
+++ b/app/components/track-page/course-card/stage-list.ts
@@ -2,14 +2,14 @@ import Component from '@glimmer/component';
 import type CourseModel from 'codecrafters-frontend/models/course';
 import type CourseStageModel from 'codecrafters-frontend/models/course-stage';
 
-type Signature = {
+interface Signature {
   Element: HTMLDivElement;
 
   Args: {
     completedStages: CourseStageModel[];
     course: CourseModel;
   };
-};
+}
 
 export default class StageListComponent extends Component<Signature> {}
 

--- a/app/components/tracks-page/track-card.ts
+++ b/app/components/tracks-page/track-card.ts
@@ -6,13 +6,13 @@ import type AuthenticatorService from 'codecrafters-frontend/services/authentica
 import type RouterService from '@ember/routing/router-service';
 import type Store from '@ember-data/store';
 
-type Signature = {
+interface Signature {
   Element: HTMLDivElement;
 
   Args: {
     language: LanguageModel;
   };
-};
+}
 
 export default class TrackCardComponent extends Component<Signature> {
   @service declare authenticator: AuthenticatorService;

--- a/app/components/user-page/course-progress-list.ts
+++ b/app/components/user-page/course-progress-list.ts
@@ -3,13 +3,13 @@ import { groupBy } from 'codecrafters-frontend/utils/lodash-utils';
 import type UserModel from 'codecrafters-frontend/models/user';
 import type CourseParticipationModel from 'codecrafters-frontend/models/course-participation';
 
-type Signature = {
+interface Signature {
   Element: HTMLDivElement;
 
   Args: {
     user: UserModel;
   };
-};
+}
 
 export default class CourseProgressListComponent extends Component<Signature> {
   get courseParticipationGroups() {

--- a/app/components/user-page/sidebar-container.ts
+++ b/app/components/user-page/sidebar-container.ts
@@ -3,13 +3,13 @@ import Component from '@glimmer/component';
 import { inject as service } from '@ember/service';
 import type UserModel from 'codecrafters-frontend/models/user';
 
-type Signature = {
+interface Signature {
   Element: HTMLDivElement;
 
   Args: {
     user: UserModel;
   };
-};
+}
 
 export default class SidebarContainerComponent extends Component<Signature> {
   @service declare authenticator: AuthenticatorService;

--- a/app/components/vertical-tab-list.ts
+++ b/app/components/vertical-tab-list.ts
@@ -1,12 +1,12 @@
 import Component from '@glimmer/component';
 
-type Signature = {
+interface Signature {
   Element: HTMLDivElement;
 
   Blocks: {
     default: [];
   };
-};
+}
 
 export default class VerticalTabListComponent extends Component<Signature> {}
 

--- a/app/components/vertical-tab-list/item.ts
+++ b/app/components/vertical-tab-list/item.ts
@@ -2,14 +2,14 @@ import type RouterService from '@ember/routing/router-service';
 import { service } from '@ember/service';
 import Component from '@glimmer/component';
 
-type Signature = {
+interface Signature {
   Element: HTMLDivElement;
 
   Args: {
     label: string;
     route: string;
   };
-};
+}
 
 export default class VerticalTabListItemComponent extends Component<Signature> {
   @service declare router: RouterService;

--- a/app/components/welcome-page/onboarding-survey-wizard.ts
+++ b/app/components/welcome-page/onboarding-survey-wizard.ts
@@ -8,14 +8,14 @@ import { service } from '@ember/service';
 import { task, timeout } from 'ember-concurrency';
 import { tracked } from '@glimmer/tracking';
 
-type Signature = {
+interface Signature {
   Args: {
     onboardingSurvey: OnboardingSurveyModel;
     onSurveyComplete: () => void;
   };
 
   Element: HTMLDivElement;
-};
+}
 
 export default class OnboardingSurveyWizardComponent extends Component<Signature> {
   fade = fade;

--- a/app/components/welcome-page/onboarding-survey-wizard/selectable-item.ts
+++ b/app/components/welcome-page/onboarding-survey-wizard/selectable-item.ts
@@ -1,7 +1,7 @@
 import Component from '@glimmer/component';
 import { toLeft, toRight } from 'ember-animated/transitions/move-over';
 
-type Signature = {
+interface Signature {
   Element: HTMLButtonElement;
 
   Args: {
@@ -11,7 +11,7 @@ type Signature = {
   Blocks: {
     default: [];
   };
-};
+}
 
 export default class SelectableItemComponent extends Component<Signature> {
   toRight = toRight;

--- a/app/components/welcome-page/onboarding-survey-wizard/step.ts
+++ b/app/components/welcome-page/onboarding-survey-wizard/step.ts
@@ -3,7 +3,7 @@ import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 import fade from 'ember-animated/transitions/fade';
 
-type Signature = {
+interface Signature {
   Args: {
     freeFormInput: string;
     onContinueButtonClick: () => void;
@@ -16,7 +16,7 @@ type Signature = {
   };
 
   Element: HTMLDivElement;
-};
+}
 
 export default class StepComponent extends Component<Signature> {
   fade = fade;

--- a/app/components/welcome-page/onboarding-survey-wizard/step1.ts
+++ b/app/components/welcome-page/onboarding-survey-wizard/step1.ts
@@ -2,7 +2,7 @@ import { action } from '@ember/object';
 import Component from '@glimmer/component';
 import type OnboardingSurveyModel from 'codecrafters-frontend/models/onboarding-survey';
 
-type Signature = {
+interface Signature {
   Args: {
     onboardingSurvey: OnboardingSurveyModel;
     onContinueButtonClick: () => void;
@@ -10,7 +10,7 @@ type Signature = {
   };
 
   Element: HTMLDivElement;
-};
+}
 
 export default class Step1Component extends Component<Signature> {
   options = ['Pick up a new language', 'Master a language', 'Build portfolio projects', 'Interview prep', 'Not sure yet'];

--- a/app/components/welcome-page/onboarding-survey-wizard/step2.ts
+++ b/app/components/welcome-page/onboarding-survey-wizard/step2.ts
@@ -2,7 +2,7 @@ import { action } from '@ember/object';
 import Component from '@glimmer/component';
 import type OnboardingSurveyModel from 'codecrafters-frontend/models/onboarding-survey';
 
-type Signature = {
+interface Signature {
   Args: {
     onboardingSurvey: OnboardingSurveyModel;
     onContinueButtonClick: () => void;
@@ -10,7 +10,7 @@ type Signature = {
   };
 
   Element: HTMLDivElement;
-};
+}
 
 export default class Step2Component extends Component<Signature> {
   options = [

--- a/app/controllers/concept-admin/question.ts
+++ b/app/controllers/concept-admin/question.ts
@@ -5,7 +5,7 @@ import { action } from '@ember/object';
 import { service } from '@ember/service';
 
 export default class QuestionController extends Controller {
-  @service router!: RouterService;
+  @service declare router: RouterService;
 
   declare model: {
     question: ConceptQuestionModel;

--- a/app/controllers/refer.ts
+++ b/app/controllers/refer.ts
@@ -6,7 +6,7 @@ import { inject as service } from '@ember/service';
 export default class ReferController extends Controller {
   declare model: { freeUsageGrants: FreeUsageGrantModel[] };
 
-  @service authenticator!: AuthenticatorService;
+  @service declare authenticator: AuthenticatorService;
 
   get currentUser() {
     return this.authenticator.currentUser;

--- a/app/modifiers/focus-on-insert.ts
+++ b/app/modifiers/focus-on-insert.ts
@@ -1,6 +1,6 @@
 import Modifier from 'ember-modifier';
 
-type Signature = {
+interface Signature {
   Args: {
     Positional: [];
 
@@ -8,7 +8,7 @@ type Signature = {
       preventScroll?: boolean;
     };
   };
-};
+}
 
 export default class FocusOnInsertModifier extends Modifier<Signature> {
   modify(element: HTMLElement, _positional: [], named: Signature['Args']['Named']) {

--- a/app/modifiers/highlight-code-blocks.ts
+++ b/app/modifiers/highlight-code-blocks.ts
@@ -26,11 +26,11 @@ import 'prismjs/components/prism-dart';
 import 'prismjs/components/prism-bash';
 import 'prismjs/components/prism-yaml';
 
-type Signature = {
+interface Signature {
   Args: {
     Positional: [contents: string];
   };
-};
+}
 
 const highlightCodeBlocks = modifier<Signature>((element, [_contents]) => {
   Prism.highlightAllUnder(element);

--- a/app/modifiers/in-viewport-did-change.ts
+++ b/app/modifiers/in-viewport-did-change.ts
@@ -1,10 +1,10 @@
 import { modifier } from 'ember-modifier';
 
-type Signature = {
+interface Signature {
   Args: {
     Positional: [callback: (isSticky: boolean) => void];
   };
-};
+}
 
 const inViewportDidChange = modifier<Signature>(function inViewportDidChange(element, [callback]: [(isSticky: boolean) => void]) {
   const observer = new IntersectionObserver(

--- a/app/modifiers/markdown-input.ts
+++ b/app/modifiers/markdown-input.ts
@@ -1,10 +1,10 @@
 import { modifier } from 'ember-modifier';
 
-type Signature = {
+interface Signature {
   Args: {
     Positional: [];
   };
-};
+}
 
 function handlePaste(event: ClipboardEvent) {
   const pastedData = event.clipboardData?.getData('text');

--- a/app/modifiers/route-will-change.ts
+++ b/app/modifiers/route-will-change.ts
@@ -7,11 +7,11 @@ import { action } from '@ember/object';
 import { inject as service } from '@ember/service';
 import { registerDestructor } from '@ember/destroyable';
 
-type Signature = {
+interface Signature {
   Args: {
     Positional: [(transition: Transition) => void];
   };
-};
+}
 
 function cleanup(instance: RouteWillChangeModifier) {
   instance.router.off('routeWillChange', instance.eventHandler);

--- a/app/modifiers/route-will-change.ts
+++ b/app/modifiers/route-will-change.ts
@@ -20,7 +20,7 @@ function cleanup(instance: RouteWillChangeModifier) {
 export default class RouteWillChangeModifier extends Modifier<Signature> {
   callback?: (transition: Transition) => void;
 
-  @service router!: RouterService;
+  @service declare router: RouterService;
 
   @action
   eventHandler(transition: Transition) {

--- a/app/modifiers/scroll-into-view.ts
+++ b/app/modifiers/scroll-into-view.ts
@@ -1,6 +1,6 @@
 import Modifier from 'ember-modifier';
 
-type Signature = {
+interface Signature {
   Args: {
     Positional: [];
 
@@ -9,7 +9,7 @@ type Signature = {
       block?: ScrollLogicalPosition;
     };
   };
-};
+}
 
 export default class ScrollIntoViewModifier extends Modifier<Signature> {
   modify(element: Element, _positional: [], named: Signature['Args']['Named']) {

--- a/app/modifiers/upscroll-on-insert.ts
+++ b/app/modifiers/upscroll-on-insert.ts
@@ -1,7 +1,7 @@
 import Modifier from 'ember-modifier';
 import scrollToTop from 'codecrafters-frontend/utils/scroll-to-top';
 
-type Signature = {
+interface Signature {
   Args: {
     Positional: [];
 
@@ -9,7 +9,7 @@ type Signature = {
       scrollableContainer?: string;
     };
   };
-};
+}
 
 export default class UpscrollOnInsertModifier extends Modifier<Signature> {
   modify(_: Element, _positional: [], named: Signature['Args']['Named']) {

--- a/app/routes/refer.ts
+++ b/app/routes/refer.ts
@@ -5,8 +5,8 @@ import Store from '@ember-data/store';
 import { inject as service } from '@ember/service';
 
 export default class ReferRoute extends BaseRoute {
-  @service authenticator!: AuthenticatorService;
-  @service store!: Store;
+  @service declare authenticator: AuthenticatorService;
+  @service declare store: Store;
 
   activate() {
     scrollToTop();

--- a/app/routes/referral-link.ts
+++ b/app/routes/referral-link.ts
@@ -10,8 +10,8 @@ import { inject as service } from '@ember/service';
 export default class ReferralLinkRoute extends BaseRoute {
   allowsAnonymousAccess = true;
 
-  @service authenticator!: AuthenticatorService;
-  @service store!: Store;
+  @service declare authenticator: AuthenticatorService;
+  @service declare store: Store;
   @service declare router: RouterService;
 
   activate() {

--- a/app/services/analytics-event-tracker.ts
+++ b/app/services/analytics-event-tracker.ts
@@ -8,7 +8,7 @@ export default class AnalyticsEventTrackerService extends Service {
   @service declare store: Store;
   @service declare router: RouterService;
   @service declare fastboot: FastBootService;
-  @service utmCampaignIdTracker: unknown;
+  @service declare utmCampaignIdTracker: unknown;
 
   track(eventName: string, eventProperties: Record<string, unknown>): void {
     // Don't track any analytics during FastBoot runs

--- a/app/utils/base-route.ts
+++ b/app/utils/base-route.ts
@@ -13,7 +13,7 @@ export default class BaseRoute extends Route {
   allowsAnonymousAccess = false;
   @service declare authenticator: AuthenticatorService;
   @service declare router: RouterService;
-  @service utmCampaignIdTracker: unknown;
+  @service declare utmCampaignIdTracker: unknown;
   @service declare fastboot: FastBootService;
 
   beforeModel(transition: Transition) {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Transitioned `Signature` type declarations across components from `type` to `interface`, enhancing extensibility and compatibility with TypeScript.
  - Removed the `Blocks` property from the `Signature` interface in the code walkthrough snippet, streamlining its structure.
  - Specified the `Element` property type more precisely in multiple components (e.g., changed from `HTMLElement` to `HTMLDivElement`), improving type safety and clarity.

- **Bug Fixes**
  - Resolved potential issues related to the extensibility of `Signature` definitions in multiple components.

- **Documentation**
  - Updated inline comments and documentation to reflect changes made to `Signature` declarations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->