### PR TITLE
Experiment: Stage 1 - Hide Test Runner Card Before User Has Submitted Again

### DIFF
--- a/app/components/course-page/course-stage-step/first-stage-tutorial-card.hbs
+++ b/app/components/course-page/course-stage-step/first-stage-tutorial-card.hbs
@@ -29,13 +29,13 @@
     </ExpandableStepList>
 
     {{#if @shouldHideTestRunnerCardBeforeUserHasSubmitted}}
-      {{#if (not-eq @testsStatus "passed")}}
+      {{#if @shouldShowLinkToForum}}
         <div class="prose dark:prose-invert prose-sm prose-compact mt-6">
           <p>Need help?</p>
           <ul>
             <li>
               <a
-                href="https://forum.codecrafters.io/new-topic?category=Challenges&tags=challenge%3Ashell&title=%5B{{this.courseShortName}}%5D%20How%20to%20pass%20the%20first%20stage%3F&body=Checklist%3A%0A%0A1.%20%E2%9C%85%20or%20%E2%9D%8C%3A%20I%27ve%20uncommented%20the%20code.%0A2.%20%E2%9C%85%20or%20%E2%9D%8C%3A%20I%27ve%20saved%20the%20changes.%0A3.%20%E2%9C%85%20or%20%E2%9D%8C%3A%20I%27ve%20run%20the%20git%20commands%3A%0A%0A%60%60%60%0Agit%20commit%20-am%20%22%5Bseeking%20help%20on%20forum%5D%22%0Agit%20push%20origin%20master%0A%60%60%60%0A%0A---%0A%0AHere%E2%80%99s%20a%20screenshot%20showing%20the%20output%20from%20running%20the%20Git%20commands%3A%0A%0A%5BAttach%20screenshot%20here%5D%0A%0A%5BShare%20other%20details%20here%5D"
+                href="https://forum.codecrafters.io/new-topic?category=Challenges&tags=challenge%3A{{this.courseSlug}}&title=%5B{{this.courseSlug}}%5D%20How%20to%20pass%20the%20first%20stage%3F&body=Checklist%3A%0A%0A1.%20%E2%9C%85%20or%20%E2%9D%8C%3A%20I%27ve%20uncommented%20the%20code.%0A2.%20%E2%9C%85%20or%20%E2%9D%8C%3A%20I%27ve%20saved%20the%20changes.%0A3.%20%E2%9C%85%20or%20%E2%9D%8C%3A%20I%27ve%20run%20the%20git%20commands%3A%0A%0A%60%60%60%0Agit%20commit%20-am%20%22%5Bseeking%20help%20on%20forum%5D%22%0Agit%20push%20origin%20master%0A%60%60%60%0A%0A---%0A%0AHere%E2%80%99s%20a%20screenshot%20showing%20the%20output%20from%20running%20the%20Git%20commands%3A%0A%0A%5BAttach%20screenshot%20here%5D%0A%0A%5BShare%20other%20details%20here%5D"
                 target="_blank"
                 rel="noopener noreferrer"
               >

--- a/app/components/course-page/course-stage-step/first-stage-tutorial-card.hbs
+++ b/app/components/course-page/course-stage-step/first-stage-tutorial-card.hbs
@@ -35,7 +35,7 @@
           <ul>
             <li>
               <a
-                href="https://forum.codecrafters.io/new-topic?category=Challenges&tags=challenge%3A{{this.courseSlug}}&title=%5B{{this.courseSlug}}%5D%20How%20to%20pass%20the%20first%20stage%3F&body=Checklist%3A%0A%0A1.%20%E2%9C%85%20or%20%E2%9D%8C%3A%20I%27ve%20uncommented%20the%20code.%0A2.%20%E2%9C%85%20or%20%E2%9D%8C%3A%20I%27ve%20saved%20the%20changes.%0A3.%20%E2%9C%85%20or%20%E2%9D%8C%3A%20I%27ve%20run%20the%20git%20commands%3A%0A%0A%60%60%60%0Agit%20commit%20-am%20%22%5Bseeking%20help%20on%20forum%5D%22%0Agit%20push%20origin%20master%0A%60%60%60%0A%0A---%0A%0AHere%E2%80%99s%20a%20screenshot%20showing%20the%20output%20from%20running%20the%20Git%20commands%3A%0A%0A%5BAttach%20screenshot%20here%5D%0A%0A%5BShare%20other%20details%20here%5D"
+                href="https://forum.codecrafters.io/new-topic?category=Challenges&tags=challenge%3A{{this.currentCourse.slug}}&title=%5B{{this.currentCourse.shortName}}%5D%20How%20to%20pass%20the%20first%20stage%3F&body=Checklist%3A%0A%0A1.%20%E2%9C%85%20or%20%E2%9D%8C%3A%20I%27ve%20uncommented%20the%20code.%0A2.%20%E2%9C%85%20or%20%E2%9D%8C%3A%20I%27ve%20saved%20the%20changes.%0A3.%20%E2%9C%85%20or%20%E2%9D%8C%3A%20I%27ve%20run%20the%20git%20commands%3A%0A%0A%60%60%60%0Agit%20commit%20-am%20%22%5Bseeking%20help%20on%20forum%5D%22%0Agit%20push%20origin%20master%0A%60%60%60%0A%0A---%0A%0AHere%E2%80%99s%20a%20screenshot%20showing%20the%20output%20from%20running%20the%20Git%20commands%3A%0A%0A%5BAttach%20screenshot%20here%5D%0A%0A%5BShare%20other%20details%20here%5D"
                 target="_blank"
                 rel="noopener noreferrer"
               >

--- a/app/components/course-page/course-stage-step/first-stage-tutorial-card.hbs
+++ b/app/components/course-page/course-stage-step/first-stage-tutorial-card.hbs
@@ -23,13 +23,13 @@
       {{else if (eq stepList.expandedStep.id "submit-code")}}
         <CoursePage::CourseStageStep::FirstStageTutorialCard::SubmitCodeStep
           @isComplete={{this.submitCodeStepIsComplete}}
-          @shouldHideTestRunnerCardBeforeUserHasSubmitted={{@shouldHideTestRunnerCardBeforeUserHasSubmitted}}
+          @shouldHideTestRunnerCardRelatedCopy={{@shouldHideTestRunnerCardRelatedCopy}}
         />
       {{/if}}
     </ExpandableStepList>
 
-    {{#if @shouldHideTestRunnerCardBeforeUserHasSubmitted}}
-      {{#if @shouldShowLinkToForum}}
+    {{#if @shouldHideTestRunnerCardRelatedCopy}}
+      {{#if this.shouldShowLinkToForum}}
         <div class="prose dark:prose-invert prose-sm prose-compact mt-6">
           <p>Need help?</p>
           <ul>
@@ -40,7 +40,7 @@
                 rel="noopener noreferrer"
               >
                 Post your issue</a>
-              on the forum—Andy is quick to reply, typically within 6 hours.
+              on the forum — Andy usually replies within 6 hours.
             </li>
           </ul>
         </div>

--- a/app/components/course-page/course-stage-step/first-stage-tutorial-card.hbs
+++ b/app/components/course-page/course-stage-step/first-stage-tutorial-card.hbs
@@ -21,22 +21,45 @@
           @isComplete={{this.uncommentCodeStepIsComplete}}
         />
       {{else if (eq stepList.expandedStep.id "submit-code")}}
-        <CoursePage::CourseStageStep::FirstStageTutorialCard::SubmitCodeStep @isComplete={{this.submitCodeStepIsComplete}} />
+        <CoursePage::CourseStageStep::FirstStageTutorialCard::SubmitCodeStep
+          @isComplete={{this.submitCodeStepIsComplete}}
+          @shouldHideTestRunnerCardBeforeUserHasSubmitted={{@shouldHideTestRunnerCardBeforeUserHasSubmitted}}
+        />
       {{/if}}
     </ExpandableStepList>
 
-    {{! After step 2, step 3 already contains a note on Tests Failed, so we can hide this !}}
-    {{#unless this.uncommentCodeStepIsComplete}}
-      <div class="prose dark:prose-invert prose-sm prose-compact mt-5">
-        <p>
-          {{svg-jar "information-circle" class="w-5 h-5 mb-1 inline-flex text-sky-500"}}
-          <b>Note:</b>
-          After your first Git push, you should see
-          <code class="font-semibold text-red-700 dark:text-red-300 bg-red-100 dark:bg-red-900/30 border border-red-200 dark:border-red-800/40">Tests
-            failed</code>
-          in the bar below this card. This is expected! Complete the steps above to pass the tests.
-        </p>
-      </div>
-    {{/unless}}
+    {{#if @shouldHideTestRunnerCardBeforeUserHasSubmitted}}
+      {{#if (not-eq @testsStatus "passed")}}
+        <div class="prose dark:prose-invert prose-sm prose-compact mt-6">
+          <p>Need help?</p>
+          <ul>
+            <li>
+              <a
+                href="https://forum.codecrafters.io/new-topic?category=Challenges&tags=challenge%3Ashell&title=%5B{{this.courseShortName}}%5D%20How%20to%20pass%20the%20first%20stage%3F&body=Checklist%3A%0A%0A1.%20%E2%9C%85%20or%20%E2%9D%8C%3A%20I%27ve%20uncommented%20the%20code.%0A2.%20%E2%9C%85%20or%20%E2%9D%8C%3A%20I%27ve%20saved%20the%20changes.%0A3.%20%E2%9C%85%20or%20%E2%9D%8C%3A%20I%27ve%20run%20the%20git%20commands%3A%0A%0A%60%60%60%0Agit%20commit%20-am%20%22%5Bseeking%20help%20on%20forum%5D%22%0Agit%20push%20origin%20master%0A%60%60%60%0A%0A---%0A%0AHere%E2%80%99s%20a%20screenshot%20showing%20the%20output%20from%20running%20the%20Git%20commands%3A%0A%0A%5BAttach%20screenshot%20here%5D%0A%0A%5BShare%20other%20details%20here%5D"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                Post your issue</a>
+              on the forum—Andy is quick to reply, typically within 6 hours.
+            </li>
+          </ul>
+        </div>
+      {{/if}}
+    {{else}}
+      {{! After step 2, step 3 already contains a note on Tests Failed, so we can hide this !}}
+      {{#unless this.uncommentCodeStepIsComplete}}
+        <div class="prose dark:prose-invert prose-sm prose-compact mt-5">
+          <p>
+            {{svg-jar "information-circle" class="w-5 h-5 mb-1 inline-flex text-sky-500"}}
+            <b>Note:</b>
+            After your first Git push, you should see
+            <code
+              class="font-semibold text-red-700 dark:text-red-300 bg-red-100 dark:bg-red-900/30 border border-red-200 dark:border-red-800/40"
+            >Tests failed</code>
+            in the bar below this card. This is expected! Complete the steps above to pass the tests.
+          </p>
+        </div>
+      {{/unless}}
+    {{/if}}
   </:content>
 </CoursePage::InstructionsCard>

--- a/app/components/course-page/course-stage-step/first-stage-tutorial-card.ts
+++ b/app/components/course-page/course-stage-step/first-stage-tutorial-card.ts
@@ -4,6 +4,7 @@ import CoursePageStateService from 'codecrafters-frontend/services/course-page-s
 import FeatureFlagsService from 'codecrafters-frontend/services/feature-flags';
 import Store from '@ember-data/store';
 import type CourseStageModel from 'codecrafters-frontend/models/course-stage';
+import type CourseStageStep from 'codecrafters-frontend/utils/course-page-step-list/course-stage-step';
 import type RepositoryModel from 'codecrafters-frontend/models/repository';
 import type { Step } from 'codecrafters-frontend/components/expandable-step-list';
 import { action } from '@ember/object';
@@ -14,8 +15,8 @@ interface Signature {
   Args: {
     repository: RepositoryModel;
     courseStage: CourseStageModel;
-    shouldHideTestRunnerCardBeforeUserHasSubmitted: boolean;
-    shouldShowLinkToForum: boolean;
+    currentStep: CourseStageStep;
+    shouldHideTestRunnerCardRelatedCopy: boolean;
   };
 }
 
@@ -82,6 +83,12 @@ export default class FirstStageTutorialCardComponent extends Component<Signature
 
   get navigateToFileStepWasMarkedAsComplete() {
     return this.coursePageState.manuallyCompletedStepIdsInFirstStageInstructions.includes('navigate-to-file');
+  }
+
+  get shouldShowLinkToForum() {
+    const currentStep = this.args.currentStep;
+
+    return currentStep.testsStatus !== 'passed' && currentStep.status !== 'complete';
   }
 
   get steps() {

--- a/app/components/course-page/course-stage-step/first-stage-tutorial-card.ts
+++ b/app/components/course-page/course-stage-step/first-stage-tutorial-card.ts
@@ -15,7 +15,7 @@ interface Signature {
     repository: RepositoryModel;
     courseStage: CourseStageModel;
     shouldHideTestRunnerCardBeforeUserHasSubmitted: boolean;
-    testsStatus: string;
+    shouldShowLinkToForum: boolean;
   };
 }
 
@@ -72,8 +72,8 @@ export default class FirstStageTutorialCardComponent extends Component<Signature
   @service declare featureFlags: FeatureFlagsService;
   @service declare store: Store;
 
-  get courseShortName() {
-    return this.args.courseStage.course.shortName;
+  get courseSlug() {
+    return this.args.courseStage.course.slug;
   }
 
   get navigateToFileStepIsComplete() {

--- a/app/components/course-page/course-stage-step/first-stage-tutorial-card.ts
+++ b/app/components/course-page/course-stage-step/first-stage-tutorial-card.ts
@@ -14,6 +14,8 @@ interface Signature {
   Args: {
     repository: RepositoryModel;
     courseStage: CourseStageModel;
+    shouldHideTestRunnerCardBeforeUserHasSubmitted: boolean;
+    testsStatus: string;
   };
 }
 
@@ -69,6 +71,10 @@ export default class FirstStageTutorialCardComponent extends Component<Signature
   @service declare coursePageState: CoursePageStateService;
   @service declare featureFlags: FeatureFlagsService;
   @service declare store: Store;
+
+  get courseShortName() {
+    return this.args.courseStage.course.shortName;
+  }
 
   get navigateToFileStepIsComplete() {
     return this.navigateToFileStepWasMarkedAsComplete || this.uncommentCodeStepIsComplete;

--- a/app/components/course-page/course-stage-step/first-stage-tutorial-card.ts
+++ b/app/components/course-page/course-stage-step/first-stage-tutorial-card.ts
@@ -72,8 +72,8 @@ export default class FirstStageTutorialCardComponent extends Component<Signature
   @service declare featureFlags: FeatureFlagsService;
   @service declare store: Store;
 
-  get courseSlug() {
-    return this.args.courseStage.course.slug;
+  get currentCourse() {
+    return this.args.courseStage.course;
   }
 
   get navigateToFileStepIsComplete() {

--- a/app/components/course-page/course-stage-step/first-stage-tutorial-card/submit-code-step.hbs
+++ b/app/components/course-page/course-stage-step/first-stage-tutorial-card/submit-code-step.hbs
@@ -8,7 +8,7 @@
 
 <div class="prose dark:prose-invert">
   <p class={{if @isComplete "line-through"}}>
-    Once you run the commands above, our system will automatically run tests on your code.
+    Once you run the commands above, our system will automatically test your code.
   </p>
 
   {{#if @isComplete}}
@@ -20,7 +20,7 @@
 </div>
 
 {{#unless @isComplete}}
-  {{#unless @shouldHideTestRunnerCardBeforeUserHasSubmitted}}
+  {{#unless @shouldHideTestRunnerCardRelatedCopy}}
     <p class="prose dark:prose-invert prose-sm mt-3">
       <b>Note:</b>
       If you're still seeing "Tests failed" after completing the steps above,

--- a/app/components/course-page/course-stage-step/first-stage-tutorial-card/submit-code-step.hbs
+++ b/app/components/course-page/course-stage-step/first-stage-tutorial-card/submit-code-step.hbs
@@ -8,10 +8,7 @@
 
 <div class="prose dark:prose-invert">
   <p class={{if @isComplete "line-through"}}>
-    Once you run the commands above, the
-    <code class="font-semibold text-red-700 bg-red-100 border border-red-200">Tests failed</code>
-    message below this card will change to
-    <code class="font-semibold text-green-700 bg-green-100 border border-green-200">Tests passed</code>.
+    Once you run the commands above, our system will automatically run tests on your code.
   </p>
 
   {{#if @isComplete}}
@@ -23,10 +20,12 @@
 </div>
 
 {{#unless @isComplete}}
-  <p class="prose dark:prose-invert prose-sm mt-3">
-    <b>Note:</b>
-    If you're still seeing "Tests failed" after completing the steps above,
-    <a href="#" {{on "click" this.handleViewLogsButtonClick}}>view logs</a>
-    to troubleshoot.
-  </p>
+  {{#unless @shouldHideTestRunnerCardBeforeUserHasSubmitted}}
+    <p class="prose dark:prose-invert prose-sm mt-3">
+      <b>Note:</b>
+      If you're still seeing "Tests failed" after completing the steps above,
+      <a href="#" {{on "click" this.handleViewLogsButtonClick}}>view logs</a>
+      to troubleshoot.
+    </p>
+  {{/unless}}
 {{/unless}}

--- a/app/components/course-page/course-stage-step/first-stage-tutorial-card/submit-code-step.ts
+++ b/app/components/course-page/course-stage-step/first-stage-tutorial-card/submit-code-step.ts
@@ -8,6 +8,7 @@ interface Signature {
 
   Args: {
     isComplete: boolean;
+    shouldHideTestRunnerCardBeforeUserHasSubmitted: boolean;
   };
 }
 

--- a/app/components/course-page/course-stage-step/first-stage-tutorial-card/submit-code-step.ts
+++ b/app/components/course-page/course-stage-step/first-stage-tutorial-card/submit-code-step.ts
@@ -8,7 +8,7 @@ interface Signature {
 
   Args: {
     isComplete: boolean;
-    shouldHideTestRunnerCardBeforeUserHasSubmitted: boolean;
+    shouldHideTestRunnerCardRelatedCopy: boolean;
   };
 }
 

--- a/app/controllers/course/stage/instructions.ts
+++ b/app/controllers/course/stage/instructions.ts
@@ -48,21 +48,12 @@ export default class CourseStageInstructionsController extends Controller {
     return this.model.courseStage.prerequisiteInstructionsMarkdownFor(this.model.activeRepository);
   }
 
-  get shouldHideTestRunnerCardBeforeUserHasSubmitted() {
-    return this.featureFlags.hideTestRunnerCardBeforeUserHasSubmitted;
+  get shouldHideTestRunnerCardBeforeStage1Submission() {
+    return this.featureFlags.cannotSeeTestRunnerCardBeforeStage1Submission;
   }
 
   get shouldShowFeedbackPrompt() {
     return !this.currentStep.courseStage.isFirst && this.currentStep.status === 'complete';
-  }
-
-  get shouldShowLinkToForum() {
-    return (
-      this.isCurrentStage &&
-      this.currentStep.status !== 'complete' &&
-      this.currentStep.testsStatus !== 'passed' &&
-      this.shouldHideTestRunnerCardBeforeUserHasSubmitted
-    );
   }
 
   get shouldShowPrerequisites() {
@@ -70,10 +61,21 @@ export default class CourseStageInstructionsController extends Controller {
   }
 
   get shouldShowTestRunnerCard() {
-    const shouldHideTestRunnerCard =
-      this.model.courseStage.isFirst && this.model.activeRepository.submissions.length <= 1 && this.shouldHideTestRunnerCardBeforeUserHasSubmitted;
+    if (!this.isCurrentStage) {
+      return false;
+    }
 
-    return this.isCurrentStage && this.currentStep.status !== 'complete' && !shouldHideTestRunnerCard;
+    if (this.currentStep.status === 'complete') {
+      return false;
+    }
+
+    if (this.model.courseStage.isFirst) {
+      // For stage 1, we hide the test runner card until the user's submission.
+      return !(this.model.activeRepository.submissionsCount <= 1 && this.shouldHideTestRunnerCardBeforeStage1Submission);
+    } else {
+      // For other stages, we always show the test runner card
+      return true;
+    }
   }
 
   get shouldShowUpgradePrompt() {

--- a/app/controllers/course/stage/instructions.ts
+++ b/app/controllers/course/stage/instructions.ts
@@ -4,6 +4,7 @@ import { tracked } from '@glimmer/tracking';
 import type AuthenticatorService from 'codecrafters-frontend/services/authenticator';
 import type CoursePageStateService from 'codecrafters-frontend/services/course-page-state';
 import type CourseStageModel from 'codecrafters-frontend/models/course-stage';
+import type FeatureFlagsService from 'codecrafters-frontend/services/feature-flags';
 import type RepositoryModel from 'codecrafters-frontend/models/repository';
 import type CourseStageStep from 'codecrafters-frontend/utils/course-page-step-list/course-stage-step';
 import { action } from '@ember/object';
@@ -11,10 +12,10 @@ import type RouterService from '@ember/routing/router-service';
 import { next } from '@ember/runloop';
 import { task } from 'ember-concurrency';
 import type Store from '@ember-data/store';
-
 export default class CourseStageInstructionsController extends Controller {
   @service declare authenticator: AuthenticatorService;
   @service declare coursePageState: CoursePageStateService;
+  @service declare featureFlags: FeatureFlagsService;
   @service declare router: RouterService;
   @service declare store: Store;
 
@@ -47,6 +48,10 @@ export default class CourseStageInstructionsController extends Controller {
     return this.model.courseStage.prerequisiteInstructionsMarkdownFor(this.model.activeRepository);
   }
 
+  get shouldHideTestRunnerCardBeforeUserHasSubmitted() {
+    return this.featureFlags.hideTestRunnerCardBeforeUserHasSubmitted;
+  }
+
   get shouldShowFeedbackPrompt() {
     return !this.currentStep.courseStage.isFirst && this.currentStep.status === 'complete';
   }
@@ -56,7 +61,10 @@ export default class CourseStageInstructionsController extends Controller {
   }
 
   get shouldShowTestRunnerCard() {
-    return this.isCurrentStage && this.currentStep.status !== 'complete';
+    const shouldHideTestRunnerCard =
+      this.model.courseStage.isFirst && this.model.activeRepository.submissions.length <= 1 && this.shouldHideTestRunnerCardBeforeUserHasSubmitted;
+
+    return this.isCurrentStage && this.currentStep.status !== 'complete' && !shouldHideTestRunnerCard;
   }
 
   get shouldShowUpgradePrompt() {

--- a/app/controllers/course/stage/instructions.ts
+++ b/app/controllers/course/stage/instructions.ts
@@ -56,6 +56,15 @@ export default class CourseStageInstructionsController extends Controller {
     return !this.currentStep.courseStage.isFirst && this.currentStep.status === 'complete';
   }
 
+  get shouldShowLinkToForum() {
+    return (
+      this.isCurrentStage &&
+      this.currentStep.status !== 'complete' &&
+      this.currentStep.testsStatus !== 'passed' &&
+      this.shouldHideTestRunnerCardBeforeUserHasSubmitted
+    );
+  }
+
   get shouldShowPrerequisites() {
     return !!this.prerequisiteInstructionsMarkdown;
   }

--- a/app/services/feature-flags.js
+++ b/app/services/feature-flags.js
@@ -18,12 +18,12 @@ export default class FeatureFlagsService extends Service {
     return this.currentUser?.isStaff || this.getFeatureFlagValue('can-see-short-instructions-for-stage-2') === 'test';
   }
 
-  get canSeeTweaksForStage1() {
-    return this.currentUser?.isStaff || this.getFeatureFlagValue('can-see-tweaks-for-stage-1') === 'test';
-  }
-
   get currentUser() {
     return this.authenticator.currentUser;
+  }
+
+  get hideTestRunnerCardBeforeUserHasSubmitted() {
+    return this.currentUser?.isStaff || this.getFeatureFlagValue('hide-test-runner-card-before-user-has-submitted') === 'test';
   }
 
   getFeatureFlagValue(flagName) {

--- a/app/services/feature-flags.js
+++ b/app/services/feature-flags.js
@@ -18,12 +18,12 @@ export default class FeatureFlagsService extends Service {
     return this.currentUser?.isStaff || this.getFeatureFlagValue('can-see-short-instructions-for-stage-2') === 'test';
   }
 
-  get currentUser() {
-    return this.authenticator.currentUser;
+  get cannotSeeTestRunnerCardBeforeStage1Submission() {
+    return this.currentUser?.isStaff || this.getFeatureFlagValue('cannot-see-test-runner-card-before-stage1-submission') === 'test';
   }
 
-  get hideTestRunnerCardBeforeUserHasSubmitted() {
-    return this.currentUser?.isStaff || this.getFeatureFlagValue('hide-test-runner-card-before-user-has-submitted') === 'test';
+  get currentUser() {
+    return this.authenticator.currentUser;
   }
 
   getFeatureFlagValue(flagName) {

--- a/app/templates/course/stage/instructions.hbs
+++ b/app/templates/course/stage/instructions.hbs
@@ -37,7 +37,7 @@
         @repository={{@model.activeRepository}}
         @courseStage={{@model.courseStage}}
         @shouldHideTestRunnerCardBeforeUserHasSubmitted={{this.shouldHideTestRunnerCardBeforeUserHasSubmitted}}
-        @testsStatus={{this.currentStep.testsStatus}}
+        @shouldShowLinkToForum={{this.shouldShowLinkToForum}}
         class="mb-6"
       />
     {{/if}}

--- a/app/templates/course/stage/instructions.hbs
+++ b/app/templates/course/stage/instructions.hbs
@@ -33,7 +33,13 @@
     {{/if}}
 
     {{#if @model.courseStage.isFirst}}
-      <CoursePage::CourseStageStep::FirstStageTutorialCard @repository={{@model.activeRepository}} @courseStage={{@model.courseStage}} class="mb-6" />
+      <CoursePage::CourseStageStep::FirstStageTutorialCard
+        @repository={{@model.activeRepository}}
+        @courseStage={{@model.courseStage}}
+        @shouldHideTestRunnerCardBeforeUserHasSubmitted={{this.shouldHideTestRunnerCardBeforeUserHasSubmitted}}
+        @testsStatus={{this.currentStep.testsStatus}}
+        class="mb-6"
+      />
     {{/if}}
 
     {{#if @model.courseStage.isSecond}}

--- a/app/templates/course/stage/instructions.hbs
+++ b/app/templates/course/stage/instructions.hbs
@@ -36,8 +36,8 @@
       <CoursePage::CourseStageStep::FirstStageTutorialCard
         @repository={{@model.activeRepository}}
         @courseStage={{@model.courseStage}}
-        @shouldHideTestRunnerCardBeforeUserHasSubmitted={{this.shouldHideTestRunnerCardBeforeUserHasSubmitted}}
-        @shouldShowLinkToForum={{this.shouldShowLinkToForum}}
+        @currentStep={{this.currentStep}}
+        @shouldHideTestRunnerCardRelatedCopy={{this.shouldHideTestRunnerCardBeforeStage1Submission}}
         class="mb-6"
       />
     {{/if}}


### PR DESCRIPTION
1. Hide the test runner card before user has made another submission
2. Replace copy referencing the test runner card with "Need Help" and "Post on forum" link
3. Temporarily stop asking users to debug with logs, so hopefully they surface all issues on the forum.
  
<img width="2047" alt="image" src="https://github.com/user-attachments/assets/e197a915-8cef-4032-a594-6ecabe1afab0" />

<img width="2047" alt="image" src="https://github.com/user-attachments/assets/8e56dc69-c14b-4633-9163-6a1c481ac742" />



**Checklist**:

- [x] I've thoroughly self-reviewed my changes
- [ ] I've added tests for my changes, unless they affect admin-only areas (or are otherwise not worth testing)
- [x] I've verified any visual changes using Percy (add a commit with `[percy]` in the message to trigger)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
	- Enhanced tutorial card with conditional visibility for the test runner based on user submission.
	- Added links to forums for user assistance.

- **Bug Fixes**
	- Improved logic for displaying troubleshooting notes related to test outcomes.

- **Documentation**
	- Updated component attributes to reflect new functionalities.

- **Chores**
	- Removed outdated feature flag checks and introduced new conditions for UI element visibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->