### PR TITLE
CC-1371: Add "deprecated" notice to course pages

### DIFF
--- a/app/controllers/course-overview.ts
+++ b/app/controllers/course-overview.ts
@@ -25,6 +25,10 @@ export default class CourseOverviewController extends Controller {
     }
   }
 
+  get currentUser() {
+    return this.authenticator.currentUser;
+  }
+
   get formattedCourseIsFreeExpirationDate() {
     if (this.model.course.isFreeUntil) {
       return format(this.model.course.isFreeUntil, 'd MMMM yyyy');

--- a/app/templates/course-overview.hbs
+++ b/app/templates/course-overview.hbs
@@ -14,6 +14,13 @@
           This challenge is free until
           {{this.formattedCourseIsFreeExpirationDate}}!
         </AlertWithIcon>
+      {{else if this.model.course.releaseStatusIsDeprecated}}
+        <AlertWithIcon @type="info" class="mb-4" data-test-course-deprecated-notice>
+          This challenge is deprecated.<br />
+          {{#if this.currentUser.canAccessMembershipBenefits}}
+            Since you're a member, you can still access the challenge if you'd like.
+          {{/if}}
+        </AlertWithIcon>
       {{/if}}
 
       <CourseOverviewPage::IntroductionAndStages @course={{this.model.course}} class="w-full mb-4" />

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,7 @@
         "player.js": "^0.1.0",
         "posthog-js": "^1.158.1",
         "showdown": "^2.1.0",
-        "three": "^0.167.1",
+        "three": "^0.168.0",
         "web-vitals": "^4.2.3"
       },
       "devDependencies": {
@@ -45119,9 +45119,9 @@
       }
     },
     "node_modules/three": {
-      "version": "0.167.1",
-      "resolved": "https://registry.npmjs.org/three/-/three-0.167.1.tgz",
-      "integrity": "sha512-gYTLJA/UQip6J/tJvl91YYqlZF47+D/kxiWrbTon35ZHlXEN0VOo+Qke2walF1/x92v55H6enomymg4Dak52kw=="
+      "version": "0.168.0",
+      "resolved": "https://registry.npmjs.org/three/-/three-0.168.0.tgz",
+      "integrity": "sha512-6m6jXtDwMJEK/GGMbAOTSAmxNdzKvvBzgd7q8bE/7Tr6m7PaBh5kKLrN7faWtlglXbzj7sVba48Idwx+NRsZXw=="
     },
     "node_modules/through": {
       "version": "2.3.8",

--- a/package.json
+++ b/package.json
@@ -213,7 +213,7 @@
     "player.js": "^0.1.0",
     "posthog-js": "^1.158.1",
     "showdown": "^2.1.0",
-    "three": "^0.167.1",
+    "three": "^0.168.0",
     "web-vitals": "^4.2.3"
   },
   "fastbootDependencies": [

--- a/tests/acceptance/view-course-overview-test.js
+++ b/tests/acceptance/view-course-overview-test.js
@@ -6,7 +6,7 @@ import testScenario from 'codecrafters-frontend/mirage/scenarios/test';
 import { currentURL } from '@ember/test-helpers';
 import { module, test } from 'qunit';
 import { setupApplicationTest } from 'codecrafters-frontend/tests/helpers';
-import { signIn } from 'codecrafters-frontend/tests/support/authentication-helpers';
+import { signIn, signInAsSubscriber } from 'codecrafters-frontend/tests/support/authentication-helpers';
 
 module('Acceptance | view-course-overview', function (hooks) {
   setupApplicationTest(hooks);
@@ -75,6 +75,28 @@ module('Acceptance | view-course-overview', function (hooks) {
     assert.strictEqual(
       courseOverviewPage.betaNoticeText,
       "This challenge is free to try when it's in beta. We keep challenges in beta for a few weeks to gather feedback.",
+    );
+  });
+
+  test('it has the notice for when a course is deprecated', async function (assert) {
+    testScenario(this.server);
+
+    this.server.schema.courses.findBy({ slug: 'docker' }).update('releaseStatus', 'deprecated');
+    await courseOverviewPage.visit({ course_slug: 'docker' });
+
+    assert.strictEqual(courseOverviewPage.deprecatedNoticeText, 'This challenge is deprecated.');
+  });
+
+  test('it has a longer notice for paid users when a course is deprecated', async function (assert) {
+    testScenario(this.server);
+    signInAsSubscriber(this.owner, this.server);
+
+    this.server.schema.courses.findBy({ slug: 'docker' }).update('releaseStatus', 'deprecated');
+    await courseOverviewPage.visit({ course_slug: 'docker' });
+
+    assert.strictEqual(
+      courseOverviewPage.deprecatedNoticeText,
+      "This challenge is deprecated. Since you're a member, you can still access the challenge if you'd like.",
     );
   });
 

--- a/tests/pages/course-overview-page.js
+++ b/tests/pages/course-overview-page.js
@@ -8,6 +8,7 @@ export default create({
 
   betaNoticeText: text('[data-test-course-beta-notice]'),
   clickOnStartCourse: clickable('[data-test-course-overview-header] [data-test-start-course-button]'),
+  deprecatedNoticeText: text('[data-test-course-deprecated-notice]'),
   freeNoticeText: text('[data-test-course-free-notice]'),
   stageListItems: collection('[data-test-stage-list-item]'),
   visit: visitable('/courses/:course_slug/overview'),


### PR DESCRIPTION
**Checklist**:

- [x] I've thoroughly self-reviewed my changes
- [x] I've added tests for my changes, unless they affect admin-only areas (or are otherwise not worth testing)
- [x] I've verified any visual changes using Percy (add a commit with `[percy]` in the message to trigger)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
	- Added a user access feature that displays the current user's information in the course overview.
	- Introduced conditional alerts for deprecated courses, informing users of their access status based on membership.

- **Bug Fixes**
	- Enhanced acceptance tests to ensure appropriate messaging for both regular and subscriber users regarding deprecated courses.

- **Tests**
	- Expanded test coverage for course deprecation scenarios, ensuring robust user feedback.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->