### PR TITLE
Explain membershps don't renew automatically

### DIFF
--- a/app/components/membership-page/membership-plan-section.hbs
+++ b/app/components/membership-page/membership-plan-section.hbs
@@ -7,8 +7,11 @@
       plan is currently active.
     {{else if @subscription.isActive}}
       {{#if @subscription.cancelAt}}
-        Your CodeCrafters membership is valid until
-        <b class="font-semibold">{{date-format @subscription.cancelAt format="PPPp"}}</b>.
+        <p class="mb-3">
+          Your CodeCrafters membership is valid until
+          <b class="font-semibold">{{date-format @subscription.cancelAt format="PPPp"}}</b>.
+        </p>
+        <p>Your membership doesn’t renew automatically. To restart your membership, make a new one-time payment.</p>
       {{else}}
         You are currently subscribed to the
         <b class="font-semibold">{{@subscription.pricingPlanName}}</b>

--- a/tests/acceptance/manage-membership-test.js
+++ b/tests/acceptance/manage-membership-test.js
@@ -118,7 +118,7 @@ module('Acceptance | manage-membership-test', function (hooks) {
 
     assert.strictEqual(
       membershipPage.membershipPlanSection.descriptionText,
-      `Your CodeCrafters membership is valid until ${formatWithOptions({}, 'PPPp', subscription.currentPeriodEnd)}.`,
+      `Your CodeCrafters membership is valid until ${formatWithOptions({}, 'PPPp', subscription.currentPeriodEnd)}. Your membership doesn’t renew automatically. To restart your membership, make a new one-time payment.`,
     );
   });
 


### PR DESCRIPTION
<img width="677" alt="image" src="https://github.com/user-attachments/assets/d5b596fb-a957-4cb5-8eb2-54402984984f">


**Checklist**:

- [x] I've thoroughly self-reviewed my changes
- [x] not worth testing
- [x] I've verified any visual changes using Percy (add a commit with `[percy]` in the message to trigger)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
	- Added a message to the membership plan section, clarifying that memberships do not renew automatically and informing users about the need for a one-time payment to restart their membership.
- **Bug Fixes**
	- Enhanced test cases for membership management to ensure accurate messaging regarding subscription renewal and one-time payment requirements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->