### PR TITLE
Switch Admin Course Updates page to `CodeMirror`

### DIFF
--- a/app/components/file-diff-card.hbs
+++ b/app/components/file-diff-card.hbs
@@ -26,7 +26,12 @@
   {{else}}
     <div class="text-sm leading-6">
       {{! @glint-expect-error: not ts-ified yet }}
-      <SyntaxHighlightedDiff @code={{@code}} @language={{@language}} @shouldCollapseUnchangedLines={{true}} @forceDarkTheme={{@forceDarkTheme}} />
+      <SyntaxHighlightedDiff
+        @code={{or @code ""}}
+        @language={{@language}}
+        @shouldCollapseUnchangedLines={{true}}
+        @forceDarkTheme={{@forceDarkTheme}}
+      />
     </div>
   {{/if}}
 </div>

--- a/app/components/file-diff-card.hbs
+++ b/app/components/file-diff-card.hbs
@@ -3,8 +3,30 @@
     <span class="font-mono text-xs text-gray-600 dark:text-gray-300 bold">{{@filename}}</span>
   </div>
 
-  <div class="text-sm leading-6">
-    {{! @glint-expect-error: not ts-ified yet }}
-    <SyntaxHighlightedDiff @code={{@code}} @language={{@language}} @shouldCollapseUnchangedLines={{true}} @forceDarkTheme={{@forceDarkTheme}} />
-  </div>
+  {{#if @useCodeMirror}}
+    {{#let (diff-to-document @code) as |document|}}
+      <CodeMirror
+        @document={{document.current}}
+        @originalDocument={{document.original}}
+        @filename={{@filename}}
+        @language={{@language}}
+        @allowMultipleSelections={{true}}
+        @bracketMatching={{true}}
+        @collapseUnchanged={{true}}
+        @crosshairCursor={{true}}
+        @drawSelection={{true}}
+        @rectangularSelection={{true}}
+        @readOnly={{true}}
+        @highlightSelectionMatches={{true}}
+        @highlightSpecialChars={{true}}
+        @theme={{this.codeMirrorTheme}}
+        class="block text-sm"
+      />
+    {{/let}}
+  {{else}}
+    <div class="text-sm leading-6">
+      {{! @glint-expect-error: not ts-ified yet }}
+      <SyntaxHighlightedDiff @code={{@code}} @language={{@language}} @shouldCollapseUnchangedLines={{true}} @forceDarkTheme={{@forceDarkTheme}} />
+    </div>
+  {{/if}}
 </div>

--- a/app/components/file-diff-card.ts
+++ b/app/components/file-diff-card.ts
@@ -1,17 +1,43 @@
+import { service } from '@ember/service';
 import Component from '@glimmer/component';
+import type DarkModeService from 'codecrafters-frontend/services/dark-mode';
+import { codeCraftersDark, codeCraftersLight } from 'codecrafters-frontend/utils/code-mirror-themes';
 
 interface Signature {
   Element: HTMLDivElement;
 
   Args: {
+    /**
+     * Code to render in CodeMirror/SyntaxHighlightedDiff
+     */
     code: string;
-    language: string;
+    /**
+     * Filename to render in the header.
+     * Also used to auto-detect language for code formatting
+     */
     filename: string;
+    /**
+     * Always render CodeMirror/SyntaxHighlightedDiff using Dark Theme
+     */
     forceDarkTheme?: boolean;
+    /**
+     * Override language auto-detected from `filename` and set it manually
+     */
+    language: string;
+    /**
+     * Use CodeMirror instead of SyntaxHighlightedDiff for rendering the diff
+     */
+    useCodeMirror?: boolean;
   };
 }
 
-export default class FileDiffCardComponent extends Component<Signature> {}
+export default class FileDiffCardComponent extends Component<Signature> {
+  @service declare darkMode: DarkModeService;
+
+  get codeMirrorTheme() {
+    return this.darkMode.isEnabled || this.args.forceDarkTheme ? codeCraftersDark : codeCraftersLight;
+  }
+}
 
 declare module '@glint/environment-ember-loose/registry' {
   export default interface Registry {

--- a/app/components/file-diff-card.ts
+++ b/app/components/file-diff-card.ts
@@ -10,7 +10,7 @@ interface Signature {
     /**
      * Code to render in CodeMirror/SyntaxHighlightedDiff
      */
-    code: string;
+    code?: string;
     /**
      * Filename to render in the header.
      * Also used to auto-detect language for code formatting

--- a/app/components/syntax-highlighted-diff/expandable-chunk.hbs
+++ b/app/components/syntax-highlighted-diff/expandable-chunk.hbs
@@ -5,7 +5,6 @@
       {{if @chunk.isCollapsedAtBottom 'mb-0' 'border-b'}}"
     role="button"
     {{on "click" this.handleClick}}
-    data-test-expandable-chunk
   >
     <span class="flex flex-col justify-center h-full pr-2">
       {{#if @chunk.isCollapsedAtTop}}

--- a/app/controllers/demo/file-diff-card.ts
+++ b/app/controllers/demo/file-diff-card.ts
@@ -1,0 +1,29 @@
+import Controller from '@ember/controller';
+import { action } from '@ember/object';
+import { tracked } from '@glimmer/tracking';
+import EXAMPLE_DOCUMENTS, { DiffBasedExampleDocument } from 'codecrafters-frontend/utils/code-mirror-documents';
+
+const OPTION_DEFAULTS = {
+  forceDarkTheme: false,
+  selectedDocumentIndex: 1,
+};
+
+export default class DemoFileDiffCardController extends Controller {
+  @tracked documents: DiffBasedExampleDocument[] = EXAMPLE_DOCUMENTS;
+
+  @tracked forceDarkTheme: boolean = OPTION_DEFAULTS.forceDarkTheme;
+  @tracked selectedDocumentIndex: number = OPTION_DEFAULTS.selectedDocumentIndex;
+
+  get selectedDocument() {
+    return this.documents[this.selectedDocumentIndex] || DiffBasedExampleDocument.createEmpty();
+  }
+
+  @action resetAllOptions() {
+    Object.assign(this, OPTION_DEFAULTS);
+  }
+
+  @action selectedDocumentIndexDidChange(event: Event) {
+    const target: HTMLSelectElement = event.target as HTMLSelectElement;
+    this.selectedDocumentIndex = target.selectedIndex;
+  }
+}

--- a/app/controllers/demo/file-diff-card.ts
+++ b/app/controllers/demo/file-diff-card.ts
@@ -6,6 +6,7 @@ import EXAMPLE_DOCUMENTS, { DiffBasedExampleDocument } from 'codecrafters-fronte
 const OPTION_DEFAULTS = {
   forceDarkTheme: false,
   selectedDocumentIndex: 1,
+  useCodeMirror: true,
 };
 
 export default class DemoFileDiffCardController extends Controller {
@@ -13,6 +14,7 @@ export default class DemoFileDiffCardController extends Controller {
 
   @tracked forceDarkTheme: boolean = OPTION_DEFAULTS.forceDarkTheme;
   @tracked selectedDocumentIndex: number = OPTION_DEFAULTS.selectedDocumentIndex;
+  @tracked useCodeMirror: boolean = OPTION_DEFAULTS.useCodeMirror;
 
   get selectedDocument() {
     return this.documents[this.selectedDocumentIndex] || DiffBasedExampleDocument.createEmpty();

--- a/app/router.ts
+++ b/app/router.ts
@@ -106,5 +106,6 @@ Router.map(function () {
     this.route('code-mirror');
     this.route('dark-mode-toggle');
     this.route('file-contents-card');
+    this.route('file-diff-card');
   });
 });

--- a/app/routes/demo/file-diff-card.ts
+++ b/app/routes/demo/file-diff-card.ts
@@ -1,6 +1,6 @@
 import Route from '@ember/routing/route';
 
-const QUERY_PARAMS = ['forceDarkTheme', 'selectedDocumentIndex'];
+const QUERY_PARAMS = ['forceDarkTheme', 'selectedDocumentIndex', 'useCodeMirror'];
 
 interface QueryParamOptions {
   [key: string]: {

--- a/app/routes/demo/file-diff-card.ts
+++ b/app/routes/demo/file-diff-card.ts
@@ -1,0 +1,17 @@
+import Route from '@ember/routing/route';
+
+const QUERY_PARAMS = ['forceDarkTheme', 'selectedDocumentIndex'];
+
+interface QueryParamOptions {
+  [key: string]: {
+    replace: boolean;
+  };
+}
+
+export default class DemoFileDiffCardRoute extends Route {
+  queryParams = QUERY_PARAMS.reduce<QueryParamOptions>((acc, param) => {
+    acc[param] = { replace: true };
+
+    return acc;
+  }, {});
+}

--- a/app/styles/app.css
+++ b/app/styles/app.css
@@ -7,6 +7,7 @@
 @import 'pages/course-stage-solution-page.scss';
 @import 'pages/code-walkthrough-page.scss';
 @import 'pages/course-admin-submission-diff.scss';
+@import 'pages/course-admin-updates-diff.scss';
 
 /* purgecss start ignore */
 @import '@typeform/embed/build/css/popup.css';

--- a/app/styles/pages/course-admin-updates-diff.scss
+++ b/app/styles/pages/course-admin-updates-diff.scss
@@ -1,0 +1,3 @@
+.course-admin-updates-diff-container code-mirror .cm-collapsedLines {
+  margin-left: -24px;
+}

--- a/app/templates/course-admin/update.hbs
+++ b/app/templates/course-admin/update.hbs
@@ -78,6 +78,7 @@
       @filename="course-definition.yml"
       @code={{@model.update.definitionFileContentsDiff}}
       @language="yaml"
+      @useCodeMirror={{true}}
       data-test-file-contents-diff
     />
   </div>

--- a/app/templates/course-admin/update.hbs
+++ b/app/templates/course-admin/update.hbs
@@ -1,5 +1,5 @@
 <div class="bg-white min-h-screen">
-  <div class="container mx-auto pt-4 pb-10 px-6">
+  <div class="container mx-auto pt-4 pb-10 px-6 course-admin-updates-diff-container">
     <div class="pt-3 pb-6 border-b mb-6">
       <TertiaryLinkButton @route="course-admin.updates" @models={{array @model.update.course.slug}} @size="small" class="pl-1.5 mb-3">
         <div class="flex items-center">

--- a/app/templates/demo.hbs
+++ b/app/templates/demo.hbs
@@ -30,6 +30,16 @@
         >FileContentsCard</span>
       </LinkTo>
       <LinkTo
+        @route="demo.file-diff-card"
+        role="button"
+        class="flex flex-shrink-0 items-center px-3 py-2 mr-2 border-b-2 text-sm
+          {{if (eq this.router.currentRouteName 'demo.file-diff-card') 'border-teal-500' 'border-gray-100 dark:border-gray-700'}}"
+      >
+        <span
+          class={{if (eq this.router.currentRouteName "demo.file-diff-card") "font-medium text-teal-500" "text-gray-600 dark:text-gray-200"}}
+        >FileDiffCard</span>
+      </LinkTo>
+      <LinkTo
         @route="demo.dark-mode-toggle"
         role="button"
         class="flex flex-shrink-0 items-center px-3 py-2 mr-2 border-b-2 text-sm

--- a/app/templates/demo/code-mirror.hbs
+++ b/app/templates/demo/code-mirror.hbs
@@ -5,7 +5,7 @@
   "flex cursor-default select-none text-nowrap mx-2"
   as |groupClasses labelClasses|
 }}
-  <codemirror-options class="{{groupClasses}} -mt-8">
+  <codemirror-options class="{{groupClasses}} border-dotted -mt-8">
     <codemirror-options-left class="flex flex-grow flex-wrap">
       <label class="{{labelClasses}}" title="Show an outline around the component's element">
         <Input @type="checkbox" @checked={{this.outline}} />
@@ -270,7 +270,7 @@
     </label>
   </codemirror-options>
 
-  <codemirror-options class="{{groupClasses}} border-dotted">
+  <codemirror-options class="{{groupClasses}}">
     <codemirror-options-left class="flex flex-grow flex-wrap">
       <label
         class="{{labelClasses}}"

--- a/app/templates/demo/file-diff-card.hbs
+++ b/app/templates/demo/file-diff-card.hbs
@@ -1,0 +1,45 @@
+{{page-title "FileDiffCard"}}
+
+{{#let
+  "flex flex-wrap text-sm font-semibold text-gray-600 dark:text-gray-200 border-b border-gray-200 dark:border-gray-700
+py-2"
+  "flex cursor-default select-none text-nowrap mx-2"
+  as |groupClasses labelClasses|
+}}
+  <component-options class="{{groupClasses}} -mt-8">
+    <component-options-left class="flex flex-grow flex-wrap">
+      <label class="{{labelClasses}}" title="File for the component to render (select a preset)">
+        <span class="mr-2">File:</span>
+        <select class="dark:bg-gray-700" {{on "change" this.selectedDocumentIndexDidChange}}>
+          {{#each this.documents as |doc index|}}
+            <option selected={{eq this.selectedDocumentIndex index}}>{{doc.filename}} ({{doc.language}})</option>
+          {{/each}}
+        </select>
+      </label>
+    </component-options-left>
+    <component-options-right class="flex flex-wrap">
+      <label class="{{labelClasses}}" title="Always render CodeMirror using Dark Theme">
+        <Input @type="checkbox" @checked={{this.forceDarkTheme}} />
+        <span class="ml-2">forceDarkTheme</span>
+      </label>
+    </component-options-right>
+  </component-options>
+{{/let}}
+
+<FileDiffCard
+  @code={{this.selectedDocument.diff}}
+  @filename={{this.selectedDocument.filename}}
+  @language={{this.selectedDocument.language}}
+  @forceDarkTheme={{this.forceDarkTheme}}
+  class="mt-4 {{if this.forceDarkTheme 'dark'}}"
+/>
+
+<div class="my-2 text-right">
+  <span
+    role="button"
+    class="text-xs text-blue-600 hover:text-blue-800 dark:text-blue-200 dark:hover:text-blue-400 underline cursor-pointer"
+    {{on "click" this.resetAllOptions}}
+  >Reset all options</span>
+</div>
+
+{{outlet}}

--- a/app/templates/demo/file-diff-card.hbs
+++ b/app/templates/demo/file-diff-card.hbs
@@ -18,6 +18,10 @@ py-2"
       </label>
     </component-options-left>
     <component-options-right class="flex flex-wrap">
+      <label class="{{labelClasses}}" title="Use CodeMirror instead of SyntaxHighlightedDiff for rendering the diff">
+        <Input @type="checkbox" @checked={{this.useCodeMirror}} />
+        <span class="ml-2">useCodeMirror</span>
+      </label>
       <label class="{{labelClasses}}" title="Always render CodeMirror using Dark Theme">
         <Input @type="checkbox" @checked={{this.forceDarkTheme}} />
         <span class="ml-2">forceDarkTheme</span>
@@ -27,6 +31,7 @@ py-2"
 {{/let}}
 
 <FileDiffCard
+  @useCodeMirror={{this.useCodeMirror}}
   @code={{this.selectedDocument.diff}}
   @filename={{this.selectedDocument.filename}}
   @language={{this.selectedDocument.language}}

--- a/app/utils/code-mirror-documents.ts
+++ b/app/utils/code-mirror-documents.ts
@@ -44,6 +44,10 @@ export class DiffBasedExampleDocument extends ExampleDocument {
 
     this.diff = diff;
   }
+
+  static createEmpty() {
+    return new this({ filename: 'empty.txt', language: 'text' });
+  }
 }
 
 export default [

--- a/tests/acceptance/course-admin/view-update-test.js
+++ b/tests/acceptance/course-admin/view-update-test.js
@@ -58,7 +58,7 @@ module('Acceptance | course-admin | view-update', function (hooks) {
 
     const update = this.server.create('course-definition-update', {
       course: this.server.schema.courses.findBy({ slug: 'redis' }),
-      definitionFileContentsDiff: 'old contents',
+      definitionFileContentsDiff: ' old contents\n',
       description: 'Updated stage instructions for stage 1 & stage 2',
       lastErrorMessage: null,
       lastSyncedAt: new Date(2020, 1, 1),
@@ -70,12 +70,21 @@ module('Acceptance | course-admin | view-update', function (hooks) {
     await updatesPage.visit({ course_slug: 'redis' });
     await updatesPage.updateListItems[0].clickOnViewUpdateButton();
 
-    update.update('definitionFileContentsDiff', '+ updated diff');
+    update.update('definitionFileContentsDiff', '-old contents\n+updated diff\n');
 
     await updatePage.clickOnSyncWithGitHubButton();
     await settled(); // Investigate why clickable() doesn't call settled()
 
-    assert.ok(updatePage.fileContentsDiff.text.includes('+ updated diff'), 'diff should be updated after syncing with github');
+    assert.strictEqual(
+      updatePage.fileContentsDiff.codeMirror.content.changedLines[0].text,
+      'updated diff',
+      'diff should be updated after syncing with github',
+    );
+    assert.strictEqual(
+      updatePage.fileContentsDiff.codeMirror.content.deletedChunks[0].text,
+      'old contents',
+      'diff should be updated after syncing with github',
+    );
   });
 
   test('it should properly be properly rendered as an html', async function (assert) {

--- a/tests/pages/course-admin/update-page.js
+++ b/tests/pages/course-admin/update-page.js
@@ -1,4 +1,5 @@
 import { attribute, clickable, collection, create, visitable } from 'ember-cli-page-object';
+import codeMirror from 'codecrafters-frontend/tests/pages/components/code-mirror';
 
 export default create({
   applyUpdateButton: {
@@ -13,7 +14,7 @@ export default create({
 
   fileContentsDiff: {
     expandableChunks: collection('[data-test-expandable-chunk]'),
-
+    codeMirror,
     scope: '[data-test-file-contents-diff]',
   },
 

--- a/tests/pages/course-admin/update-page.js
+++ b/tests/pages/course-admin/update-page.js
@@ -1,4 +1,4 @@
-import { attribute, clickable, collection, create, visitable } from 'ember-cli-page-object';
+import { attribute, clickable, create, visitable } from 'ember-cli-page-object';
 import codeMirror from 'codecrafters-frontend/tests/pages/components/code-mirror';
 
 export default create({
@@ -13,9 +13,8 @@ export default create({
   },
 
   fileContentsDiff: {
-    expandableChunks: collection('[data-test-expandable-chunk]'),
-    codeMirror,
     scope: '[data-test-file-contents-diff]',
+    codeMirror,
   },
 
   description: {


### PR DESCRIPTION
Related to #1231 

### Brief

This switches the Admin Course Updates page to use `CodeMirror` instead of `SyntaxHighlightedDiff`, as well as adds support for CodeMirror to the `FileDiffCard` component.

### Details

- `FileDiffCard` now supports rendering the diff using `CodeMirror` instead of `SyntaxHighlightedDiff`
  - enabled by passing `@useCodeMirror={{true}}` argument
  - three more templates can now make use of it (via separate PRs):
    - `app/components/course-page/course-stage-step/first-stage-tutorial-card/uncomment-code-step.hbs`
    - `app/components/course-page/course-stage-step/second-stage-instructions-card/implement-solution-step.hbs`
    - `app/components/course-page/test-results-bar/autofix-section/autofix-result.hbs`
- Switched Admin Course Updates page to use CodeMirror
  - without any further measuring, the speed boost of rendering / expanding 5000 hidden lines feels **SIGNIFICANT**
- Added `FileDiffCard` to the Demo page
  - allows toggling `@useCodeMirror` to compare how diffs are rendered using `CodeMirror` vs `SyntaxHighlightedDiff`
  - allows toggling `@forceDarkTheme`
- Updated test `it should have a working button for syncing with github for individual update` to check CodeMirror's elements

### Screenshots

<img width="558" alt="Знімок екрана 2024-11-19 о 14 26 57" src="https://github.com/user-attachments/assets/fc0a3c11-fd77-4a31-84f0-aa9ffcc21d36">

<img width="1014" alt="Знімок екрана 2024-11-19 о 14 27 24" src="https://github.com/user-attachments/assets/b3b9149e-2e0e-412e-be40-40d2da402b28">

### Checklist

- [x] I've thoroughly self-reviewed my changes
- [x] I've added tests for my changes, unless they affect admin-only areas (or are otherwise not worth testing)
- [x] I've verified any visual changes using Percy (add a commit with `[percy]` in the message to trigger)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **New Features**
  - Introduced a new `FileDiffCard` component for displaying file differences with enhanced rendering options, including support for CodeMirror and dark mode.
  - Added a new route for navigating to the `FileDiffCard` component within the demo section.
  - Implemented a user-friendly interface with dropdowns and checkboxes for selecting documents and toggling rendering options.
  - Added a reset button to restore default options in the file diff card.
  - Enhanced styling for the course admin updates diff to improve visual presentation.
  - Introduced new styles for the CodeMirror options to enhance visual distinction.

- **Bug Fixes**
  - Improved handling of optional properties to ensure better flexibility in document rendering.
  - Removed accessibility attributes that may affect automated testing.

- **Documentation**
  - Updated styles to include new components and ensure proper layout and design.

- **Chores**
  - Added example documents for diverse use cases in the diff representation.
  - Updated test cases to verify changes in document rendering accurately.
  - Modified imports in tests to streamline dependencies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->