### PR TITLE
Recommend Git instead of CLI for stage 2

### DIFF
--- a/app/components/course-page/course-stage-step/test-runner-card/run-tests-instructions.hbs
+++ b/app/components/course-page/course-stage-step/test-runner-card/run-tests-instructions.hbs
@@ -38,11 +38,9 @@
 
 <CopyableTerminalCommandWithVariants @variants={{this.commandVariants}} @onVariantSelect={{this.handleVariantSelect}} />
 
-{{#if (eq this.recommendedClientType "cli")}}
-  <div class="prose dark:prose-invert prose-sm prose-compact mt-3">
-    <p>
-      We recommend using the
-      <a href="https://codecrafters.io/cli" target="_blank" rel="noopener noreferrer">CodeCrafters CLI</a>, but you can use Git too.
-    </p>
-  </div>
-{{/if}}
+<div class="prose dark:prose-invert prose-sm prose-compact mt-3">
+  <p>
+    We recommend using the
+    <a href="https://codecrafters.io/cli" target="_blank" rel="noopener noreferrer">CodeCrafters CLI</a>, but you can use Git too.
+  </p>
+</div>

--- a/app/components/course-page/course-stage-step/test-runner-card/run-tests-instructions.ts
+++ b/app/components/course-page/course-stage-step/test-runner-card/run-tests-instructions.ts
@@ -36,7 +36,7 @@ export default class RunTestsInstructionsComponent extends Component<Signature> 
     if (this.recommendedClientType === 'cli') {
       return [cliVariant, gitVariant];
     } else {
-      return [gitVariant];
+      return [gitVariant, cliVariant];
     }
   }
 
@@ -45,7 +45,7 @@ export default class RunTestsInstructionsComponent extends Component<Signature> 
   }
 
   get recommendedClientType() {
-    if (this.args.currentStep.courseStage.isFirst) {
+    if (this.args.currentStep.courseStage.isFirst || this.args.currentStep.courseStage.isSecond) {
       return 'git';
     } else {
       return 'cli';

--- a/tests/acceptance/course-page/test-runner-card-test.js
+++ b/tests/acceptance/course-page/test-runner-card-test.js
@@ -11,7 +11,7 @@ module('Acceptance | course-page | test-runner-card', function (hooks) {
   setupApplicationTest(hooks);
   setupAnimationTest(hooks);
 
-  test('suggests CLI by default for stage 2', async function (assert) {
+  test('suggests Git for stage 2', async function (assert) {
     testScenario(this.server);
     signIn(this.owner, this.server);
 
@@ -29,6 +29,57 @@ module('Acceptance | course-page | test-runner-card', function (hooks) {
     await catalogPage.clickOnCourse('Build your own Redis');
 
     assert.strictEqual(currentURL(), '/courses/redis/stages/rg2', 'current URL is course page URL');
+
+    await coursePage.testRunnerCard.click(); // Expand to view instructions
+
+    assert.strictEqual(coursePage.testRunnerCard.copyableTerminalCommands.length, 1, 'only one copyable terminal command is present by default');
+
+    assert.strictEqual(
+      coursePage.testRunnerCard.copyableTerminalCommands[0].copyableText,
+      'git add . git commit --allow-empty -m "[any message]" git push origin master',
+      'copyable text mentions git by default',
+    );
+
+    await coursePage.testRunnerCard.copyableTerminalCommands[0].clickOnVariantButton('git');
+
+    assert.strictEqual(
+      coursePage.testRunnerCard.copyableTerminalCommands[0].copyableText,
+      ['git add .', 'git commit --allow-empty -m "[any message]"', 'git push origin master'].join(' '),
+      'copyable text is updated to include git commands',
+    );
+
+    await coursePage.testRunnerCard.copyableTerminalCommands[0].clickOnVariantButton('codecrafters cli');
+
+    assert.strictEqual(
+      coursePage.testRunnerCard.copyableTerminalCommands[0].copyableText,
+      'codecrafters test # Visit https://codecrafters.io/cli to install',
+      'copyable text mentions cli after switching back',
+    );
+  });
+
+  test('suggests CLI by default for stage 3', async function (assert) {
+    testScenario(this.server);
+    signIn(this.owner, this.server);
+
+    let currentUser = this.server.schema.users.first();
+    let python = this.server.schema.languages.findBy({ name: 'Python' });
+    let redis = this.server.schema.courses.findBy({ slug: 'redis' });
+
+    let repository = this.server.create('repository', 'withFirstStageCompleted', {
+      course: redis,
+      language: python,
+      user: currentUser,
+    });
+
+    this.server.create('submission', 'withStageCompletion', {
+      repository: repository,
+      courseStage: redis.stages.models.toArray().find((stage) => stage.position === 2),
+    });
+
+    await catalogPage.visit();
+    await catalogPage.clickOnCourse('Build your own Redis');
+
+    assert.strictEqual(currentURL(), '/courses/redis/stages/wy1', 'current URL is course page URL');
 
     await coursePage.testRunnerCard.click(); // Expand to view instructions
 


### PR DESCRIPTION
- Rename second stage instructions card to second stage tutorial card across files.
- Rename second-stage instructions card to second-stage tutorial card components.
- Fix ID in second-stage tutorial card and remove unnecessary pause in tests.
- Refactor run-tests-instructions to always recommend CLI and Git options.
