### PR TITLE
Update `@codemirror/view` from `6.26.3` to `6.36.1`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -34,6 +34,7 @@
         "@codecov/webpack-plugin": "^1.6.0",
         "@codemirror/language-data": "^6.5.0",
         "@codemirror/merge": "^6.7.4",
+        "@codemirror/view": "^6.36.1",
         "@ember/optional-features": "^2.2.0",
         "@ember/render-modifiers": "^2.0.4",
         "@ember/string": "^3.1.1",
@@ -2668,18 +2669,21 @@
       }
     },
     "node_modules/@codemirror/state": {
-      "version": "6.4.1",
-      "resolved": "https://registry.npmjs.org/@codemirror/state/-/state-6.4.1.tgz",
-      "integrity": "sha512-QkEyUiLhsJoZkbumGZlswmAhA7CBU02Wrz7zvH4SrcifbsqwlXShVXg65f3v/ts57W3dqyamEriMhij1Z3Zz4A==",
-      "dev": true
-    },
-    "node_modules/@codemirror/view": {
-      "version": "6.26.3",
-      "resolved": "https://registry.npmjs.org/@codemirror/view/-/view-6.26.3.tgz",
-      "integrity": "sha512-gmqxkPALZjkgSxIeeweY/wGQXBfwTUaLs8h7OKtSwfbj9Ct3L11lD+u1sS7XHppxFQoMDiMDp07P9f3I2jWOHw==",
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/@codemirror/state/-/state-6.5.0.tgz",
+      "integrity": "sha512-MwBHVK60IiIHDcoMet78lxt6iw5gJOGSbNbOIVBHWVXIH4/Nq1+GQgLLGgI1KlnN86WDXsPudVaqYHKBIx7Eyw==",
       "dev": true,
       "dependencies": {
-        "@codemirror/state": "^6.4.0",
+        "@marijn/find-cluster-break": "^1.0.0"
+      }
+    },
+    "node_modules/@codemirror/view": {
+      "version": "6.36.1",
+      "resolved": "https://registry.npmjs.org/@codemirror/view/-/view-6.36.1.tgz",
+      "integrity": "sha512-miD1nyT4m4uopZaDdO2uXU/LLHliKNYL9kB1C1wJHrunHLm/rpkb5QVSokqgw9hFqEZakrdlb/VGWX8aYZTslQ==",
+      "dev": true,
+      "dependencies": {
+        "@codemirror/state": "^6.5.0",
         "style-mod": "^4.1.0",
         "w3c-keyname": "^2.2.4"
       }
@@ -7313,6 +7317,12 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/@marijn/find-cluster-break": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@marijn/find-cluster-break/-/find-cluster-break-1.0.2.tgz",
+      "integrity": "sha512-l0h88YhZFyKdXIFNfSWpyjStDjGHwZ/U7iobcK1cQQD8sejsONdQtTVU+1wVN1PBw40PiiHB1vA5S7VTfQiP9g==",
+      "dev": true
     },
     "node_modules/@miragejs/pretender-node-polyfill": {
       "version": "0.1.2",

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "@codecov/webpack-plugin": "^1.6.0",
     "@codemirror/language-data": "^6.5.0",
     "@codemirror/merge": "^6.7.4",
+    "@codemirror/view": "^6.36.1",
     "@ember/optional-features": "^2.2.0",
     "@ember/render-modifiers": "^2.0.4",
     "@ember/string": "^3.1.1",


### PR DESCRIPTION
### Brief

This updates `@codemirror/view` from `6.26.3` (inherited from `codemirror`) to `6.36.1` (explicitly)

### Details

There are no major or braking changes, but some new types and options were added, potentially helpful for styling and line comments. Changelog here: https://github.com/codemirror/view/blob/main/CHANGELOG.md

### Checklist

- [x] I've thoroughly self-reviewed my changes
- [x] I've added tests for my changes, unless they affect admin-only areas (or are otherwise not worth testing)
- [x] I've verified any visual changes using Percy (add a commit with `[percy]` in the message to trigger)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Added a new development dependency: `@codemirror/view` version `^6.36.1`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->