### PR TITLE
Deregister `fireOnFocus` callback when `confetti` service is destroyed

### DIFF
--- a/app/services/confetti.ts
+++ b/app/services/confetti.ts
@@ -2,6 +2,7 @@ import Service, { inject as service } from '@ember/service';
 import confetti from 'canvas-confetti';
 import FastBootService from 'ember-cli-fastboot/services/fastboot';
 import type FocusService from './focus';
+import { registerDestructor } from '@ember/destroyable';
 
 export default class ConfettiService extends Service {
   @service declare focus: FocusService;
@@ -55,6 +56,10 @@ export default class ConfettiService extends Service {
           this.fire(options);
           this.focus.deregisterCallback(callbackId);
         }
+      });
+
+      registerDestructor(this, () => {
+        this.focus.deregisterCallback(callbackId);
       });
     }
   }


### PR DESCRIPTION
### Brief

Accidentally ran into a bug while testing: if you run the tests in the background and focus the browser after they finish — an exception will happen.

### Details

`ConfettiService` never deregisters a `fireOnFocus` callback if it's destroyed and the focus event hasn't been triggered yet. This tiny fix fixes it.

### Checklist

- [x] I've thoroughly self-reviewed my changes
- [x] I've added tests for my changes, unless they affect admin-only areas (or are otherwise not worth testing)
- [x] I've verified any visual changes using Percy (add a commit with `[percy]` in the message to trigger)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved cleanup process for the Confetti service to prevent potential memory leaks by ensuring proper deregistration of callbacks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->