### PR TITLE
CC-1480: Highlight language guides in stage 2 tutorial card

### DIFF
--- a/app/components/course-page/course-stage-step/second-stage-instructions-card.hbs
+++ b/app/components/course-page/course-stage-step/second-stage-instructions-card.hbs
@@ -1,10 +1,4 @@
-<CoursePage::InstructionsCard
-  @title="How to pass this stage"
-  id="second-stage-instructions-card"
-  ...attributes
-  {{did-update this.loadLanguageGuides @courseStage}}
-  {{did-insert this.loadLanguageGuides}}
->
+<CoursePage::InstructionsCard @title="How to pass this stage" id="second-stage-instructions-card" ...attributes>
   <:content>
     <div class="prose dark:prose-invert mb-5">
       <p>
@@ -24,14 +18,14 @@
           @repository={{@repository}}
           @courseStage={{@courseStage}}
           @isComplete={{this.readInstructionsStepIsComplete}}
-          @isShowingLanguageGuide={{this.isShowingLanguageGuide}}
+          @shouldRecommendLanguageGuide={{@shouldRecommendLanguageGuide}}
         />
       {{else if (eq stepList.expandedStep.id "implement-solution")}}
         <CoursePage::CourseStageStep::SecondStageInstructionsCard::ImplementSolutionStep
           @repository={{@repository}}
           @courseStage={{@courseStage}}
           @isComplete={{this.implementSolutionStepIsComplete}}
-          @isShowingLanguageGuide={{this.isShowingLanguageGuide}}
+          @shouldRecommendLanguageGuide={{@shouldRecommendLanguageGuide}}
         />
       {{else if (eq stepList.expandedStep.id "run-tests")}}
         <CoursePage::CourseStageStep::SecondStageInstructionsCard::RunTestsStep

--- a/app/components/course-page/course-stage-step/second-stage-instructions-card.hbs
+++ b/app/components/course-page/course-stage-step/second-stage-instructions-card.hbs
@@ -1,4 +1,10 @@
-<CoursePage::InstructionsCard @title="How to pass this stage" id="second-stage-instructions-card" ...attributes>
+<CoursePage::InstructionsCard
+  @title="How to pass this stage"
+  id="second-stage-instructions-card"
+  ...attributes
+  {{did-update this.loadLanguageGuides @courseStage}}
+  {{did-insert this.loadLanguageGuides}}
+>
   <:content>
     <div class="prose dark:prose-invert mb-5">
       <p>
@@ -18,12 +24,14 @@
           @repository={{@repository}}
           @courseStage={{@courseStage}}
           @isComplete={{this.readInstructionsStepIsComplete}}
+          @isShowingLanguageGuide={{this.isShowingLanguageGuide}}
         />
       {{else if (eq stepList.expandedStep.id "implement-solution")}}
         <CoursePage::CourseStageStep::SecondStageInstructionsCard::ImplementSolutionStep
           @repository={{@repository}}
           @courseStage={{@courseStage}}
           @isComplete={{this.implementSolutionStepIsComplete}}
+          @isShowingLanguageGuide={{this.isShowingLanguageGuide}}
         />
       {{else if (eq stepList.expandedStep.id "run-tests")}}
         <CoursePage::CourseStageStep::SecondStageInstructionsCard::RunTestsStep

--- a/app/components/course-page/course-stage-step/second-stage-instructions-card.ts
+++ b/app/components/course-page/course-stage-step/second-stage-instructions-card.ts
@@ -5,7 +5,9 @@ import Store from '@ember-data/store';
 import type RepositoryModel from 'codecrafters-frontend/models/repository';
 import type CourseStageModel from 'codecrafters-frontend/models/course-stage';
 import { action } from '@ember/object';
+import { task } from 'ember-concurrency';
 import type { Step } from 'codecrafters-frontend/components/expandable-step-list';
+import type FeatureFlagsService from 'codecrafters-frontend/services/feature-flags';
 
 interface Signature {
   Element: HTMLDivElement;
@@ -54,6 +56,7 @@ class RunTestsStep extends BaseStep implements Step {
 }
 
 export default class SecondStageInstructionsCardComponent extends Component<Signature> {
+  @service declare featureFlags: FeatureFlagsService;
   @service declare coursePageState: CoursePageStateService;
   @service declare store: Store;
 
@@ -67,6 +70,12 @@ export default class SecondStageInstructionsCardComponent extends Component<Sign
 
   get implementSolutionStepWasMarkedAsComplete() {
     return this.coursePageState.manuallyCompletedStepIdsInSecondStageInstructions.includes('implement-solution');
+  }
+
+  get isShowingLanguageGuide() {
+    const languageGuide = this.args.courseStage.languageGuides.findBy('language', this.args.repository.language);
+
+    return this.featureFlags.canSeeLanguageGuidesForStage2 && !!languageGuide;
   }
 
   get readInstructionsStepIsComplete() {
@@ -110,6 +119,18 @@ export default class SecondStageInstructionsCardComponent extends Component<Sign
   handleViewLogsButtonClick() {
     this.coursePageState.testResultsBarIsExpanded = true;
   }
+
+  @action
+  loadLanguageGuides(): void {
+    this.loadLanguageGuidesTask.perform();
+  }
+
+  loadLanguageGuidesTask = task({ keepLatest: true }, async (): Promise<void> => {
+    await this.store.query('course-stage-language-guide', {
+      course_stage_id: this.args.courseStage.id,
+      include: 'course-stage,language',
+    });
+  });
 }
 
 declare module '@glint/environment-ember-loose/registry' {

--- a/app/components/course-page/course-stage-step/second-stage-instructions-card/implement-solution-step.hbs
+++ b/app/components/course-page/course-stage-step/second-stage-instructions-card/implement-solution-step.hbs
@@ -3,13 +3,12 @@
     Head over to your editor / IDE and implement your solution.
   </p>
   <p>
-    {{#if @isShowingLanguageGuide}}
+    {{#if @shouldRecommendLanguageGuide}}
       If you want a quick look at what functions to use, we recommend looking at
-      <a href="#language-guide-card">{{this.currentLanguageName}} Guide</a>.
+      <a href="#language-guide-card">{{@repository.language.name}} Guide</a>.
     {{else}}
       If you want a quick look at what functions to use or how to structure your code, we recommend looking at
       <LinkTo @route="course.stage.code-examples">Code Examples</LinkTo>.
     {{/if}}
-
   </p>
 </div>

--- a/app/components/course-page/course-stage-step/second-stage-instructions-card/implement-solution-step.hbs
+++ b/app/components/course-page/course-stage-step/second-stage-instructions-card/implement-solution-step.hbs
@@ -3,7 +3,13 @@
     Head over to your editor / IDE and implement your solution.
   </p>
   <p>
-    If you want a quick look at what functions to use or how to structure your code, we recommend looking at
-    <LinkTo @route="course.stage.code-examples">Code Examples</LinkTo>.
+    {{#if @isShowingLanguageGuide}}
+      If you want a quick look at what functions to use, we recommend looking at
+      <a href="#language-guide-card">{{this.currentLanguageName}} Guide</a>.
+    {{else}}
+      If you want a quick look at what functions to use or how to structure your code, we recommend looking at
+      <LinkTo @route="course.stage.code-examples">Code Examples</LinkTo>.
+    {{/if}}
+
   </p>
 </div>

--- a/app/components/course-page/course-stage-step/second-stage-instructions-card/implement-solution-step.hbs
+++ b/app/components/course-page/course-stage-step/second-stage-instructions-card/implement-solution-step.hbs
@@ -4,11 +4,15 @@
   </p>
   <p>
     {{#if @shouldRecommendLanguageGuide}}
-      If you want a quick look at what functions to use, we recommend looking at
-      <a href="#language-guide-card">{{@repository.language.name}} Guide</a>.
+      If you want a quick look at what functions to use or how to structure your code, we recommend looking at
+      <LinkTo @route="course.stage.code-examples">Code Examples</LinkTo>
+      tab or the
+      <a href="#language-guide-card">{{@repository.language.name}} Guide</a>
+      card.
     {{else}}
       If you want a quick look at what functions to use or how to structure your code, we recommend looking at
-      <LinkTo @route="course.stage.code-examples">Code Examples</LinkTo>.
+      <LinkTo @route="course.stage.code-examples">Code Examples</LinkTo>
+      tab.
     {{/if}}
   </p>
 </div>

--- a/app/components/course-page/course-stage-step/second-stage-instructions-card/implement-solution-step.ts
+++ b/app/components/course-page/course-stage-step/second-stage-instructions-card/implement-solution-step.ts
@@ -9,15 +9,11 @@ interface Signature {
     repository: RepositoryModel;
     courseStage: CourseStageModel;
     isComplete: boolean;
-    isShowingLanguageGuide: boolean;
+    shouldRecommendLanguageGuide: boolean;
   };
 }
 
-export default class ImplementSolutionStepComponent extends Component<Signature> {
-  get currentLanguageName(): string {
-    return this.args.repository.language!.name;
-  }
-}
+export default class ImplementSolutionStepComponent extends Component<Signature> {}
 
 declare module '@glint/environment-ember-loose/registry' {
   export default interface Registry {

--- a/app/components/course-page/course-stage-step/second-stage-instructions-card/implement-solution-step.ts
+++ b/app/components/course-page/course-stage-step/second-stage-instructions-card/implement-solution-step.ts
@@ -9,10 +9,15 @@ interface Signature {
     repository: RepositoryModel;
     courseStage: CourseStageModel;
     isComplete: boolean;
+    isShowingLanguageGuide: boolean;
   };
 }
 
-export default class ImplementSolutionStepComponent extends Component<Signature> {}
+export default class ImplementSolutionStepComponent extends Component<Signature> {
+  get currentLanguageName(): string {
+    return this.args.repository.language!.name;
+  }
+}
 
 declare module '@glint/environment-ember-loose/registry' {
   export default interface Registry {

--- a/app/components/course-page/course-stage-step/second-stage-instructions-card/read-instructions-step.hbs
+++ b/app/components/course-page/course-stage-step/second-stage-instructions-card/read-instructions-step.hbs
@@ -9,17 +9,19 @@
   </p>
   <ul>
     <li>
-      {{#if @shouldRecommendLanguageGuide}}
+      The
+      <LinkTo @route="course.stage.code-examples">Code Examples</LinkTo>
+      tab, which contains code examples from other users.
+    </li>
+
+    {{#if @shouldRecommendLanguageGuide}}
+      <li>
         The
         <a href="#language-guide-card">{{@repository.language.name}} Guide</a>
         card, which contains
         {{@repository.language.name}}-specific instructions for this stage.
-      {{else}}
-        The
-        <LinkTo @route="course.stage.code-examples">Code Examples</LinkTo>
-        tab, which contains code examples from other users.
-      {{/if}}
-    </li>
+      </li>
+    {{/if}}
 
     {{! Let's limit to 2 suggestions for now so that we don't overwhelm the user.}}
     {{#if (gt @courseStage.screencasts.length 0)}}

--- a/app/components/course-page/course-stage-step/second-stage-instructions-card/read-instructions-step.hbs
+++ b/app/components/course-page/course-stage-step/second-stage-instructions-card/read-instructions-step.hbs
@@ -1,7 +1,7 @@
 <div class="prose dark:prose-invert prose-compact">
   <p>
     The
-    <a href="#your-task-card">"Your Task"</a>
+    <a href="#your-task-card">Your Task</a>
     card below contains a description of what you need to implement to pass tests.
   </p>
   <p>
@@ -9,11 +9,11 @@
   </p>
   <ul>
     <li>
-      {{#if @isShowingLanguageGuide}}
+      {{#if @shouldRecommendLanguageGuide}}
         The
-        <a href="#language-guide-card">{{this.currentLanguageName}} Guide</a>
+        <a href="#language-guide-card">{{@repository.language.name}} Guide</a>
         card, which contains
-        {{this.currentLanguageName}}-specific instructions for this stage.
+        {{@repository.language.name}}-specific instructions for this stage.
       {{else}}
         The
         <LinkTo @route="course.stage.code-examples">Code Examples</LinkTo>

--- a/app/components/course-page/course-stage-step/second-stage-instructions-card/read-instructions-step.hbs
+++ b/app/components/course-page/course-stage-step/second-stage-instructions-card/read-instructions-step.hbs
@@ -9,9 +9,16 @@
   </p>
   <ul>
     <li>
-      The
-      <LinkTo @route="course.stage.code-examples">Code Examples</LinkTo>
-      tab, which contains code examples from other users.
+      {{#if @isShowingLanguageGuide}}
+        The
+        <a href="#language-guide-card">{{this.currentLanguageName}} Guide</a>
+        card, which contains
+        {{this.currentLanguageName}}-specific instructions for this stage.
+      {{else}}
+        The
+        <LinkTo @route="course.stage.code-examples">Code Examples</LinkTo>
+        tab, which contains code examples from other users.
+      {{/if}}
     </li>
 
     {{! Let's limit to 2 suggestions for now so that we don't overwhelm the user.}}

--- a/app/components/course-page/course-stage-step/second-stage-instructions-card/read-instructions-step.ts
+++ b/app/components/course-page/course-stage-step/second-stage-instructions-card/read-instructions-step.ts
@@ -9,15 +9,11 @@ interface Signature {
     repository: RepositoryModel;
     courseStage: CourseStageModel;
     isComplete: boolean;
-    isShowingLanguageGuide: boolean;
+    shouldRecommendLanguageGuide: boolean;
   };
 }
 
-export default class ReadInstructionsStepComponent extends Component<Signature> {
-  get currentLanguageName(): string {
-    return this.args.repository.language!.name;
-  }
-}
+export default class ReadInstructionsStepComponent extends Component<Signature> {}
 
 declare module '@glint/environment-ember-loose/registry' {
   export default interface Registry {

--- a/app/components/course-page/course-stage-step/second-stage-instructions-card/read-instructions-step.ts
+++ b/app/components/course-page/course-stage-step/second-stage-instructions-card/read-instructions-step.ts
@@ -9,10 +9,15 @@ interface Signature {
     repository: RepositoryModel;
     courseStage: CourseStageModel;
     isComplete: boolean;
+    isShowingLanguageGuide: boolean;
   };
 }
 
-export default class ReadInstructionsStepComponent extends Component<Signature> {}
+export default class ReadInstructionsStepComponent extends Component<Signature> {
+  get currentLanguageName(): string {
+    return this.args.repository.language!.name;
+  }
+}
 
 declare module '@glint/environment-ember-loose/registry' {
   export default interface Registry {

--- a/app/components/course-page/course-stage-step/simple-language-guide-card.hbs
+++ b/app/components/course-page/course-stage-step/simple-language-guide-card.hbs
@@ -1,45 +1,41 @@
-<div {{did-update this.loadLanguageGuides @courseStage}} {{did-insert this.loadLanguageGuides}}>
-  {{#if this.languageGuide}}
-    <CoursePage::InstructionsCard
-      @contentIdentifier={{@courseStage.id}}
-      @isCollapsedByDefault={{true}}
-      @onExpand={{this.handleExpand}}
-      id="language-guide-card"
-      data-test-language-guide-card
-      ...attributes
-    >
-      <:header>
-        <div class="flex items-center justify-between border-b dark:border-white/5 pb-2 mb-5 w-full">
-          <div class="flex items-center gap-x-3">
-            <h2 class="font-semibold text-lg text-gray-700 dark:text-gray-200 flex items-center">
-              {{@language.name}}&nbsp;Guide
-            </h2>
+<CoursePage::InstructionsCard
+  @contentIdentifier={{@courseStage.id}}
+  @isCollapsedByDefault={{true}}
+  @onExpand={{this.handleExpand}}
+  id="language-guide-card"
+  data-test-language-guide-card
+  ...attributes
+>
+  <:header>
+    <div class="flex items-center justify-between border-b dark:border-white/5 pb-2 mb-5 w-full">
+      <div class="flex items-center gap-x-3">
+        <h2 class="font-semibold text-lg text-gray-700 dark:text-gray-200 flex items-center">
+          {{@language.name}}&nbsp;Guide
+        </h2>
 
-            <Pill @color="green" class="text-xs">
-              BETA
-              <EmberTooltip @text="This is a beta feature, please send us feedback!" @side="top" />
-            </Pill>
-          </div>
+        <Pill @color="green" class="text-xs">
+          BETA
+          <EmberTooltip @text="This is a beta feature, please send us feedback!" @side="top" />
+        </Pill>
+      </div>
 
-          <FeedbackButton
-            @source="course_stage_language_guide"
-            @sourceMetadata={{hash language_slug=@language.slug}}
-            class="inline-flex"
-            @dropdownPosition="right"
-            data-test-feedback-button
-          >
-            <TertiaryButton @size="small">
-              Share Feedback
-            </TertiaryButton>
-          </FeedbackButton>
-        </div>
-      </:header>
+      <FeedbackButton
+        @source="course_stage_language_guide"
+        @sourceMetadata={{hash language_slug=@language.slug}}
+        class="inline-flex"
+        @dropdownPosition="right"
+        data-test-feedback-button
+      >
+        <TertiaryButton @size="small">
+          Share Feedback
+        </TertiaryButton>
+      </FeedbackButton>
+    </div>
+  </:header>
 
-      <:content>
-        <div class="prose dark:prose-invert has-prism-highlighting" {{highlight-code-blocks this.languageGuide.markdownForBeginner}}>
-          {{markdown-to-html this.languageGuide.markdownForBeginner}}
-        </div>
-      </:content>
-    </CoursePage::InstructionsCard>
-  {{/if}}
-</div>
+  <:content>
+    <div class="prose dark:prose-invert has-prism-highlighting" {{highlight-code-blocks this.languageGuide.markdownForBeginner}}>
+      {{markdown-to-html this.languageGuide.markdownForBeginner}}
+    </div>
+  </:content>
+</CoursePage::InstructionsCard>

--- a/app/components/course-page/course-stage-step/simple-language-guide-card.hbs
+++ b/app/components/course-page/course-stage-step/simple-language-guide-card.hbs
@@ -1,5 +1,5 @@
 <CoursePage::InstructionsCard
-  @contentIdentifier={{@courseStage.id}}
+  @contentIdentifier={{@languageGuide.id}}
   @isCollapsedByDefault={{true}}
   @onExpand={{this.handleExpand}}
   id="language-guide-card"
@@ -10,7 +10,7 @@
     <div class="flex items-center justify-between border-b dark:border-white/5 pb-2 mb-5 w-full">
       <div class="flex items-center gap-x-3">
         <h2 class="font-semibold text-lg text-gray-700 dark:text-gray-200 flex items-center">
-          {{@language.name}}&nbsp;Guide
+          {{@languageGuide.language.name}}&nbsp;Guide
         </h2>
 
         <Pill @color="green" class="text-xs">
@@ -21,7 +21,7 @@
 
       <FeedbackButton
         @source="course_stage_language_guide"
-        @sourceMetadata={{hash language_slug=@language.slug}}
+        @sourceMetadata={{hash language_slug=@languageGuide.language.slug}}
         class="inline-flex"
         @dropdownPosition="right"
         data-test-feedback-button
@@ -34,8 +34,8 @@
   </:header>
 
   <:content>
-    <div class="prose dark:prose-invert has-prism-highlighting" {{highlight-code-blocks this.languageGuide.markdownForBeginner}}>
-      {{markdown-to-html this.languageGuide.markdownForBeginner}}
+    <div class="prose dark:prose-invert has-prism-highlighting" {{highlight-code-blocks @languageGuide.markdownForBeginner}}>
+      {{markdown-to-html @languageGuide.markdownForBeginner}}
     </div>
   </:content>
 </CoursePage::InstructionsCard>

--- a/app/components/course-page/course-stage-step/simple-language-guide-card.ts
+++ b/app/components/course-page/course-stage-step/simple-language-guide-card.ts
@@ -1,6 +1,4 @@
 import Component from '@glimmer/component';
-import CourseStageModel from 'codecrafters-frontend/models/course-stage';
-import LanguageModel from 'codecrafters-frontend/models/language';
 import Store from '@ember-data/store';
 import { action } from '@ember/object';
 import { inject as service } from '@ember/service';
@@ -10,23 +8,16 @@ interface Signature {
   Element: HTMLDivElement;
 
   Args: {
-    courseStage: CourseStageModel;
-    language?: LanguageModel;
+    languageGuide: CourseStageLanguageGuideModel;
   };
 }
 
 export default class SimpleLanguageGuideCardComponent extends Component<Signature> {
   @service declare store: Store;
 
-  get languageGuide(): CourseStageLanguageGuideModel {
-    return this.args.courseStage.languageGuides.findBy('language', this.args.language)!;
-  }
-
   @action
   handleExpand(): void {
-    if (this.languageGuide) {
-      this.languageGuide.createView();
-    }
+    this.args.languageGuide.createView();
   }
 }
 

--- a/app/components/course-page/course-stage-step/simple-language-guide-card.ts
+++ b/app/components/course-page/course-stage-step/simple-language-guide-card.ts
@@ -4,7 +4,7 @@ import LanguageModel from 'codecrafters-frontend/models/language';
 import Store from '@ember-data/store';
 import { action } from '@ember/object';
 import { inject as service } from '@ember/service';
-import { task } from 'ember-concurrency';
+import type CourseStageLanguageGuideModel from 'codecrafters-frontend/models/course-stage-language-guide';
 
 interface Signature {
   Element: HTMLDivElement;
@@ -18,8 +18,8 @@ interface Signature {
 export default class SimpleLanguageGuideCardComponent extends Component<Signature> {
   @service declare store: Store;
 
-  get languageGuide() {
-    return this.args.courseStage.languageGuides.findBy('language', this.args.language);
+  get languageGuide(): CourseStageLanguageGuideModel {
+    return this.args.courseStage.languageGuides.findBy('language', this.args.language)!;
   }
 
   @action
@@ -28,18 +28,6 @@ export default class SimpleLanguageGuideCardComponent extends Component<Signatur
       this.languageGuide.createView();
     }
   }
-
-  @action
-  loadLanguageGuides(): void {
-    this.loadLanguageGuidesTask.perform();
-  }
-
-  loadLanguageGuidesTask = task({ keepLatest: true }, async (): Promise<void> => {
-    await this.store.query('course-stage-language-guide', {
-      course_stage_id: this.args.courseStage.id,
-      include: 'course-stage,language',
-    });
-  });
 }
 
 declare module '@glint/environment-ember-loose/registry' {

--- a/app/controllers/course/stage/instructions.ts
+++ b/app/controllers/course/stage/instructions.ts
@@ -41,6 +41,10 @@ export default class CourseStageInstructionsController extends Controller {
     return this.model.activeRepository.currentStage === this.model.courseStage;
   }
 
+  get languageGuide() {
+    return this.model.courseStage.languageGuides.findBy('language', this.model.activeRepository.language);
+  }
+
   get prerequisiteInstructionsMarkdown() {
     return this.model.courseStage.prerequisiteInstructionsMarkdownFor(this.model.activeRepository);
   }
@@ -50,13 +54,7 @@ export default class CourseStageInstructionsController extends Controller {
   }
 
   get shouldShowLanguageGuide() {
-    const languageGuide = this.model.courseStage.languageGuides.findBy('language', this.model.activeRepository.language);
-
-    return (
-      !this.model.courseStage.isFirst &&
-      !!languageGuide &&
-      (this.featureFlags.canSeeLanguageGuidesForStage2 || this.authenticator.currentUser?.isStaff)
-    );
+    return !this.model.courseStage.isFirst && !!this.languageGuide && this.featureFlags.canSeeLanguageGuidesForStage2;
   }
 
   get shouldShowPrerequisites() {

--- a/app/templates/course/stage/instructions.hbs
+++ b/app/templates/course/stage/instructions.hbs
@@ -1,4 +1,8 @@
-<CoursePage::PreviousStepsIncompleteOverlay @currentStep={{this.currentStep}}>
+<CoursePage::PreviousStepsIncompleteOverlay
+  @currentStep={{this.currentStep}}
+  {{did-update this.loadLanguageGuides @model.courseStage}}
+  {{did-insert this.loadLanguageGuides}}
+>
   <div class="pt-6 pb-32 px-3 md:px-6 lg:px-10" {{did-update this.handleDidUpdateTestsStatus this.currentStep.testsStatus}}>
     {{#if this.shouldShowUpgradePrompt}}
       <CoursePage::CourseStageStep::UpgradePrompt @featureSlugToHighlight="content" class="mb-6" />
@@ -36,6 +40,7 @@
       <CoursePage::CourseStageStep::SecondStageInstructionsCard
         @repository={{@model.activeRepository}}
         @courseStage={{@model.courseStage}}
+        @shouldRecommendLanguageGuide={{this.shouldShowLanguageGuide}}
         class="mb-6"
       />
     {{/if}}

--- a/app/templates/course/stage/instructions.hbs
+++ b/app/templates/course/stage/instructions.hbs
@@ -86,11 +86,10 @@
     <CoursePage::CourseStageStep::YourTaskCard @repository={{@model.activeRepository}} @courseStage={{@model.courseStage}} />
 
     {{#if this.shouldShowLanguageGuide}}
-      <CoursePage::CourseStageStep::SimpleLanguageGuideCard
-        @courseStage={{@model.courseStage}}
-        @language={{@model.activeRepository.language}}
-        class="mt-6"
-      />
+      {{! Extra if condition convinces typescript that languageGuide isn't null }}
+      {{#if this.languageGuide}}
+        <CoursePage::CourseStageStep::SimpleLanguageGuideCard @languageGuide={{this.languageGuide}} class="mt-6" />
+      {{/if}}
     {{/if}}
 
     <div data-percy-hints-section>

--- a/tests/acceptance/course-page/attempt-course-stage-test.js
+++ b/tests/acceptance/course-page/attempt-course-stage-test.js
@@ -41,7 +41,7 @@ module('Acceptance | course-page | attempt-course-stage', function (hooks) {
         'fetch repositories (course page)',
         'fetch leaderboard entries (course page)',
         'fetch hints (course page)',
-        // 'fetch language guide (course page)',
+        'fetch language guide (course page)',
       ].length,
     );
 

--- a/tests/acceptance/course-page/resume-course-test.js
+++ b/tests/acceptance/course-page/resume-course-test.js
@@ -39,7 +39,7 @@ module('Acceptance | course-page | resume-course-test', function (hooks) {
         'fetch repositories (course page)',
         'fetch leaderboard entries (course page)',
         'fetch hints (course page)',
-        // 'fetch language guide (course page)',
+        'fetch language guide (course page)',
       ].length,
     );
   });

--- a/tests/acceptance/course-page/switch-repository-test.js
+++ b/tests/acceptance/course-page/switch-repository-test.js
@@ -45,6 +45,7 @@ module('Acceptance | course-page | switch-repository', function (hooks) {
       'fetch repositories (course page)',
       'fetch leaderboard entries (course page)',
       'fetch hints (course page)',
+      'fetch language guides (course page)',
     ].length;
 
     assert.strictEqual(coursePage.repositoryDropdown.activeRepositoryName, goRepository.name, 'repository with last push should be active');

--- a/tests/acceptance/course-page/try-other-language-test.js
+++ b/tests/acceptance/course-page/try-other-language-test.js
@@ -36,7 +36,7 @@ module('Acceptance | course-page | try-other-language', function (hooks) {
       'fetch repositories (course page)',
       'fetch leaderboard entries (course page)',
       'fetch hints (course page)',
-      'fetch language guide (course page)',
+      'fetch language guides (course page)',
     ].length;
 
     await catalogPage.visit();

--- a/tests/acceptance/course-page/try-other-language-test.js
+++ b/tests/acceptance/course-page/try-other-language-test.js
@@ -36,7 +36,7 @@ module('Acceptance | course-page | try-other-language', function (hooks) {
       'fetch repositories (course page)',
       'fetch leaderboard entries (course page)',
       'fetch hints (course page)',
-      // 'fetch language guide (course page)',
+      'fetch language guide (course page)',
     ].length;
 
     await catalogPage.visit();


### PR DESCRIPTION
**Checklist**:

- [x] I've thoroughly self-reviewed my changes
- [ ] I've added tests for my changes, unless they affect admin-only areas (or are otherwise not worth testing)
- [ ] I've verified any visual changes using Percy (add a commit with `[percy]` in the message to trigger)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced dynamic visibility for language guides in the instructions card, enhancing user experience.
	- Added conditional rendering for language guide recommendations in the "Implement Solution" and "Read Instructions" steps.
	- Enhanced responsiveness of the course stage instructions by integrating language guide loading.
	- Updated user interface to display language-specific guidance based on the availability of language guides.

- **Bug Fixes**
	- Improved state management for displaying language guides based on feature flags.

- **Documentation**
	- Updated component interfaces to include new properties related to language guide visibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->