### PR TITLE
CC-1393: Change copy to make it more clear what "free usage" means in "X days free" badge + referrals page

### DIFF
--- a/app/components/course-page/course-stage-step/community-solution-card/header-label.hbs
+++ b/app/components/course-page/course-stage-step/community-solution-card/header-label.hbs
@@ -14,7 +14,6 @@
   <Pill @color="green" ...attributes>
     Yours
 
-    {{! @glint-expect-error not types yet }}
     <EmberPopover @popperContainer="body">
       <div class="prose prose-sm prose-invert text-white">
         <p>

--- a/app/components/course-page/step-progress-indicator.hbs
+++ b/app/components/course-page/step-progress-indicator.hbs
@@ -24,7 +24,6 @@
       <div class="flex ml-1 mb-px group/tooltip-trigger">
         {{svg-jar "question-mark-circle" class="w-4 h-4 fill-current text-gray-300 dark:text-gray-500 group-hover/tooltip-trigger:text-gray-400"}}
 
-        {{! @glint-expect-error EmberPopover is not typed }}
         <EmberPopover @popperContainer="body">
           <div class="prose prose-sm prose-invert text-white">
             {{! The extra #if here is solely for type-checking }}

--- a/app/components/feature-card.hbs
+++ b/app/components/feature-card.hbs
@@ -5,11 +5,13 @@
     <div class="text-gray-700 font-semibold mb-2 transition-colors">
       {{@title}}
     </div>
-    <div class="text-gray-500 text-xs leading-5 markdown-list">
-      {{markdown-to-html @contentMarkdown}}
-      {{#if (has-block "popover")}}
-        {{yield to="popover"}}
-      {{/if}}
-    </div>
+
+    {{#if (has-block "content")}}
+      {{yield to="content"}}
+    {{else if @contentMarkdown}}
+      <div class="text-gray-500 text-xs leading-5">
+        {{markdown-to-html @contentMarkdown}}
+      </div>
+    {{/if}}
   </div>
 </div>

--- a/app/components/feature-card.hbs
+++ b/app/components/feature-card.hbs
@@ -7,6 +7,13 @@
     </div>
     <div class="text-gray-500 text-xs leading-5 markdown-list">
       {{markdown-to-html @contentMarkdown}}
+      {{#if @popover}}
+        {{! @glint-ignore }}
+        <EmberPopover @targetId={{@popover.targetId}} @side="bottom">
+          {{html-safe @popover.html}}
+        </EmberPopover>
+        {{! @glint-ignore }}
+      {{/if}}
     </div>
   </div>
 </div>

--- a/app/components/feature-card.hbs
+++ b/app/components/feature-card.hbs
@@ -9,7 +9,7 @@
     {{#if (has-block "content")}}
       {{yield to="content"}}
     {{else if @contentMarkdown}}
-      <div class="text-gray-500 text-xs leading-5">
+      <div class="text-gray-500 text-xs leading-5 markdown-list">
         {{markdown-to-html @contentMarkdown}}
       </div>
     {{/if}}

--- a/app/components/feature-card.hbs
+++ b/app/components/feature-card.hbs
@@ -7,12 +7,8 @@
     </div>
     <div class="text-gray-500 text-xs leading-5 markdown-list">
       {{markdown-to-html @contentMarkdown}}
-      {{#if @popover}}
-        {{! @glint-ignore }}
-        <EmberPopover @targetId={{@popover.targetId}} @side="bottom">
-          {{html-safe @popover.html}}
-        </EmberPopover>
-        {{! @glint-ignore }}
+      {{#if (has-block "popover")}}
+        {{yield to="popover"}}
       {{/if}}
     </div>
   </div>

--- a/app/components/feature-card.ts
+++ b/app/components/feature-card.ts
@@ -6,8 +6,11 @@ interface Signature {
   Args: {
     contentMarkdown: string;
     imageUrl: string;
-    popover?: { targetId: string; html: string };
     title: string;
+  };
+
+  Blocks: {
+    popover?: [];
   };
 }
 

--- a/app/components/feature-card.ts
+++ b/app/components/feature-card.ts
@@ -4,13 +4,13 @@ interface Signature {
   Element: HTMLDivElement;
 
   Args: {
-    contentMarkdown: string;
+    contentMarkdown?: string;
     imageUrl: string;
     title: string;
   };
 
   Blocks: {
-    popover?: [];
+    content?: [];
   };
 }
 

--- a/app/components/feature-card.ts
+++ b/app/components/feature-card.ts
@@ -6,6 +6,7 @@ interface Signature {
   Args: {
     contentMarkdown: string;
     imageUrl: string;
+    popover?: { targetId: string; html: string };
     title: string;
   };
 }

--- a/app/components/header/free-weeks-left-button.ts
+++ b/app/components/header/free-weeks-left-button.ts
@@ -30,7 +30,7 @@ export default class FreeWeeksLeftButtonComponent extends Component<Signature> {
   }
 
   get freeWeeksLeftTooltipCopy() {
-    return `Your free usage expires on ${format(this.currentUser?.lastFreeUsageGrantExpiresAt as Date, 'PP')}.`;
+    return `Your free content access expires on ${format(this.currentUser?.lastFreeUsageGrantExpiresAt as Date, 'PP')}.`;
   }
 }
 

--- a/app/components/referrals-page/referral-feature-cards.hbs
+++ b/app/components/referrals-page/referral-feature-cards.hbs
@@ -1,15 +1,41 @@
 <div ...attributes>
   {{#each this.featureList as |feature|}}
     <div class="flex justify-center">
-      <FeatureCard @contentMarkdown={{feature.bodyMarkdown}} @imageUrl={{feature.imageUrl}} @title={{feature.title}}>
-        <:popover>
-          {{#if feature.popover}}
-            {{! @glint-expect-error EmberPopover is not typed }}
-            <EmberPopover @targetId={{feature.popover.targetId}} @side="bottom">
-              {{html-safe feature.popover.html}}
-            </EmberPopover>
-          {{/if}}
-        </:popover>
+      <FeatureCard @imageUrl={{feature.imageUrl}} @title={{feature.title}}>
+        <:content>
+          <div class="text-gray-500 text-xs leading-5">
+            {{#if (eq feature.slug "generate-link")}}
+              <p>
+                Refer friends with a unique URL.
+              </p>
+            {{else if (eq feature.slug "gift-one-week-free")}}
+              <p>
+                Each referral gets 1 week of
+                <u class="decoration-dotted">
+                  paid content access
+
+                  <EmberPopover @side="bottom">
+                    Includes all stages from paid challenges, but excludes other membership benefits like dark mode, turbo test runs etc.
+                    <a href="https://docs.codecrafters.io/membership/content" class="underline">Learn more</a>
+                  </EmberPopover>
+                </u>
+              </p>
+            {{else if (eq feature.slug "get-one-year-free")}}
+              <p>
+                1 week of
+                <u class="decoration-dotted">
+                  paid content access
+
+                  <EmberPopover @side="bottom">
+                    Includes all stages from paid challenges, but excludes other membership benefits like dark mode, turbo test runs etc.
+                    <a href="https://docs.codecrafters.io/membership/content" class="underline">Learn more</a>
+                  </EmberPopover>
+                </u>
+                per referral. Up to 52 weeks.'
+              </p>
+            {{/if}}
+          </div>
+        </:content>
       </FeatureCard>
     </div>
   {{/each}}

--- a/app/components/referrals-page/referral-feature-cards.hbs
+++ b/app/components/referrals-page/referral-feature-cards.hbs
@@ -1,7 +1,16 @@
 <div ...attributes>
   {{#each this.featureList as |feature|}}
     <div class="flex justify-center">
-      <FeatureCard @contentMarkdown={{feature.bodyMarkdown}} @imageUrl={{feature.imageUrl}} @popover={{feature.popover}} @title={{feature.title}} />
+      <FeatureCard @contentMarkdown={{feature.bodyMarkdown}} @imageUrl={{feature.imageUrl}} @title={{feature.title}}>
+        <:popover>
+          {{#if feature.popover}}
+            {{! @glint-expect-error EmberPopover is not typed }}
+            <EmberPopover @targetId={{feature.popover.targetId}} @side="bottom">
+              {{html-safe feature.popover.html}}
+            </EmberPopover>
+          {{/if}}
+        </:popover>
+      </FeatureCard>
     </div>
   {{/each}}
 </div>

--- a/app/components/referrals-page/referral-feature-cards.hbs
+++ b/app/components/referrals-page/referral-feature-cards.hbs
@@ -1,7 +1,7 @@
 <div ...attributes>
   {{#each this.featureList as |feature|}}
     <div class="flex justify-center">
-      <FeatureCard @imageUrl={{feature.imageUrl}} @title={{feature.title}} @contentMarkdown={{feature.bodyMarkdown}} />
+      <FeatureCard @contentMarkdown={{feature.bodyMarkdown}} @imageUrl={{feature.imageUrl}} @popover={{feature.popover}} @title={{feature.title}} />
     </div>
   {{/each}}
 </div>

--- a/app/components/referrals-page/referral-feature-cards.hbs
+++ b/app/components/referrals-page/referral-feature-cards.hbs
@@ -31,7 +31,7 @@
                     <a href="https://docs.codecrafters.io/membership/content" class="underline">Learn more</a>
                   </EmberPopover>
                 </u>
-                per referral. Up to 52 weeks.'
+                per referral. Up to 52 weeks.
               </p>
             {{/if}}
           </div>

--- a/app/components/referrals-page/referral-feature-cards.ts
+++ b/app/components/referrals-page/referral-feature-cards.ts
@@ -12,9 +12,8 @@ interface Signature {
 }
 
 type Feature = {
-  bodyMarkdown: string;
   imageUrl: string;
-  popover?: { targetId: string; html: string };
+  slug: string;
   title: string;
 };
 
@@ -23,26 +22,18 @@ export default class ReferralFeatureCardsComponent extends Component<Signature> 
     return [
       {
         title: 'Generate your link in 1 click.',
-        bodyMarkdown: 'Refer friends with a unique URL.',
         imageUrl: generateLinkImage,
+        slug: 'generate-link',
       },
       {
         title: '1 week free for your friends.',
-        bodyMarkdown: 'Each referral gets 1 week of <u id="popover-target-friends" class="decoration-dotted">paid content access</u>.',
         imageUrl: giftOneWeekFreeImage,
-        popover: {
-          targetId: 'popover-target-friends',
-          html: 'Includes all stages from paid challenges, but excludes other membership benefits like dark mode, turbo test runs etc. <a href="https://docs.codecrafters.io/membership/content" class="underline">Learn more</a>',
-        },
+        slug: 'gift-one-week-free',
       },
       {
         title: 'Up to 1 year free for you.',
-        bodyMarkdown: '1 week of <u id="popover-target-you" class="decoration-dotted">paid content access</u> per referral. Up to 52 weeks.',
         imageUrl: getOneYearFreeImage,
-        popover: {
-          targetId: 'popover-target-you',
-          html: 'Includes all stages from paid challenges, but excludes other membership benefits like dark mode, turbo test runs etc. <a href="https://docs.codecrafters.io/membership/content" class="underline">Learn more</a>',
-        },
+        slug: 'get-one-year-free',
       },
     ];
   }

--- a/app/components/referrals-page/referral-feature-cards.ts
+++ b/app/components/referrals-page/referral-feature-cards.ts
@@ -12,9 +12,10 @@ interface Signature {
 }
 
 type Feature = {
-  title: string;
   bodyMarkdown: string;
   imageUrl: string;
+  popover?: { targetId: string; html: string };
+  title: string;
 };
 
 export default class ReferralFeatureCardsComponent extends Component<Signature> {
@@ -27,13 +28,21 @@ export default class ReferralFeatureCardsComponent extends Component<Signature> 
       },
       {
         title: '1 week free for your friends.',
-        bodyMarkdown: 'Each referral gets 1 week free.',
+        bodyMarkdown: 'Each referral gets 1 week of <u id="popover-target-friends" class="decoration-dotted">paid content access</u>.',
         imageUrl: giftOneWeekFreeImage,
+        popover: {
+          targetId: 'popover-target-friends',
+          html: 'Includes all stages from paid challenges, but excludes other membership benefits like dark mode, turbo test runs etc. <a href="https://docs.codecrafters.io/membership/content" class="underline">Learn more</a>',
+        },
       },
       {
         title: 'Up to 1 year free for you.',
-        bodyMarkdown: '1 week free per referral. Up to 52 weeks.',
+        bodyMarkdown: '1 week of <u id="popover-target-you" class="decoration-dotted">paid content access</u> per referral. Up to 52 weeks.',
         imageUrl: getOneYearFreeImage,
+        popover: {
+          targetId: 'popover-target-you',
+          html: 'Includes all stages from paid challenges, but excludes other membership benefits like dark mode, turbo test runs etc. <a href="https://docs.codecrafters.io/membership/content" class="underline">Learn more</a>',
+        },
       },
     ];
   }

--- a/app/templates/course/stage/instructions.hbs
+++ b/app/templates/course/stage/instructions.hbs
@@ -38,7 +38,6 @@
       />
 
       {{#if this.shouldSuppressTestRunnerCardExpands}}
-        {{! @glint-expect-error: not ts-ified }}
         <EmberPopover @popperContainer="body">
           <div class="prose prose-sm prose-invert text-white">
             {{#if (eq this.currentStep.testsStatus "failed")}}

--- a/types/glint.d.ts
+++ b/types/glint.d.ts
@@ -20,6 +20,10 @@ declare module '@glint/environment-ember-loose/registry' {
       Args: { Named: { text?: string; side?: 'top' | 'bottom' | 'left' | 'right'; delay?: number; duration?: number } };
       Blocks: { default?: [] };
     }>;
+    EmberPopover: ComponentLike<{
+      Args: { Named: { side?: 'top' | 'bottom' | 'left' | 'right'; popperContainer?: string } };
+      Blocks: { default?: [] };
+    }>;
     includes: HelperLike<{ Args: { Positional: [unknown, unknown] }; Return: boolean }>;
     'html-safe': HelperLike<{ Return: string; Args: { Positional: [string | undefined] } }>;
     join: HelperLike<{ Return: string; Args: { Positional: [string, string[]] } }>;


### PR DESCRIPTION
**Checklist**:

- [x] I've thoroughly self-reviewed my changes
- [ ] **Should I add tests for this?**
- [x] I've verified any visual changes using Percy (add a commit with `[percy]` in the message to trigger)

<img width="370" alt="image" src="https://github.com/user-attachments/assets/c905ba0f-f8b3-4543-88a4-c702bad4a2e9">


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
	- Enhanced the Feature Card component with conditional rendering, allowing for custom content display based on feature types.
	- Updated the Referrals Page to leverage contextual information using the new conditional rendering logic in the Feature Card component.
	- Introduced dynamic messages in the Feature Card based on specific feature types, improving user guidance.

- **Bug Fixes**
	- Updated tooltip text in the Free Weeks Left Button to clarify the expiration of free content access.

- **Documentation**
	- Improved property definitions for the Feature Card and Referrals Page components to reflect recent changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->