### PR TITLE
Support `collapseUnchanged` option in CodeMirror's merge view

### DIFF
--- a/app/components/code-mirror.hbs
+++ b/app/components/code-mirror.hbs
@@ -24,8 +24,9 @@
   {{did-update (fn this.optionDidChange "lineNumbers") @lineNumbers}}
   {{did-update (fn this.optionDidChange "lineSeparator") @lineSeparator}}
   {{did-update (fn this.optionDidChange "lineWrapping") @lineWrapping}}
-  {{did-update (fn this.optionDidChange "originalDocumentOrMergeControls") @mergeControls}}
-  {{did-update (fn this.optionDidChange "originalDocumentOrMergeControls") @originalDocument}}
+  {{did-update (fn this.optionDidChange "originalDocumentOrMergeControlsOrCollapseUnchanged") @mergeControls}}
+  {{did-update (fn this.optionDidChange "originalDocumentOrMergeControlsOrCollapseUnchanged") @originalDocument}}
+  {{did-update (fn this.optionDidChange "originalDocumentOrMergeControlsOrCollapseUnchanged") @collapseUnchanged}}
   {{did-update (fn this.optionDidChange "placeholder") @placeholder}}
   {{did-update (fn this.optionDidChange "readOnly") @readOnly}}
   {{did-update (fn this.optionDidChange "rectangularSelection") @rectangularSelection}}

--- a/app/components/code-mirror.ts
+++ b/app/components/code-mirror.ts
@@ -307,7 +307,7 @@ const OPTION_HANDLERS: OptionHandlersSignature = {
           unifiedMergeView({
             original: originalDocument,
             mergeControls: !!mergeControls,
-            // collapseUnchanged: { margin: 3, minSize: 4 },
+            collapseUnchanged: { margin: 2, minSize: 4 },
           }),
         ]
       : [];

--- a/app/components/code-mirror.ts
+++ b/app/components/code-mirror.ts
@@ -178,6 +178,10 @@ export interface Signature {
        */
       mergeControls?: boolean;
       /**
+       * Enable collapsing unchanged lines in the diff editor
+       */
+      collapseUnchanged?: boolean;
+      /**
        * Preserve changes history when parent component passes a new `@document` to the component
        */
       preserveHistory?: boolean;
@@ -235,7 +239,7 @@ export interface OptionHandlersSignature {
   tabSize: (tabSize?: number) => Extension[];
   theme: (theme?: Extension) => Extension[];
   languageOrFilename: (newValue: string | undefined, args: Signature['Args']['Named'], changedOptionName?: string) => Promise<Extension[]>;
-  originalDocumentOrMergeControls: (
+  originalDocumentOrMergeControlsOrCollapseUnchanged: (
     newValue: string | boolean | undefined,
     args: Signature['Args']['Named'],
     changedOptionName?: string,
@@ -301,13 +305,13 @@ const OPTION_HANDLERS: OptionHandlersSignature = {
 
     return loadedLanguage ? [loadedLanguage] : [];
   },
-  originalDocumentOrMergeControls: (_newValue, { originalDocument, mergeControls }) => {
+  originalDocumentOrMergeControlsOrCollapseUnchanged: (_newValue, { originalDocument, mergeControls, collapseUnchanged }) => {
     return originalDocument
       ? [
           unifiedMergeView({
             original: originalDocument,
             mergeControls: !!mergeControls,
-            collapseUnchanged: { margin: 2, minSize: 4 },
+            collapseUnchanged: collapseUnchanged ? { margin: 2, minSize: 4 } : undefined,
           }),
         ]
       : [];
@@ -353,7 +357,7 @@ export default class CodeMirrorComponent extends Component<Signature> {
     const handlerMethod = OPTION_HANDLERS[optionName];
 
     // some compartments need to be unloaded before new changes are applied
-    if (['originalDocumentOrMergeControls'].includes(optionName)) {
+    if (['originalDocumentOrMergeControlsOrCollapseUnchanged'].includes(optionName)) {
       this.renderedView?.dispatch({
         effects: compartment?.reconfigure([]),
       });

--- a/app/controllers/demo/code-mirror.ts
+++ b/app/controllers/demo/code-mirror.ts
@@ -176,6 +176,7 @@ export default class DemoCodeMirrorController extends Controller {
   @tracked lineSeparator: boolean = true;
   @tracked lineWrapping: boolean = true;
   @tracked mergeControls: boolean = true;
+  @tracked collapseUnchanged: boolean = true;
   @tracked originalDocument: boolean = false;
   @tracked placeholder: boolean = true;
   @tracked preserveHistory: boolean = false;

--- a/app/controllers/demo/code-mirror.ts
+++ b/app/controllers/demo/code-mirror.ts
@@ -46,7 +46,10 @@ export default class DemoCodeMirrorController extends Controller {
 
   @tracked documents: ExampleDocument[] = [
     new ExampleDocument({
-      document: 'An example plain-text document',
+      document:
+        'An example plain-text document 1\nAn example plain-text document 2\nAn example plain-text document 3\nAn example plain-text document 4\nAn example plain-text document 5\nAn example plain-text document 6\nAn example plain-text document 7\nAn example plain-text document 8\nAn example plain-text document 9\nAn example plain-text modified document 10\nAn example plain-text document 11\nAn example plain-text document 12\nAn example plain-text document 13\nAn example plain-text document 14\nAn example plain-text document 15\nAn example plain-text document 16\nAn example plain-text document 17\nAn example plain-text document 18\nAn example plain-text document 19',
+      originalDocument:
+        'An example plain-text document 1\nAn example plain-text document 2\nAn example plain-text document 3\nAn example plain-text document 4\nAn example plain-text document 5\nAn example plain-text document 6\nAn example plain-text document 7\nAn example plain-text document 8\nAn example plain-text document 9\nAn example plain-text document 10\nAn example plain-text document 11\nAn example plain-text document 12\nAn example plain-text document 13\nAn example plain-text document 14\nAn example plain-text document 15\nAn example plain-text document 16\nAn example plain-text document 17\nAn example plain-text document 18\nAn example plain-text document 19',
       filename: 'test.txt',
       language: 'text',
     }),

--- a/app/templates/demo/code-mirror.hbs
+++ b/app/templates/demo/code-mirror.hbs
@@ -132,6 +132,10 @@
       </label>
     </codemirror-options-left>
     <codemirror-options-right class="flex flex-wrap">
+      <label class="{{labelClasses}}" title="Enable collapsing unchanged lines in the diff editor">
+        <Input @type="checkbox" @checked={{this.collapseUnchanged}} disabled={{not this.originalDocument}} />
+        <span class="ml-2 {{unless this.originalDocument 'text-gray-300'}}">collapseUnchanged</span>
+      </label>
       <label class="{{labelClasses}}" title="Enable showing accept/reject buttons in the diff editor">
         <Input @type="checkbox" @checked={{this.mergeControls}} disabled={{not this.originalDocument}} />
         <span class="ml-2 {{unless this.originalDocument 'text-gray-300'}}">mergeControls</span>
@@ -284,6 +288,7 @@
   @lineNumbers={{this.lineNumbers}}
   @lineWrapping={{this.lineWrapping}}
   @mergeControls={{this.mergeControls}}
+  @collapseUnchanged={{this.collapseUnchanged}}
   @preserveHistory={{this.preserveHistory}}
   @readOnly={{this.readOnly}}
   @rectangularSelection={{this.rectangularSelection}}

--- a/app/utils/code-mirror-themes.ts
+++ b/app/utils/code-mirror-themes.ts
@@ -31,6 +31,10 @@ const BASE_STYLE = {
     lineHeight: '1.5rem',
     padding: '0 1rem 0 0.625rem',
   },
+  '.cm-deletedChunk': {
+    lineHeight: '1.5rem',
+    padding: '0 1rem 0 0.625rem',
+  },
 };
 
 export const codeCraftersLight = [EditorView.theme(Object.assign({}, BASE_STYLE), { dark: false }), githubLight];

--- a/tests/integration/components/code-mirror-test.js
+++ b/tests/integration/components/code-mirror-test.js
@@ -374,6 +374,18 @@ module('Integration | Component | code-mirror', function (hooks) {
       skip('it does something useful with the editor');
     });
 
+    module('collapseUnchanged', function () {
+      test("it doesn't break the editor when passed", async function (assert) {
+        this.set('collapseUnchanged', true);
+        await render(hbs`<CodeMirror @collapseUnchanged={{this.collapseUnchanged}} />`);
+        assert.ok(codeMirror.hasRendered);
+        this.set('collapseUnchanged', false);
+        assert.ok(codeMirror.hasRendered);
+      });
+
+      skip('it does something useful with the editor');
+    });
+
     module('originalDocument', function () {
       test("it doesn't break the editor when passed", async function (assert) {
         this.set('originalDocument', 'original content');


### PR DESCRIPTION
Related to #1231 

### Brief

This adds support for collapsing long blocks of unchanged lines in CodeMirror's merge view.

### Details

- Added `@collapseUnchanged` argument to CodeMirror component
- Added a test for `@collapseUnchanged` argument
- Fixed styles of `.cm-deletedChunk`
- There is currently no straightforward way to customize "⦚ X unchanged lines ⦚" text :(

### Video

https://github.com/user-attachments/assets/27b04fd8-61e7-4354-a295-f64b6d14b032

### Checklist

- [x] I've thoroughly self-reviewed my changes
- [x] I've added tests for my changes, unless they affect admin-only areas (or are otherwise not worth testing)
- [x] I've verified any visual changes using Percy (add a commit with `[percy]` in the message to trigger)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a new option to collapse unchanged lines within the CodeMirror editor.
  - Added a checkbox in the UI to enable or disable the collapsing functionality.

- **Bug Fixes**
  - Improved handling of document states for better user experience.

- **Visual Improvements**
  - Enhanced styling for visual consistency of deleted code segments in the editor.

- **Tests**
  - Added integration tests to verify functionality related to the new collapsing feature.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->