### PR TITLE
Add waitFor decorator to loadResources method in GitHub integration modal.

### DIFF
--- a/app/components/course-page/configure-github-integration-modal.js
+++ b/app/components/course-page/configure-github-integration-modal.js
@@ -4,6 +4,7 @@ import { action } from '@ember/object';
 import { inject as service } from '@ember/service';
 import { partition } from 'codecrafters-frontend/utils/lodash-utils';
 import { tracked } from '@glimmer/tracking';
+import { waitFor } from '@ember/test-waiters';
 import rippleSpinnerImage from '/assets/images/icons/ripple-spinner.svg';
 
 export default class ConfigureGithubIntegrationModalComponent extends Component {
@@ -92,6 +93,7 @@ export default class ConfigureGithubIntegrationModalComponent extends Component 
   }
 
   @action
+  @waitFor
   async loadResources() {
     // Already exists, we can reload async
     if (this.githubRepositorySyncConfiguration) {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced resource loading in the GitHub integration modal, ensuring data is fully available before user actions.
  
- **Bug Fixes**
	- Improved control flow for loading resources, potentially reducing errors related to incomplete data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->