### PR TITLE
Update `@codemirror/merge` to `6.7.4`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -33,7 +33,7 @@
         "@babel/plugin-proposal-decorators": "^7.25.9",
         "@codecov/webpack-plugin": "^1.2.1",
         "@codemirror/language-data": "^6.5.0",
-        "@codemirror/merge": "^6.7.2",
+        "@codemirror/merge": "^6.7.4",
         "@ember/optional-features": "^2.2.0",
         "@ember/render-modifiers": "^2.0.4",
         "@ember/string": "^3.1.1",
@@ -2652,9 +2652,9 @@
       }
     },
     "node_modules/@codemirror/merge": {
-      "version": "6.7.2",
-      "resolved": "https://registry.npmjs.org/@codemirror/merge/-/merge-6.7.2.tgz",
-      "integrity": "sha512-HSzuWoV4E+F0DROOSwGZMYIDXh+y4iA64ffRADXPBbKKSwx9bsYNM4i7qN8t0mc8H0PYNBoehOvsW2Nitmnx9g==",
+      "version": "6.7.4",
+      "resolved": "https://registry.npmjs.org/@codemirror/merge/-/merge-6.7.4.tgz",
+      "integrity": "sha512-9FpIFTgzkaxkZE93XKoFR6caAB6sCAfYCW2NT+atGEmdv/1Mt1ouxA+hKxGRYdMvdH9Ph0KMJtYnzEi+QCGAiQ==",
       "dev": true,
       "dependencies": {
         "@codemirror/language": "^6.0.0",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "@babel/plugin-proposal-decorators": "^7.25.9",
     "@codecov/webpack-plugin": "^1.2.1",
     "@codemirror/language-data": "^6.5.0",
-    "@codemirror/merge": "^6.7.2",
+    "@codemirror/merge": "^6.7.4",
     "@ember/optional-features": "^2.2.0",
     "@ember/render-modifiers": "^2.0.4",
     "@ember/string": "^3.1.1",


### PR DESCRIPTION
Related to #1231

### Brief

This updates `@codemirror/merge` from `6.7.2` to `6.7.4`, in which a [commit](https://github.com/codemirror/merge/commit/cb375119d9000d0837a4dbeae6c7735a3a633bc7) fixes a bug in line-alignment of changes, thus fixing the most obvious bugs with new line insertions appearing as deletions & re-insertions of the following line in the diff.

### Before

<img width="993" alt="Знімок екрана 2024-11-20 о 10 54 07" src="https://github.com/user-attachments/assets/581a7cdf-63ca-4ca9-a95d-47fd47977d2f">

### After

<img width="992" alt="Знімок екрана 2024-11-20 о 10 56 41" src="https://github.com/user-attachments/assets/8220eb06-6c20-40bf-a38b-97abd56b73b9">

### Note

It appears that the Accept/Reject buttons of the `@mergeControls` option are now missing for the inserted lines, but luckily, we don't use those.

### Checklist

- [x] I've thoroughly self-reviewed my changes
- [x] I've added tests for my changes, unless they affect admin-only areas (or are otherwise not worth testing)
- [x] I've verified any visual changes using Percy (add a commit with `[percy]` in the message to trigger)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated the version of the `@codemirror/merge` dependency to improve stability and performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->