### PR TITLE
CC-1361 Auto-select language when navigating from track page

### DIFF
--- a/app/components/course-page/introduction-step/create-repository-card.hbs
+++ b/app/components/course-page/introduction-step/create-repository-card.hbs
@@ -15,8 +15,7 @@
     {{#if (eq this.expandedSection.type "SelectLanguageSection")}}
       {{! @glint-expect-error not ts-fied yet }}
       <CoursePage::IntroductionStep::CreateRepositoryCard::SelectLanguageSection
-        {{! TODO: Fetch this from query params? }}
-        @preferredLanguageSlug={{null}}
+        @preferredLanguageSlug={{@preferredLanguageSlug}}
         @errorMessage={{this.repositoryCreationErrorMessage}}
         @repository={{@repository}}
         @onLanguageSelection={{this.handleLanguageSelection}}

--- a/app/components/course-page/introduction-step/create-repository-card.ts
+++ b/app/components/course-page/introduction-step/create-repository-card.ts
@@ -15,6 +15,7 @@ interface Signature {
 
   Args: {
     repository: RepositoryModel;
+    preferredLanguageSlug: string | undefined;
   };
 }
 

--- a/app/components/course-page/introduction-step/create-repository-card.ts
+++ b/app/components/course-page/introduction-step/create-repository-card.ts
@@ -14,8 +14,8 @@ interface Signature {
   Element: HTMLDivElement;
 
   Args: {
-    repository: RepositoryModel;
     preferredLanguageSlug: string | undefined;
+    repository: RepositoryModel;
   };
 }
 

--- a/app/components/course-page/introduction-step/create-repository-card/language-button.hbs
+++ b/app/components/course-page/introduction-step/create-repository-card/language-button.hbs
@@ -9,7 +9,7 @@
       {{/if}}
     </div>
 
-    <div class="text-base {{if @isSelected 'text-teal-500' 'group-hover:text-teal-500'}} font-semibold">
+    <div class="text-base {{if @isSelected 'text-teal-500' 'group-hover:text-teal-500'}} font-semibold" data-test-language-button-text>
       {{@language.name}}
     </div>
 

--- a/app/components/course-page/introduction-step/create-repository-card/language-button.hbs
+++ b/app/components/course-page/introduction-step/create-repository-card/language-button.hbs
@@ -1,4 +1,4 @@
-<TertiaryButton class="group {{if @isSelected 'border-teal-500'}}" ...attributes>
+<TertiaryButton class="group {{if @isSelected 'border-teal-500'}}" data-test-language-button ...attributes>
   <div class="flex items-center">
     <div class="flex items-center mr-2">
       {{#if @isSelected}}

--- a/app/components/course-page/introduction-step/create-repository-card/show-other-languages-button.hbs
+++ b/app/components/course-page/introduction-step/create-repository-card/show-other-languages-button.hbs
@@ -1,5 +1,5 @@
 {{! @glint-nocheck: not typesafe yet }}
-<TertiaryButton class="group" data-test-show-other-language-button ...attributes>
+<TertiaryButton class="group" data-test-show-other-languages-button ...attributes>
   <div class="flex items-center">
     <div class="flex items-center mr-2">
       {{svg-jar "code" class="text-gray-400 h-6 fill-current group-hover:text-teal-500"}}

--- a/app/components/course-page/introduction-step/create-repository-card/show-other-languages-button.hbs
+++ b/app/components/course-page/introduction-step/create-repository-card/show-other-languages-button.hbs
@@ -1,5 +1,5 @@
 {{! @glint-nocheck: not typesafe yet }}
-<TertiaryButton class="group" ...attributes>
+<TertiaryButton class="group" data-test-show-other-language-button ...attributes>
   <div class="flex items-center">
     <div class="flex items-center mr-2">
       {{svg-jar "code" class="text-gray-400 h-6 fill-current group-hover:text-teal-500"}}

--- a/app/routes/course.ts
+++ b/app/routes/course.ts
@@ -17,6 +17,7 @@ export type ModelType = {
   course: CourseModel;
   activeRepository: RepositoryModel;
   repositories: RepositoryModel[];
+  track: string | undefined;
 };
 
 export default class CourseRoute extends BaseRoute {
@@ -130,6 +131,7 @@ export default class CourseRoute extends BaseRoute {
       course: course,
       activeRepository: activeRepository,
       repositories: repositories,
+      track: transition.to?.queryParams['track'],
     };
   }
 

--- a/app/templates/course/introduction.hbs
+++ b/app/templates/course/introduction.hbs
@@ -7,5 +7,5 @@
   {{/if}}
 
   <CoursePage::IntroductionStep::WelcomeCard @repository={{@model.activeRepository}} class="mb-6" />
-  <CoursePage::IntroductionStep::CreateRepositoryCard @repository={{@model.activeRepository}} class="mb-6" />
+  <CoursePage::IntroductionStep::CreateRepositoryCard @repository={{@model.activeRepository}} @preferredLanguageSlug={{@model.track}} class="mb-6" />
 </div>

--- a/tests/acceptance/course-page/start-course-test.js
+++ b/tests/acceptance/course-page/start-course-test.js
@@ -35,7 +35,7 @@ module('Acceptance | course-page | start-course', function (hooks) {
     assert.strictEqual(coursePage.createRepositoryCard.languageButtons[0].text, 'Python', 'the only one language-button must be Python');
     assert.ok(coursePage.createRepositoryCard.showOtherLanguagesButton.isVisible, 'show-other-languages button is visible');
 
-    await coursePage.createRepositoryCard.clickOnShowOtherLanguagesButton();
+    await coursePage.createRepositoryCard.showOtherLanguagesButton.click();
     await percySnapshot('Auto Select Language - After Clicking Show-Other-Languages Button');
 
     assert.ok(coursePage.createRepositoryCard.languageButtons.length > 1, 'more than one language button are visible');

--- a/tests/acceptance/course-page/start-course-test.js
+++ b/tests/acceptance/course-page/start-course-test.js
@@ -28,11 +28,18 @@ module('Acceptance | course-page | start-course', function (hooks) {
     await catalogPage.clickOnTrack('Python');
     await trackPage.clickOnCourseCard('Build your own Dummy →');
 
-    await percySnapshot('Auto Select Language - Select Language');
+    await percySnapshot('Auto Select Language - Before Clicking Show-Other-Languages Button');
 
     assert.strictEqual(coursePage.createRepositoryCard.expandedSectionTitle, 'Preferred Language', 'current section title is preferred language');
-    assert.dom('button[data-test-language-button]').exists({ count: 1 }, 'show just one language button');
-    assert.ok(coursePage.createRepositoryCard.showOtherLanguageButton.isVisible, 'show other language button is visible');
+    assert.strictEqual(coursePage.createRepositoryCard.languageButtons.length, 1, 'only one language-button can be visible');
+    assert.strictEqual(coursePage.createRepositoryCard.languageButtons[0].text, 'Python', 'the only one language-button must be Python');
+    assert.ok(coursePage.createRepositoryCard.showOtherLanguagesButton.isVisible, 'show-other-languages button is visible');
+
+    await coursePage.createRepositoryCard.clickOnShowOtherLanguagesButton();
+    await percySnapshot('Auto Select Language - After Clicking Show-Other-Languages Button');
+
+    assert.ok(coursePage.createRepositoryCard.languageButtons.length > 1, 'more than one language button are visible');
+    assert.ok(coursePage.createRepositoryCard.showOtherLanguagesButton.isHidden, 'show-other-languages button is hidden');
 
     await animationsSettled();
   });

--- a/tests/acceptance/course-page/start-course-test.js
+++ b/tests/acceptance/course-page/start-course-test.js
@@ -17,6 +17,26 @@ module('Acceptance | course-page | start-course', function (hooks) {
   setupApplicationTest(hooks);
   setupAnimationTest(hooks);
 
+  test('can auto select language coming from track page', async function (assert) {
+    testScenario(this.server, ['dummy']);
+    signIn(this.owner, this.server);
+
+    const course = this.server.schema.courses.findBy({ slug: 'dummy' });
+    course.update({ releaseStatus: 'live' });
+
+    await catalogPage.visit();
+    await catalogPage.clickOnTrack('Python');
+    await trackPage.clickOnCourseCard('Build your own Dummy →');
+
+    await percySnapshot('Auto Select Language - Select Language');
+
+    assert.strictEqual(coursePage.createRepositoryCard.expandedSectionTitle, 'Preferred Language', 'current section title is preferred language');
+    assert.dom('button[data-test-language-button]').exists({ count: 1 }, 'show just one language button');
+    assert.ok(coursePage.createRepositoryCard.showOtherLanguageButton.isVisible, 'show other language button is visible');
+
+    await animationsSettled();
+  });
+
   test('can start course', async function (assert) {
     testScenario(this.server, ['dummy']);
     signIn(this.owner, this.server);

--- a/tests/pages/components/course-page/create-repository-card.js
+++ b/tests/pages/components/course-page/create-repository-card.js
@@ -7,7 +7,6 @@ export default {
   clickOnNextQuestionButton: clickable('[data-test-next-question-button]'),
   clickOnOptionButton: clickOnText('button'),
   clickOnRequestLanguageButton: clickable('.ember-basic-dropdown-trigger'),
-  clickOnShowOtherLanguagesButton: clickable('[data-test-show-other-languages-button]'),
   continueButton: { scope: '[data-test-continue-button]' },
   copyableCloneRepositoryInstructions: text('[data-test-copyable-repository-clone-instructions] .font-mono'),
   description: text('[data-test-course-description]'),

--- a/tests/pages/components/course-page/create-repository-card.js
+++ b/tests/pages/components/course-page/create-repository-card.js
@@ -1,4 +1,4 @@
-import { clickOnText, clickable, isVisible, text } from 'ember-cli-page-object';
+import { collection, clickOnText, clickable, isVisible, text } from 'ember-cli-page-object';
 import requestLanguageDropdown from './repository-setup-card/request-language-dropdown';
 
 export default {
@@ -7,13 +7,16 @@ export default {
   clickOnNextQuestionButton: clickable('[data-test-next-question-button]'),
   clickOnOptionButton: clickOnText('button'),
   clickOnRequestLanguageButton: clickable('.ember-basic-dropdown-trigger'),
+  clickOnShowOtherLanguagesButton: clickable('[data-test-show-other-languages-button]'),
   continueButton: { scope: '[data-test-continue-button]' },
-  showOtherLanguageButton: { scope: '[data-test-show-other-language-button]' },
   copyableCloneRepositoryInstructions: text('[data-test-copyable-repository-clone-instructions] .font-mono'),
   description: text('[data-test-course-description]'),
   expandedSectionTitle: text('[data-test-expanded-section-title]'),
   footerText: text('[data-test-footer]'),
   hasRequestedLanguagesPrompt: isVisible('[data-test-requested-languages-prompt]'),
+  languageButtons: collection('[data-test-language-button]', {
+    text: text('[data-test-language-button-text]'),
+  }),
 
   requestedLanguagesPrompt: {
     scope: '[data-test-requested-languages-prompt]',
@@ -22,6 +25,7 @@ export default {
 
   requestLanguageDropdown: requestLanguageDropdown,
   scope: '[data-test-create-repository-card]',
+  showOtherLanguagesButton: { scope: '[data-test-show-other-languages-button]' },
 
   get statusIsInProgress() {
     return this.statusText === 'In-progress';

--- a/tests/pages/components/course-page/create-repository-card.js
+++ b/tests/pages/components/course-page/create-repository-card.js
@@ -8,6 +8,7 @@ export default {
   clickOnOptionButton: clickOnText('button'),
   clickOnRequestLanguageButton: clickable('.ember-basic-dropdown-trigger'),
   continueButton: { scope: '[data-test-continue-button]' },
+  showOtherLanguageButton: { scope: '[data-test-show-other-language-button]' },
   copyableCloneRepositoryInstructions: text('[data-test-copyable-repository-clone-instructions] .font-mono'),
   description: text('[data-test-course-description]'),
   expandedSectionTitle: text('[data-test-expanded-section-title]'),


### PR DESCRIPTION
**Checklist**:

- [x] I've thoroughly self-reviewed my changes
- [x] I've added tests for my changes
- [x] I've verified any visual changes using Percy (add a commit with `[percy]` in the message to trigger)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
	- The `CreateRepositoryCard` component now dynamically receives the preferred language from the parent context, enhancing user experience by catering to language preferences.
	- A new `track` property has been introduced to the course model, allowing for better tracking and analytics of course navigation.
	- Acceptance tests have been added to verify the functionality of auto-selecting a language based on user interactions.

- **Bug Fixes**
	- Resolved the issue of the `CreateRepositoryCard` not receiving preferred language information by updating its property binding.

- **Improvements**
	- Enhanced testability of buttons in the `CreateRepositoryCard` component with new data attributes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->