### PR TITLE
add dark mode warning

### DIFF
--- a/app/components/header/account-dropdown.hbs
+++ b/app/components/header/account-dropdown.hbs
@@ -55,9 +55,18 @@
       <Header::AccountDropdownLink @text="Settings" @icon="cog" {{on "click" (fn this.handleSettingsLinkClick dd.actions)}} />
 
       <div class="flex items-center justify-between gap-8 px-3 py-1.5">
-        <span class="prose dark:prose-invert prose-sm">
-          Theme
-        </span>
+        <div class="flex items-center gap-1">
+          <span class="prose dark:prose-invert prose-sm">
+            Theme
+          </span>
+
+          {{#unless this.darkMode.currentRouteSupportsDarkMode}}
+            <div class="flex">
+              {{svg-jar "exclamation" class="w-5 h-5 text-yellow-500"}}
+              <EmberTooltip @text="This page does not support dark mode yet." />
+            </div>
+          {{/unless}}
+        </div>
 
         <DarkModeToggleWithUpgradePrompt @size="small" />
       </div>

--- a/app/components/header/account-dropdown.ts
+++ b/app/components/header/account-dropdown.ts
@@ -8,9 +8,11 @@ import type RouterService from '@ember/routing/router-service';
 import type Store from '@ember-data/store';
 import type TeamModel from 'codecrafters-frontend/models/team';
 import type FeatureFlagsService from 'codecrafters-frontend/services/feature-flags';
+import type DarkModeService from 'codecrafters-frontend/services/dark-mode';
 
 export default class AccountDropdownComponent extends Component {
   @service declare authenticator: AuthenticatorService;
+  @service declare darkMode: DarkModeService;
   @service declare featureFlags: FeatureFlagsService;
   @service declare router: RouterService;
   @service declare store: Store;

--- a/app/services/dark-mode.ts
+++ b/app/services/dark-mode.ts
@@ -90,7 +90,7 @@ export default class DarkModeService extends Service {
    * Returns whether current route supports Dark Mode
    * @private
    */
-  get #currentRouteSupportsDarkMode(): boolean {
+  get currentRouteSupportsDarkMode(): boolean {
     let currentRoute: RouteInfo | null = this.router.currentRoute;
 
     while (currentRoute) {
@@ -115,7 +115,7 @@ export default class DarkModeService extends Service {
    * "dark route", or derived from localStorage & system preference
    */
   get isEnabled(): boolean {
-    return this.#currentRouteSupportsDarkMode && (this.#currentRouteRequiresDarkMode || this.#isEnabledViaPreferences || this.isEnabledTemporarily);
+    return this.currentRouteSupportsDarkMode && (this.#currentRouteRequiresDarkMode || this.#isEnabledViaPreferences || this.isEnabledTemporarily);
   }
 
   /**


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added a conditional message in the account dropdown to inform users when dark mode is not supported on the current page.
	- Enhanced the account dropdown component to integrate dark mode functionality, improving user experience based on preferences.

- **Bug Fixes**
	- Made the `currentRouteSupportsDarkMode` method publicly accessible, facilitating better integration of dark mode features across the application. 

- **Styling Improvements**
	- Updated the HTML structure of the account dropdown for a cleaner layout, grouping related elements for better organization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->