### PR TITLE
CC-1539: Fix start-track button

### DIFF
--- a/app/components/track-page/start-track-button.hbs
+++ b/app/components/track-page/start-track-button.hbs
@@ -1,4 +1,4 @@
-<PrimaryButton class="mr-2 flex items-center" data-test-start-track-button {{on "click" this.handleClicked}} @size="large" ...attributes>
+<PrimaryButton class="mr-2 flex items-center" data-test-primary-start-track-button {{on "click" this.handleClicked}} @size="large" ...attributes>
   {{#if this.currentUserIsAnonymous}}
     {{svg-jar "github" class="fill-current w-5 transform transition-all mr-2"}}
   {{/if}}

--- a/app/components/track-page/start-track-button.ts
+++ b/app/components/track-page/start-track-button.ts
@@ -30,7 +30,7 @@ export default class CourseOverviewStartTrackButtonComponent extends Component<S
     if (this.currentUserIsAnonymous) {
       this.authenticator.initiateLogin(null);
     } else {
-      this.router.transitionTo('course', this.args.courses[0]!.slug, { queryParams: { track: this.args.language.slug } });
+      this.router.transitionTo('course', this.args.courses[0]!.slug, { queryParams: { repo: null, track: this.args.language.slug } });
     }
   }
 }

--- a/tests/acceptance/track-page/start-track-test.js
+++ b/tests/acceptance/track-page/start-track-test.js
@@ -1,0 +1,63 @@
+import testScenario from 'codecrafters-frontend/mirage/scenarios/test';
+import trackPage from 'codecrafters-frontend/tests/pages/track-page';
+import { module, test } from 'qunit';
+import { setupApplicationTest } from 'codecrafters-frontend/tests/helpers';
+import { signIn } from 'codecrafters-frontend/tests/support/authentication-helpers';
+import { currentURL, visit } from '@ember/test-helpers';
+
+module('Acceptance | track-page | start-track', function (hooks) {
+  setupApplicationTest(hooks);
+
+  test('it display the start-track-button for anonymous user', async function (assert) {
+    testScenario(this.server);
+
+    await visit('/tracks/go');
+    assert.ok(trackPage.hasStartTrackButton, 'start track button should be visible for anonymous users');
+  });
+
+  test('it display the start-track-button for logged-in user who has not started course in the track', async function (assert) {
+    testScenario(this.server);
+    signIn(this.owner, this.server);
+
+    await visit('/tracks/go');
+    assert.ok(trackPage.hasStartTrackButton, 'start track button should be visible for users without course progress');
+  });
+
+  test('it does not display the start-track-button for logged-in user who has started course in the track', async function (assert) {
+    testScenario(this.server);
+    signIn(this.owner, this.server);
+
+    let currentUser = this.server.schema.users.first();
+    let git = this.server.schema.courses.findBy({ slug: 'git' });
+    let go = this.server.schema.languages.findBy({ slug: 'go' });
+    this.server.create('repository', 'withFirstStageCompleted', {
+      course: git,
+      language: go,
+      user: currentUser,
+    });
+
+    await visit('/tracks/go');
+    assert.notOk(trackPage.hasStartTrackButton, 'start track button should not be visible for users with course progress');
+  });
+
+  test('it starts track for logged-in user who has started course in a different track', async function (assert) {
+    testScenario(this.server);
+    signIn(this.owner, this.server);
+
+    let currentUser = this.server.schema.users.first();
+    let grep = this.server.schema.courses.findBy({ slug: 'grep' });
+    let python = this.server.schema.languages.findBy({ slug: 'python' });
+    this.server.create('repository', 'withFirstStageCompleted', {
+      course: grep,
+      language: python,
+      user: currentUser,
+    });
+
+    await visit('/tracks/go');
+    assert.ok(trackPage.hasStartTrackButton, 'start track button is visible');
+
+    await trackPage.clickOnStartTrackButton();
+    assert.ok(currentURL().includes('track=go'), 'started course page should have `track` query param in URL');
+    assert.notOk(currentURL().includes('repo='), 'started course page should not have `repo` query param in URL');
+  });
+});

--- a/tests/pages/track-page.js
+++ b/tests/pages/track-page.js
@@ -13,7 +13,9 @@ export default createPage({
   },
 
   clickOnResumeTrackButton: clickable('[data-test-resume-track-button]'),
+  clickOnStartTrackButton: clickable('[data-test-primary-start-track-button]'),
   hasResumeTrackButton: isVisible('[data-test-resume-track-button]'),
+  hasStartTrackButton: isVisible('[data-test-primary-start-track-button]'),
 
   header: {
     descriptionText: text('[data-test-track-header-description]'),


### PR DESCRIPTION
Clear `repo` in `queryParams`, so that previously created repos won't interfere with the result of clicking Start Track button again.

**Checklist**:

- [x] I've thoroughly self-reviewed my changes
- [x] I've added tests for my changes, unless they affect admin-only areas (or are otherwise not worth testing)
- [ ] I've verified any visual changes using Percy (add a commit with `[percy]` in the message to trigger)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
	- Enhanced routing behavior for starting a track, now including additional query parameters for non-anonymous users.
	- Added acceptance tests to verify the visibility and behavior of the "start track" button under various user scenarios.
	- Introduced methods to interact with the "start track" button in the testing framework.

- **Bug Fixes**
	- Improved identifier for the "start track" button to ensure accurate testing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->