### PR TITLE
Use a dedicated gutter for Expand Unchanged Lines Bar gutter elements

### DIFF
--- a/app/utils/code-mirror-collapse-unchanged-gutter-widget-class.ts
+++ b/app/utils/code-mirror-collapse-unchanged-gutter-widget-class.ts
@@ -1,4 +1,4 @@
-import { EditorView, GutterMarker, gutterWidgetClass } from '@codemirror/view';
+import { EditorView, gutter, GutterMarker, gutterWidgetClass } from '@codemirror/view';
 
 export class CollapseUnchangedGutterMarker extends GutterMarker {
   elementClass = 'cm-collapseUnchangedBarNeighbor';
@@ -30,11 +30,17 @@ export class CollapseUnchangedGutterMarker extends GutterMarker {
 }
 
 export function collapseUnchangedGutterWidgetClass() {
-  return gutterWidgetClass.of(function (_view, widget, _block): GutterMarker | null {
-    if ('type' in widget && widget.type === 'collapsed-unchanged-code') {
-      return new CollapseUnchangedGutterMarker();
-    }
+  return [
+    gutter({
+      class: 'cm-collapseUnchangedBarGutter',
+      renderEmptyElements: true,
+    }),
+    gutterWidgetClass.of(function (_view, widget, _block): GutterMarker | null {
+      if ('type' in widget && widget.type === 'collapsed-unchanged-code') {
+        return new CollapseUnchangedGutterMarker();
+      }
 
-    return null;
-  });
+      return null;
+    }),
+  ];
 }

--- a/app/utils/code-mirror-themes.ts
+++ b/app/utils/code-mirror-themes.ts
@@ -63,7 +63,12 @@ const BASE_STYLE = {
           color: 'rgb(102 153 0)',
         },
       },
+    },
+  },
 
+  // Collapse unchanged lines gutter
+  '.cm-collapseUnchangedBarGutter': {
+    '& .cm-gutterElement': {
       '&.cm-collapseUnchangedBarNeighbor': {
         '& .cm-collapseUnchangedBarGutterElement': {
           content: '""',
@@ -192,8 +197,8 @@ export const codeCraftersDark = [
         backgroundColor: tailwindColors.gray['900'],
       },
 
-      // Changes gutter for diff +/- indicators
-      '.cm-changeGutter': {
+      // Collapse unchanged lines gutter
+      '.cm-collapseUnchangedBarGutter': {
         '& .cm-gutterElement': {
           '&.cm-collapseUnchangedBarNeighbor': {
             '& .cm-collapseUnchangedBarGutterElement': {


### PR DESCRIPTION
Related to #1231 

### Brief

This switches to using a separate dedicated gutter `.cm-collapseUnchangedBarGutter`, to visualize corresponding Collapsed Unchanged Bar siblings, making the implementation compatible with the right-side gutter, in preparation for adding the Line Comments extension.

### Details

We're currently styling `.cm-changedLines` gutter elements to visualize corresponding Collapsed Unchanged Bar siblings — the elements that cover the whole gutter width and show Expand icons. This only works if the `.cm-changedLines` gutter is present, which is not the case in the right-side gutter, which I'm currently creating for the line comments extension.

### Screenshots

<img width="431" alt="Знімок екрана 2025-01-11 о 18 13 36" src="https://github.com/user-attachments/assets/960a49b8-c19d-4e5f-ba8f-eea6e2925f09" />

<img width="634" alt="Знімок екрана 2025-01-11 о 16 08 11" src="https://github.com/user-attachments/assets/342ce869-e26d-49ce-913e-c6467cfd1046" />

<img width="628" alt="Знімок екрана 2025-01-11 о 16 08 31" src="https://github.com/user-attachments/assets/73fa8633-7fa6-43e6-9ec4-0ad09b6c3daf" />

### Checklist

- [x] I've thoroughly self-reviewed my changes
- [x] I've added tests for my changes, unless they affect admin-only areas (or are otherwise not worth testing)
- [x] I've verified any visual changes using Percy (add a commit with `[percy]` in the message to trigger)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced CodeMirror editor with a new mechanism to collapse unchanged lines.
	- Added interactive gutter elements for improved code viewing experience.

- **Style**
	- Updated CodeMirror theme styles to support line collapsing functionality.
	- Introduced new visual styles for the collapse bar interactions, enhancing user engagement.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->