### PR TITLE
CC-1553: Render GitHub names on user pages and team members list

### DIFF
--- a/app/components/team-page/members-list-item.hbs
+++ b/app/components/team-page/members-list-item.hbs
@@ -11,7 +11,7 @@
     <div>
       <div class="text-gray-700 text-sm">
         {{#if @membership.user.githubName}}
-          <span class="font-semibold" data-test-username>{{@membership.user.githubName}}</span>
+          <span class="font-semibold" data-test-github-name>{{@membership.user.githubName}}</span>
         {{else}}
           <span class="font-semibold" data-test-username>{{@membership.user.username}}</span>
         {{/if}}

--- a/app/components/team-page/members-list-item.hbs
+++ b/app/components/team-page/members-list-item.hbs
@@ -10,7 +10,11 @@
 
     <div>
       <div class="text-gray-700 text-sm">
-        <span class="font-semibold" data-test-username>{{@membership.user.username}}</span>
+        {{#if @membership.user.githubName}}
+          <span class="font-semibold" data-test-username>{{@membership.user.githubName}}</span>
+        {{else}}
+          <span class="font-semibold" data-test-username>{{@membership.user.username}}</span>
+        {{/if}}
 
         {{#if @membership.isAdmin}}
           <span class="text-gray-400"> (admin)</span>

--- a/app/components/user-page/sidebar-container.hbs
+++ b/app/components/user-page/sidebar-container.hbs
@@ -1,10 +1,6 @@
 <div ...attributes>
   <img alt="avatar" src={{@user.avatarUrl}} class="border-2 border-white shadow rounded w-48 h-48 mb-6" />
 
-  <div class="font-bold text-2xl text-gray-600">
-    {{@user.name}}
-  </div>
-
   {{#if @user.hasAnonymousModeEnabled}}
     <a
       class="group inline-flex items-center text-gray-400 mb-4 w-full"
@@ -20,6 +16,10 @@
       {{svg-jar "github" class="fill-current w-5 ml-2 group-hover:text-gray-500"}}
     </a>
   {{else}}
+    <div class="font-bold text-2xl text-gray-600" data-test-github-name>
+      {{@user.githubName}}
+    </div>
+
     <a
       class="group inline-flex items-center text-gray-400 mb-4 w-full"
       href={{@user.githubProfileUrl}}

--- a/app/models/user.ts
+++ b/app/models/user.ts
@@ -31,6 +31,7 @@ export default class UserModel extends Model {
   @attr('string') declare avatarUrl: string;
   @attr('date') declare createdAt: Date;
   @attr() declare featureFlags: { [key: string]: string };
+  @attr('string') declare githubName: string | null;
   @attr('string') declare githubUsername: string;
   @attr('boolean') declare hasActiveFreeUsageGrants: boolean;
   @attr('boolean') declare hasAnonymousModeEnabled: boolean;

--- a/mirage/scenarios/default.js
+++ b/mirage/scenarios/default.js
@@ -10,6 +10,7 @@ export default function (server) {
     id: '63c51e91-e448-4ea9-821b-a80415f266d3',
     avatarUrl: 'https://github.com/rohitpaulk.png',
     createdAt: new Date('2019-01-01T00:00:00.000Z'),
+    githubName: 'Paul Kuruvilla',
     githubUsername: 'rohitpaulk',
     username: 'rohitpaulk',
     name: 'Paul Kuruvilla',

--- a/mirage/scenarios/test.js
+++ b/mirage/scenarios/test.js
@@ -13,6 +13,7 @@ export default function (server, courses = ['redis', 'docker', 'dummy', 'git', '
     id: '63c51e91-e448-4ea9-821b-a80415f266d3',
     avatarUrl: 'https://github.com/rohitpaulk.png',
     createdAt: new Date('2019-01-01T00:00:00.000Z'),
+    githubName: 'Paul Kuruvilla',
     githubUsername: 'rohitpaulk',
     username: 'rohitpaulk',
     name: 'Paul Kuruvilla',

--- a/tests/acceptance/team-page/view-team-test.js
+++ b/tests/acceptance/team-page/view-team-test.js
@@ -43,6 +43,7 @@ module('Acceptance | view-team-test', function (hooks) {
     const member1 = this.server.create('user', {
       avatarUrl: 'https://github.com/sarupbanskota.png',
       createdAt: new Date(),
+      githubName: 'Sarup Banskota',
       githubUsername: 'sarupbanskota',
       username: 'sarupbanskota',
     });

--- a/tests/acceptance/team-page/view-team-test.js
+++ b/tests/acceptance/team-page/view-team-test.js
@@ -113,7 +113,7 @@ module('Acceptance | view-team-test', function (hooks) {
     assert.strictEqual(teamPage.members.length, 4, 'expected 4 members to be present');
 
     window.confirm = () => true;
-    await teamPage.memberByUsername('rohitpaulk').clickLeaveTeamButton();
+    await teamPage.memberByGithubName('Paul Kuruvilla').clickLeaveTeamButton();
 
     assert.strictEqual(currentURL(), '/catalog', 'should redirect to catalog page');
   });

--- a/tests/acceptance/view-user-profile-test.js
+++ b/tests/acceptance/view-user-profile-test.js
@@ -1,12 +1,13 @@
 import percySnapshot from '@percy/ember';
 import testScenario from 'codecrafters-frontend/mirage/scenarios/test';
+import profilePage from 'codecrafters-frontend/tests/pages/settings/profile-page';
 import userPage from 'codecrafters-frontend/tests/pages/user-page';
 import { assertTooltipContent } from 'ember-tooltips/test-support';
 import { currentURL } from '@ember/test-helpers';
 import { module, test } from 'qunit';
 import { setupApplicationTest } from 'codecrafters-frontend/tests/helpers';
 import { setupWindowMock } from 'ember-window-mock/test-support';
-import { signIn, signInAsAdmin } from 'codecrafters-frontend/tests/support/authentication-helpers';
+import { signIn, signInAsAdmin, signInAsSubscriber } from 'codecrafters-frontend/tests/support/authentication-helpers';
 
 module('Acceptance | view-user-profile', function (hooks) {
   setupApplicationTest(hooks);
@@ -90,6 +91,30 @@ module('Acceptance | view-user-profile', function (hooks) {
     await percySnapshot('User profile');
 
     assert.strictEqual(1, 1);
+  });
+
+  test('it should show the GitHub name if it is set', async function (assert) {
+    testScenario(this.server);
+    signIn(this.owner, this.server);
+
+    const user = this.server.schema.users.findBy({ username: 'rohitpaulk' });
+
+    await userPage.visit({ username: user.username });
+    assert.ok(userPage.githubName.isVisible, 'GitHub name should be visible');
+    assert.strictEqual(userPage.githubName.text, 'Paul Kuruvilla');
+  });
+
+  test('it should not show the GitHub name when anonymous mode is enabled', async function (assert) {
+    testScenario(this.server);
+    signInAsSubscriber(this.owner, this.server);
+
+    const user = this.server.schema.users.findBy({ username: 'rohitpaulk' });
+
+    await profilePage.visit();
+    await profilePage.anonymousModeToggle.toggle();
+
+    await userPage.visit({ username: user.username });
+    assert.notOk(userPage.githubName.isVisible, 'GitHub name should not be visible');
   });
 
   // TODO: Add test for not found

--- a/tests/pages/team-page.js
+++ b/tests/pages/team-page.js
@@ -8,8 +8,13 @@ export default create({
   members: collection('[data-test-members-list-item-container]', {
     clickLeaveTeamButton: clickable('[data-test-leave-team-button]'),
     clickRemoveButton: clickable('[data-test-remove-button]'),
+    githubName: text('[data-test-github-name]'),
     username: text('[data-test-username]'),
   }),
+
+  memberByGithubName(githubName) {
+    return this.members.toArray().findBy('githubName', githubName);
+  },
 
   memberByUsername(username) {
     return this.members.toArray().findBy('username', username);

--- a/tests/pages/user-page.js
+++ b/tests/pages/user-page.js
@@ -20,6 +20,11 @@ export default createPage({
     link: attribute('href'),
   },
 
+  githubName: {
+    scope: '[data-test-github-name]',
+    text: text(),
+  },
+
   profileCustomizationNotice: { scope: '[data-test-profile-customization-notice]' },
 
   profileDescriptionMarkdown: {


### PR DESCRIPTION
**Checklist**:

- [x] I've thoroughly self-reviewed my changes
- [x] I've added tests for my changes, unless they affect admin-only areas (or are otherwise not worth testing)
- [x] I've verified any visual changes using Percy (add a commit with `[percy]` in the message to trigger)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced user interface to display GitHub names when available in team and user profile views.
	- Introduced new tests to verify GitHub name visibility based on user settings.

- **Bug Fixes**
	- Adjusted logic to ensure correct display of user names in various scenarios.

- **Tests**
	- Added tests for new GitHub name functionality in user profiles and team member views.

- **Chores**
	- Updated test data to include GitHub names for consistency in testing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->