### PR TITLE
Fix broken link "Anonymous mode" in PricingCard

### DIFF
--- a/app/components/pay-page/pricing-card.ts
+++ b/app/components/pay-page/pricing-card.ts
@@ -43,8 +43,8 @@ export default class PricingCardComponent extends Component<Signature> {
       { text: 'No limits on content', link: 'https://docs.codecrafters.io/content' },
       { text: 'Turbo test runs', link: 'https://codecrafters.io/turbo' },
       { text: 'Code examples', link: 'https://docs.codecrafters.io/code-examples' },
-      { text: 'Dark mode', link: 'https://docs.codecrafters.io/membership/dark-mode' }, // TODO: Short link doesn't work?
-      { text: 'Anonymous mode', link: 'https://docs.codecrafters.io/anonymous-mode' },
+      { text: 'Dark mode', link: 'https://docs.codecrafters.io/membership/dark-mode' },
+      { text: 'Anonymous mode', link: 'https://docs.codecrafters.io/membership/anonymous-mode' },
       { text: 'Access to Perks', link: 'https://codecrafters.io/perks' },
       { text: 'Priority support' },
     ];


### PR DESCRIPTION
**Checklist**:

- [x] I've thoroughly self-reviewed my changes
- [x] Not worth testing
- [ ] I've verified any visual changes using Percy (add a commit with `[percy]` in the message to trigger)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated the link for the 'Anonymous mode' feature in the Pricing Card component.

- **Bug Fixes**
	- Ensured error handling remains effective for unknown pricing frequencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->