### PR TITLE
Tweak `git commit` command

### DIFF
--- a/app/components/course-page/course-stage-step/first-stage-instructions-card/submit-code-step.hbs
+++ b/app/components/course-page/course-stage-step/first-stage-instructions-card/submit-code-step.hbs
@@ -4,7 +4,7 @@
   </p>
 </div>
 
-<CopyableTerminalCommand @commands={{array 'git commit -am "<any message>"' "git push origin master"}} class="mb-3" />
+<CopyableTerminalCommand @commands={{array 'git commit -am "[any message]"' "git push origin master"}} class="mb-3" />
 
 <div class="prose dark:prose-invert">
   <p class={{if @isComplete "line-through"}}>

--- a/app/components/course-page/course-stage-step/first-stage-instructions-card/submit-code-step.hbs
+++ b/app/components/course-page/course-stage-step/first-stage-instructions-card/submit-code-step.hbs
@@ -4,7 +4,7 @@
   </p>
 </div>
 
-<CopyableTerminalCommand @commands={{array "git commit -am 'pass 1st stage' # any msg" "git push origin master"}} class="mb-3" />
+<CopyableTerminalCommand @commands={{array 'git commit -am "<any message>"' "git push origin master"}} class="mb-3" />
 
 <div class="prose dark:prose-invert">
   <p class={{if @isComplete "line-through"}}>

--- a/app/components/course-page/course-stage-step/test-runner-card/move-to-next-step-instructions.ts
+++ b/app/components/course-page/course-stage-step/test-runner-card/move-to-next-step-instructions.ts
@@ -29,7 +29,7 @@ export default class MoveToNextStepInstructionsComponent extends Component<Signa
 
     const gitVariant = {
       label: 'git',
-      commands: ['git add .', 'git commit --allow-empty -m "pass stage" # any message', 'git push origin master'],
+      commands: ['git add .', 'git commit --allow-empty -m "[any message]"', 'git push origin master'],
     };
 
     if (this.recommendedClientType === 'cli') {

--- a/app/components/course-page/course-stage-step/test-runner-card/refactor-code-instructions.ts
+++ b/app/components/course-page/course-stage-step/test-runner-card/refactor-code-instructions.ts
@@ -29,7 +29,7 @@ export default class RefactorCodeInstructionsComponent extends Component<Signatu
 
     const gitVariant = {
       label: 'git',
-      commands: ['git add .', 'git commit --allow-empty -m "run tests" # any message', 'git push origin master'],
+      commands: ['git add .', 'git commit --allow-empty -m "[any message]"', 'git push origin master'],
     };
 
     if (this.recommendedClientType === 'cli') {

--- a/app/components/course-page/course-stage-step/test-runner-card/run-tests-instructions.ts
+++ b/app/components/course-page/course-stage-step/test-runner-card/run-tests-instructions.ts
@@ -30,7 +30,7 @@ export default class RunTestsInstructionsComponent extends Component<Signature> 
 
     const gitVariant = {
       label: 'git',
-      commands: ['git add .', 'git commit --allow-empty -m "pass stage" # any message', 'git push origin master'],
+      commands: ['git add .', 'git commit --allow-empty -m "[any message]"', 'git push origin master'],
     };
 
     if (this.recommendedClientType === 'cli') {

--- a/tests/acceptance/course-page/test-runner-card-test.js
+++ b/tests/acceptance/course-page/test-runner-card-test.js
@@ -44,7 +44,7 @@ module('Acceptance | course-page | test-runner-card', function (hooks) {
 
     assert.strictEqual(
       coursePage.testRunnerCard.copyableTerminalCommands[0].copyableText,
-      ['git add .', 'git commit --allow-empty -m "pass stage" # any message', 'git push origin master'].join(' '),
+      ['git add .', 'git commit --allow-empty -m "[any message]"', 'git push origin master'].join(' '),
       'copyable text is updated to include git commands',
     );
 


### PR DESCRIPTION
**Checklist**:

- [x] I've thoroughly self-reviewed my changes
- [x] Not worth testing
- [x] I've verified any visual changes using Percy (add a commit with `[percy]` in the message to trigger)

1. Change single quotes to double quotes
2. Move `# any msg` inside the double quotes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
	- Enhanced clarity in terminal command inputs by replacing specific placeholders with more generic ones, allowing users greater flexibility in documenting their commits and improving overall user experience.
  
- **Bug Fixes**
	- Updated test assertions to reflect the new generic placeholder format, ensuring broader applicability in testing scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->