### PR TITLE
Bind all CodeMirror Demo options to query params & allow resetting them

### DIFF
--- a/app/controllers/demo/code-mirror.ts
+++ b/app/controllers/demo/code-mirror.ts
@@ -42,6 +42,50 @@ class ExampleDocument {
 export default class DemoCodeMirrorController extends Controller {
   @service declare darkMode: DarkModeService;
 
+  queryParams = [
+    'allowMultipleSelections',
+    'autocompletion',
+    'bracketMatching',
+    'closeBrackets',
+    'collapseUnchanged',
+    'crosshairCursor',
+    'document',
+    'drawSelection',
+    'dropCursor',
+    'editable',
+    'filename',
+    'foldGutter',
+    'highlightActiveLine',
+    'highlightSelectionMatches',
+    'highlightSpecialChars',
+    'highlightTrailingWhitespace',
+    'highlightWhitespace',
+    'history',
+    'indentOnInput',
+    'indentUnit',
+    'indentWithTab',
+    'language',
+    'lineNumbers',
+    'lineSeparator',
+    'lineWrapping',
+    'mergeControls',
+    'originalDocument',
+    'outline',
+    'placeholder',
+    'preserveHistory',
+    'readOnly',
+    'rectangularSelection',
+    'scrollPastEnd',
+    'selectedDocumentIndex',
+    'selectedIndentUnitIndex',
+    'selectedLineSeparatorIndex',
+    'selectedTabSizeIndex',
+    'selectedThemeIndex',
+    'syntaxHighlighting',
+    'tabSize',
+    'theme',
+  ];
+
   @tracked placeholderMessage = 'Welcome to CodeCrafters test zone for CodeMirror! Start editing the document here...';
 
   @tracked documents: ExampleDocument[] = [

--- a/app/controllers/demo/code-mirror.ts
+++ b/app/controllers/demo/code-mirror.ts
@@ -16,6 +16,50 @@ const THEME_EXTENSIONS: {
 const SUPPORTED_THEMES = [...Object.keys(THEME_EXTENSIONS), 'codeCraftersAuto'];
 const DEFAULT_THEME = 'codeCraftersAuto';
 
+const OPTION_DEFAULTS = {
+  allowMultipleSelections: true,
+  autocompletion: true,
+  bracketMatching: true,
+  closeBrackets: true,
+  collapseUnchanged: true,
+  crosshairCursor: true,
+  document: true,
+  drawSelection: true,
+  dropCursor: true,
+  editable: true,
+  filename: true,
+  foldGutter: true,
+  highlightActiveLine: true,
+  highlightSelectionMatches: true,
+  highlightSpecialChars: true,
+  highlightTrailingWhitespace: true,
+  highlightWhitespace: true,
+  history: true,
+  indentOnInput: true,
+  indentUnit: true,
+  indentWithTab: true,
+  language: true,
+  lineNumbers: true,
+  lineSeparator: true,
+  lineWrapping: true,
+  mergeControls: true,
+  originalDocument: false,
+  outline: true,
+  placeholder: true,
+  preserveHistory: false,
+  readOnly: false,
+  rectangularSelection: true,
+  scrollPastEnd: false,
+  selectedDocumentIndex: 1,
+  selectedIndentUnitIndex: 1,
+  selectedLineSeparatorIndex: 1,
+  selectedTabSizeIndex: 2,
+  selectedThemeIndex: SUPPORTED_THEMES.indexOf(DEFAULT_THEME),
+  syntaxHighlighting: true,
+  tabSize: true,
+  theme: true,
+};
+
 class ExampleDocument {
   @tracked document!: string;
   @tracked originalDocument!: string;
@@ -157,11 +201,11 @@ export default class DemoCodeMirrorController extends Controller {
 
   @tracked themes = [...SUPPORTED_THEMES];
 
-  @tracked selectedDocumentIndex: number = 1;
-  @tracked selectedIndentUnitIndex: number = 1;
-  @tracked selectedLineSeparatorIndex: number = 1;
-  @tracked selectedTabSizeIndex: number = 2;
-  @tracked selectedThemeIndex: number = this.themes.indexOf(DEFAULT_THEME);
+  @tracked selectedDocumentIndex = OPTION_DEFAULTS.selectedDocumentIndex;
+  @tracked selectedIndentUnitIndex = OPTION_DEFAULTS.selectedIndentUnitIndex;
+  @tracked selectedLineSeparatorIndex = OPTION_DEFAULTS.selectedLineSeparatorIndex;
+  @tracked selectedTabSizeIndex = OPTION_DEFAULTS.selectedTabSizeIndex;
+  @tracked selectedThemeIndex = OPTION_DEFAULTS.selectedThemeIndex;
 
   get selectedDocument() {
     return this.documents[this.selectedDocumentIndex];
@@ -193,43 +237,43 @@ export default class DemoCodeMirrorController extends Controller {
     return theme !== undefined ? themeMap[theme] : undefined;
   }
 
-  @tracked outline: boolean = true;
+  @tracked outline = OPTION_DEFAULTS.outline;
 
-  @tracked allowMultipleSelections: boolean = true;
-  @tracked autocompletion: boolean = true;
-  @tracked bracketMatching: boolean = true;
-  @tracked closeBrackets: boolean = true;
-  @tracked crosshairCursor: boolean = true;
-  @tracked document: boolean = true;
-  @tracked drawSelection: boolean = true;
-  @tracked dropCursor: boolean = true;
-  @tracked editable: boolean = true;
-  @tracked filename: boolean = true;
-  @tracked foldGutter: boolean = true;
-  @tracked highlightActiveLine: boolean = true;
-  @tracked highlightSelectionMatches: boolean = true;
-  @tracked highlightSpecialChars: boolean = true;
-  @tracked highlightTrailingWhitespace: boolean = true;
-  @tracked highlightWhitespace: boolean = true;
-  @tracked history: boolean = true;
-  @tracked indentOnInput: boolean = true;
-  @tracked indentUnit: boolean = true;
-  @tracked indentWithTab: boolean = true;
-  @tracked language: boolean = true;
-  @tracked lineNumbers: boolean = true;
-  @tracked lineSeparator: boolean = true;
-  @tracked lineWrapping: boolean = true;
-  @tracked mergeControls: boolean = true;
-  @tracked collapseUnchanged: boolean = true;
-  @tracked originalDocument: boolean = false;
-  @tracked placeholder: boolean = true;
-  @tracked preserveHistory: boolean = false;
-  @tracked readOnly: boolean = false;
-  @tracked rectangularSelection: boolean = true;
-  @tracked scrollPastEnd: boolean = false;
-  @tracked syntaxHighlighting: boolean = true;
-  @tracked tabSize: boolean = true;
-  @tracked theme: boolean = true;
+  @tracked allowMultipleSelections = OPTION_DEFAULTS.allowMultipleSelections;
+  @tracked autocompletion = OPTION_DEFAULTS.autocompletion;
+  @tracked bracketMatching = OPTION_DEFAULTS.bracketMatching;
+  @tracked closeBrackets = OPTION_DEFAULTS.closeBrackets;
+  @tracked crosshairCursor = OPTION_DEFAULTS.crosshairCursor;
+  @tracked document = OPTION_DEFAULTS.document;
+  @tracked drawSelection = OPTION_DEFAULTS.drawSelection;
+  @tracked dropCursor = OPTION_DEFAULTS.dropCursor;
+  @tracked editable = OPTION_DEFAULTS.editable;
+  @tracked filename = OPTION_DEFAULTS.filename;
+  @tracked foldGutter = OPTION_DEFAULTS.foldGutter;
+  @tracked highlightActiveLine = OPTION_DEFAULTS.highlightActiveLine;
+  @tracked highlightSelectionMatches = OPTION_DEFAULTS.highlightSelectionMatches;
+  @tracked highlightSpecialChars = OPTION_DEFAULTS.highlightSpecialChars;
+  @tracked highlightTrailingWhitespace = OPTION_DEFAULTS.highlightTrailingWhitespace;
+  @tracked highlightWhitespace = OPTION_DEFAULTS.highlightWhitespace;
+  @tracked history = OPTION_DEFAULTS.history;
+  @tracked indentOnInput = OPTION_DEFAULTS.indentOnInput;
+  @tracked indentUnit = OPTION_DEFAULTS.indentUnit;
+  @tracked indentWithTab = OPTION_DEFAULTS.indentWithTab;
+  @tracked language = OPTION_DEFAULTS.language;
+  @tracked lineNumbers = OPTION_DEFAULTS.lineNumbers;
+  @tracked lineSeparator = OPTION_DEFAULTS.lineSeparator;
+  @tracked lineWrapping = OPTION_DEFAULTS.lineWrapping;
+  @tracked mergeControls = OPTION_DEFAULTS.mergeControls;
+  @tracked collapseUnchanged = OPTION_DEFAULTS.collapseUnchanged;
+  @tracked originalDocument = OPTION_DEFAULTS.originalDocument;
+  @tracked placeholder = OPTION_DEFAULTS.placeholder;
+  @tracked preserveHistory = OPTION_DEFAULTS.preserveHistory;
+  @tracked readOnly = OPTION_DEFAULTS.readOnly;
+  @tracked rectangularSelection = OPTION_DEFAULTS.rectangularSelection;
+  @tracked scrollPastEnd = OPTION_DEFAULTS.scrollPastEnd;
+  @tracked syntaxHighlighting = OPTION_DEFAULTS.syntaxHighlighting;
+  @tracked tabSize = OPTION_DEFAULTS.tabSize;
+  @tracked theme = OPTION_DEFAULTS.theme;
 
   @action documentDidChange(_target: Controller, newValue: string) {
     if (!this.document) {
@@ -239,6 +283,10 @@ export default class DemoCodeMirrorController extends Controller {
     if (this.selectedDocument?.document !== newValue) {
       this.selectedDocument!.document = newValue;
     }
+  }
+
+  @action resetAllOptions() {
+    Object.assign(this, OPTION_DEFAULTS);
   }
 
   @action selectedDocumentIndexDidChange(event: Event) {

--- a/app/routes/demo/code-mirror.ts
+++ b/app/routes/demo/code-mirror.ts
@@ -1,3 +1,169 @@
 import Route from '@ember/routing/route';
 
-export default class DemoCodeMirrorRoute extends Route {}
+export default class DemoCodeMirrorRoute extends Route {
+  queryParams = {
+    allowMultipleSelections: {
+      replace: true,
+    },
+
+    autocompletion: {
+      replace: true,
+    },
+
+    bracketMatching: {
+      replace: true,
+    },
+
+    closeBrackets: {
+      replace: true,
+    },
+
+    collapseUnchanged: {
+      replace: true,
+    },
+
+    crosshairCursor: {
+      replace: true,
+    },
+
+    document: {
+      replace: true,
+    },
+
+    drawSelection: {
+      replace: true,
+    },
+
+    dropCursor: {
+      replace: true,
+    },
+
+    editable: {
+      replace: true,
+    },
+
+    filename: {
+      replace: true,
+    },
+
+    foldGutter: {
+      replace: true,
+    },
+
+    highlightActiveLine: {
+      replace: true,
+    },
+
+    highlightSelectionMatches: {
+      replace: true,
+    },
+
+    highlightSpecialChars: {
+      replace: true,
+    },
+
+    highlightTrailingWhitespace: {
+      replace: true,
+    },
+
+    highlightWhitespace: {
+      replace: true,
+    },
+
+    history: {
+      replace: true,
+    },
+
+    indentOnInput: {
+      replace: true,
+    },
+
+    indentUnit: {
+      replace: true,
+    },
+
+    indentWithTab: {
+      replace: true,
+    },
+
+    language: {
+      replace: true,
+    },
+
+    lineNumbers: {
+      replace: true,
+    },
+
+    lineSeparator: {
+      replace: true,
+    },
+
+    lineWrapping: {
+      replace: true,
+    },
+
+    mergeControls: {
+      replace: true,
+    },
+
+    originalDocument: {
+      replace: true,
+    },
+
+    outline: {
+      replace: true,
+    },
+
+    placeholder: {
+      replace: true,
+    },
+
+    preserveHistory: {
+      replace: true,
+    },
+
+    readOnly: {
+      replace: true,
+    },
+
+    rectangularSelection: {
+      replace: true,
+    },
+
+    scrollPastEnd: {
+      replace: true,
+    },
+
+    selectedDocumentIndex: {
+      replace: true,
+    },
+
+    selectedIndentUnitIndex: {
+      replace: true,
+    },
+
+    selectedLineSeparatorIndex: {
+      replace: true,
+    },
+
+    selectedTabSizeIndex: {
+      replace: true,
+    },
+
+    selectedThemeIndex: {
+      replace: true,
+    },
+
+    syntaxHighlighting: {
+      replace: true,
+    },
+
+    tabSize: {
+      replace: true,
+    },
+
+    theme: {
+      replace: true,
+    },
+  };
+}

--- a/app/routes/demo/code-mirror.ts
+++ b/app/routes/demo/code-mirror.ts
@@ -1,169 +1,59 @@
 import Route from '@ember/routing/route';
 
-export default class DemoCodeMirrorRoute extends Route {
-  queryParams = {
-    allowMultipleSelections: {
-      replace: true,
-    },
+const QUERY_PARAMS = [
+  'allowMultipleSelections',
+  'autocompletion',
+  'bracketMatching',
+  'closeBrackets',
+  'collapseUnchanged',
+  'crosshairCursor',
+  'document',
+  'drawSelection',
+  'dropCursor',
+  'editable',
+  'filename',
+  'foldGutter',
+  'highlightActiveLine',
+  'highlightSelectionMatches',
+  'highlightSpecialChars',
+  'highlightTrailingWhitespace',
+  'highlightWhitespace',
+  'history',
+  'indentOnInput',
+  'indentUnit',
+  'indentWithTab',
+  'language',
+  'lineNumbers',
+  'lineSeparator',
+  'lineWrapping',
+  'mergeControls',
+  'originalDocument',
+  'outline',
+  'placeholder',
+  'preserveHistory',
+  'readOnly',
+  'rectangularSelection',
+  'scrollPastEnd',
+  'selectedDocumentIndex',
+  'selectedIndentUnitIndex',
+  'selectedLineSeparatorIndex',
+  'selectedTabSizeIndex',
+  'selectedThemeIndex',
+  'syntaxHighlighting',
+  'tabSize',
+  'theme',
+];
 
-    autocompletion: {
-      replace: true,
-    },
-
-    bracketMatching: {
-      replace: true,
-    },
-
-    closeBrackets: {
-      replace: true,
-    },
-
-    collapseUnchanged: {
-      replace: true,
-    },
-
-    crosshairCursor: {
-      replace: true,
-    },
-
-    document: {
-      replace: true,
-    },
-
-    drawSelection: {
-      replace: true,
-    },
-
-    dropCursor: {
-      replace: true,
-    },
-
-    editable: {
-      replace: true,
-    },
-
-    filename: {
-      replace: true,
-    },
-
-    foldGutter: {
-      replace: true,
-    },
-
-    highlightActiveLine: {
-      replace: true,
-    },
-
-    highlightSelectionMatches: {
-      replace: true,
-    },
-
-    highlightSpecialChars: {
-      replace: true,
-    },
-
-    highlightTrailingWhitespace: {
-      replace: true,
-    },
-
-    highlightWhitespace: {
-      replace: true,
-    },
-
-    history: {
-      replace: true,
-    },
-
-    indentOnInput: {
-      replace: true,
-    },
-
-    indentUnit: {
-      replace: true,
-    },
-
-    indentWithTab: {
-      replace: true,
-    },
-
-    language: {
-      replace: true,
-    },
-
-    lineNumbers: {
-      replace: true,
-    },
-
-    lineSeparator: {
-      replace: true,
-    },
-
-    lineWrapping: {
-      replace: true,
-    },
-
-    mergeControls: {
-      replace: true,
-    },
-
-    originalDocument: {
-      replace: true,
-    },
-
-    outline: {
-      replace: true,
-    },
-
-    placeholder: {
-      replace: true,
-    },
-
-    preserveHistory: {
-      replace: true,
-    },
-
-    readOnly: {
-      replace: true,
-    },
-
-    rectangularSelection: {
-      replace: true,
-    },
-
-    scrollPastEnd: {
-      replace: true,
-    },
-
-    selectedDocumentIndex: {
-      replace: true,
-    },
-
-    selectedIndentUnitIndex: {
-      replace: true,
-    },
-
-    selectedLineSeparatorIndex: {
-      replace: true,
-    },
-
-    selectedTabSizeIndex: {
-      replace: true,
-    },
-
-    selectedThemeIndex: {
-      replace: true,
-    },
-
-    syntaxHighlighting: {
-      replace: true,
-    },
-
-    tabSize: {
-      replace: true,
-    },
-
-    theme: {
-      replace: true,
-    },
+interface QueryParamOptions {
+  [key: string]: {
+    replace: boolean;
   };
+}
+
+export default class DemoCodeMirrorRoute extends Route {
+  queryParams = QUERY_PARAMS.reduce<QueryParamOptions>((acc, param) => {
+    acc[param] = { replace: true };
+
+    return acc;
+  }, {});
 }

--- a/app/templates/demo/code-mirror.hbs
+++ b/app/templates/demo/code-mirror.hbs
@@ -295,7 +295,15 @@
   @scrollPastEnd={{this.scrollPastEnd}}
   @syntaxHighlighting={{this.syntaxHighlighting}}
   {{! Element classes }}
-  class="block overflow-auto my-4 h-72 {{if this.outline 'outline-2 outline-dashed outline-green-500'}}"
+  class="block overflow-auto mt-4 h-72 {{if this.outline 'outline-2 outline-dashed outline-green-500'}}"
 />
+
+<div class="my-2 text-right">
+  <span
+    role="button"
+    class="text-xs text-blue-600 hover:text-blue-800 dark:text-blue-200 dark:hover:text-blue-400 underline cursor-pointer"
+    {{on "click" this.resetAllOptions}}
+  >Reset all options</span>
+</div>
 
 {{outlet}}


### PR DESCRIPTION
Related to #1231 

### Brief

This makes all options selected on the CodeMirror Demo page be stored in queryParams, so that a specific editor configuration can be easily linked to. 

### Details

Since refreshing the page no longer resets all options to defaults, due to them being stored in queryParams, added a control for resetting them manually.

### Demo

https://github.com/user-attachments/assets/66f8a585-0ba9-4422-ae00-47c501820a08

### Checklist

- [x] I've thoroughly self-reviewed my changes
- [x] I've added tests for my changes, unless they affect admin-only areas (or are otherwise not worth testing)
- [x] I've verified any visual changes using Percy (add a commit with `[percy]` in the message to trigger)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
	- Introduced a reset button for users to easily revert all CodeMirror options to their default settings.
	- Enhanced URL query parameters for dynamic configuration of CodeMirror editor features.

- **Bug Fixes**
	- Adjusted styling for improved layout and accessibility.

- **Chores**
	- Centralized default options management for easier maintenance and configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->