### PR TITLE
An even better Collapse Unchanged Gutter

### DIFF
--- a/app/components/code-mirror.ts
+++ b/app/components/code-mirror.ts
@@ -136,7 +136,7 @@ const OPTION_HANDLERS: { [key: string]: OptionHandler } = {
             highlightChanges: !!highlightChanges,
             syntaxHighlightDeletions: !!syntaxHighlighting && !!syntaxHighlightDeletions,
           }),
-          collapseUnchangedGutter(),
+          collapseUnchanged ? collapseUnchangedGutter() : [],
         ]
       : [];
   },

--- a/app/components/code-mirror.ts
+++ b/app/components/code-mirror.ts
@@ -37,7 +37,7 @@ import {
 import { languages } from '@codemirror/language-data';
 import { markdown } from '@codemirror/lang-markdown';
 import { highlightNewlines } from 'codecrafters-frontend/utils/code-mirror-highlight-newlines';
-import { collapseUnchangedGutterWidgetClass } from 'codecrafters-frontend/utils/code-mirror-collapse-unchanged-gutter-widget-class';
+import { collapseUnchangedGutter } from 'codecrafters-frontend/utils/code-mirror-collapse-unchanged-gutter';
 
 function generateHTMLElement(src: string): HTMLElement {
   const div = document.createElement('div');
@@ -136,7 +136,7 @@ const OPTION_HANDLERS: { [key: string]: OptionHandler } = {
             highlightChanges: !!highlightChanges,
             syntaxHighlightDeletions: !!syntaxHighlighting && !!syntaxHighlightDeletions,
           }),
-          collapseUnchangedGutterWidgetClass(),
+          collapseUnchangedGutter(),
         ]
       : [];
   },

--- a/app/utils/code-mirror-collapse-unchanged-gutter-widget-class.ts
+++ b/app/utils/code-mirror-collapse-unchanged-gutter-widget-class.ts
@@ -9,7 +9,7 @@ export class CollapseUnchangedGutterMarker extends GutterMarker {
     el.addEventListener('click', (_e) => {
       const editor = el.closest('.cm-editor');
       const gutter = el.closest('.cm-gutter');
-      const gutterElement = el.closest('.cm-collapseUnchangedBarNeighbor');
+      const gutterElement = el.closest('.cm-gutterElement');
       const gutterElementSiblings = gutter?.querySelectorAll('.cm-collapseUnchangedBarNeighbor');
 
       if (!editor || !gutter || !gutterElement || !gutterElementSiblings) {

--- a/app/utils/code-mirror-collapse-unchanged-gutter-widget-class.ts
+++ b/app/utils/code-mirror-collapse-unchanged-gutter-widget-class.ts
@@ -1,7 +1,7 @@
-import { EditorView, gutter, GutterMarker, gutterWidgetClass } from '@codemirror/view';
+import { EditorView, gutter, GutterMarker } from '@codemirror/view';
 
 export class CollapseUnchangedGutterMarker extends GutterMarker {
-  elementClass = 'cm-collapseUnchangedBarNeighbor';
+  elementClass = 'cm-collapseUnchangedBarSibling';
 
   toDOM(_view: EditorView): Node {
     const el = document.createElement('div');
@@ -10,7 +10,7 @@ export class CollapseUnchangedGutterMarker extends GutterMarker {
       const editor = el.closest('.cm-editor');
       const gutter = el.closest('.cm-gutter');
       const gutterElement = el.closest('.cm-gutterElement');
-      const gutterElementSiblings = gutter?.querySelectorAll('.cm-collapseUnchangedBarNeighbor');
+      const gutterElementSiblings = gutter?.querySelectorAll('.cm-collapseUnchangedBarSibling');
 
       if (!editor || !gutter || !gutterElement || !gutterElementSiblings) {
         return;

--- a/app/utils/code-mirror-collapse-unchanged-gutter-widget-class.ts
+++ b/app/utils/code-mirror-collapse-unchanged-gutter-widget-class.ts
@@ -34,13 +34,13 @@ export function collapseUnchangedGutterWidgetClass() {
     gutter({
       class: 'cm-collapseUnchangedBarGutter',
       renderEmptyElements: true,
-    }),
-    gutterWidgetClass.of(function (_view, widget, _block): GutterMarker | null {
-      if ('type' in widget && widget.type === 'collapsed-unchanged-code') {
-        return new CollapseUnchangedGutterMarker();
-      }
+      widgetMarker(_view, widget, _block) {
+        if ('type' in widget && widget.type === 'collapsed-unchanged-code') {
+          return new CollapseUnchangedGutterMarker();
+        }
 
-      return null;
+        return null;
+      },
     }),
   ];
 }

--- a/app/utils/code-mirror-collapse-unchanged-gutter.ts
+++ b/app/utils/code-mirror-collapse-unchanged-gutter.ts
@@ -19,10 +19,10 @@ export class CollapseUnchangedGutterMarker extends GutterMarker {
       // Find the index of the clicked gutter element
       const gutterElementIndex = [...gutterElementSiblings.values()].indexOf(gutterElement);
 
-      // Find the corresponding expand unchanged bar in the content
-      const expandCollapsedBar = editor.querySelectorAll<HTMLElement>('.cm-content .cm-collapsedLines').item(gutterElementIndex);
+      // Find the corresponding Collapse Unchanged Bar in the content
+      const collapsedUnchangedBar = editor.querySelectorAll<HTMLElement>('.cm-content .cm-collapsedLines').item(gutterElementIndex);
 
-      expandCollapsedBar?.click();
+      collapsedUnchangedBar?.click();
     });
 
     return el;

--- a/app/utils/code-mirror-collapse-unchanged-gutter.ts
+++ b/app/utils/code-mirror-collapse-unchanged-gutter.ts
@@ -1,32 +1,37 @@
-import { EditorView, gutter, GutterMarker } from '@codemirror/view';
+import { EditorView, gutter, GutterMarker, type WidgetType } from '@codemirror/view';
+
+function isCollapseUnchangedWidget(widget: WidgetType) {
+  return 'type' in widget && widget.type === 'collapsed-unchanged-code';
+}
+
+function toDOM(_view: EditorView): Node {
+  const el = document.createElement('div');
+  el.className = 'cm-collapseUnchangedGutterElement';
+  el.addEventListener('click', (_e) => {
+    const editor = el.closest('.cm-editor');
+    const gutter = el.closest('.cm-gutter');
+    const gutterElement = el.closest('.cm-gutterElement');
+    const gutterElementSiblings = gutter?.querySelectorAll('.cm-collapseUnchangedBarSibling');
+
+    if (!editor || !gutter || !gutterElement || !gutterElementSiblings) {
+      return;
+    }
+
+    // Find the index of the clicked gutter element
+    const gutterElementIndex = [...gutterElementSiblings.values()].indexOf(gutterElement);
+
+    // Find the corresponding Collapse Unchanged Bar in the content
+    const collapsedUnchangedBar = editor.querySelectorAll<HTMLElement>('.cm-content .cm-collapsedLines').item(gutterElementIndex);
+
+    collapsedUnchangedBar?.click();
+  });
+
+  return el;
+}
 
 export class CollapseUnchangedGutterMarker extends GutterMarker {
   elementClass = 'cm-collapseUnchangedBarSibling';
-
-  toDOM(_view: EditorView): Node {
-    const el = document.createElement('div');
-    el.className = 'cm-collapseUnchangedGutterElement';
-    el.addEventListener('click', (_e) => {
-      const editor = el.closest('.cm-editor');
-      const gutter = el.closest('.cm-gutter');
-      const gutterElement = el.closest('.cm-gutterElement');
-      const gutterElementSiblings = gutter?.querySelectorAll('.cm-collapseUnchangedBarSibling');
-
-      if (!editor || !gutter || !gutterElement || !gutterElementSiblings) {
-        return;
-      }
-
-      // Find the index of the clicked gutter element
-      const gutterElementIndex = [...gutterElementSiblings.values()].indexOf(gutterElement);
-
-      // Find the corresponding Collapse Unchanged Bar in the content
-      const collapsedUnchangedBar = editor.querySelectorAll<HTMLElement>('.cm-content .cm-collapsedLines').item(gutterElementIndex);
-
-      collapsedUnchangedBar?.click();
-    });
-
-    return el;
-  }
+  toDOM = toDOM;
 }
 
 export function collapseUnchangedGutter() {
@@ -35,11 +40,7 @@ export function collapseUnchangedGutter() {
       class: 'cm-collapseUnchangedGutter',
       renderEmptyElements: true,
       widgetMarker(_view, widget, _block) {
-        if ('type' in widget && widget.type === 'collapsed-unchanged-code') {
-          return new CollapseUnchangedGutterMarker();
-        }
-
-        return null;
+        return isCollapseUnchangedWidget(widget) ? new CollapseUnchangedGutterMarker() : null;
       },
     }),
   ];

--- a/app/utils/code-mirror-collapse-unchanged-gutter.ts
+++ b/app/utils/code-mirror-collapse-unchanged-gutter.ts
@@ -5,7 +5,7 @@ export class CollapseUnchangedGutterMarker extends GutterMarker {
 
   toDOM(_view: EditorView): Node {
     const el = document.createElement('div');
-    el.className = 'cm-collapseUnchangedBarGutterElement';
+    el.className = 'cm-collapseUnchangedGutterElement';
     el.addEventListener('click', (_e) => {
       const editor = el.closest('.cm-editor');
       const gutter = el.closest('.cm-gutter');
@@ -32,7 +32,7 @@ export class CollapseUnchangedGutterMarker extends GutterMarker {
 export function collapseUnchangedGutter() {
   return [
     gutter({
-      class: 'cm-collapseUnchangedBarGutter',
+      class: 'cm-collapseUnchangedGutter',
       renderEmptyElements: true,
       widgetMarker(_view, widget, _block) {
         if ('type' in widget && widget.type === 'collapsed-unchanged-code') {

--- a/app/utils/code-mirror-collapse-unchanged-gutter.ts
+++ b/app/utils/code-mirror-collapse-unchanged-gutter.ts
@@ -29,7 +29,7 @@ export class CollapseUnchangedGutterMarker extends GutterMarker {
   }
 }
 
-export function collapseUnchangedGutterWidgetClass() {
+export function collapseUnchangedGutter() {
   return [
     gutter({
       class: 'cm-collapseUnchangedBarGutter',

--- a/app/utils/code-mirror-themes.ts
+++ b/app/utils/code-mirror-themes.ts
@@ -69,7 +69,7 @@ const BASE_STYLE = {
   // Collapse unchanged lines gutter
   '.cm-collapseUnchangedBarGutter': {
     '& .cm-gutterElement': {
-      '&.cm-collapseUnchangedBarNeighbor': {
+      '&.cm-collapseUnchangedBarSibling': {
         '& .cm-collapseUnchangedBarGutterElement': {
           content: '""',
           position: 'absolute',
@@ -200,7 +200,7 @@ export const codeCraftersDark = [
       // Collapse unchanged lines gutter
       '.cm-collapseUnchangedBarGutter': {
         '& .cm-gutterElement': {
-          '&.cm-collapseUnchangedBarNeighbor': {
+          '&.cm-collapseUnchangedBarSibling': {
             '& .cm-collapseUnchangedBarGutterElement': {
               borderColor: blendColors(tailwindColors.white, 0.075, blendColors(tailwindColors.sky['900'], 0.4, tailwindColors.slate['800'])),
               backgroundColor: blendColors(tailwindColors.sky['900'], 0.4, tailwindColors.slate['800']),

--- a/app/utils/code-mirror-themes.ts
+++ b/app/utils/code-mirror-themes.ts
@@ -67,10 +67,10 @@ const BASE_STYLE = {
   },
 
   // Collapse unchanged lines gutter
-  '.cm-collapseUnchangedBarGutter': {
+  '.cm-collapseUnchangedGutter': {
     '& .cm-gutterElement': {
       '&.cm-collapseUnchangedBarSibling': {
-        '& .cm-collapseUnchangedBarGutterElement': {
+        '& .cm-collapseUnchangedGutterElement': {
           content: '""',
           position: 'absolute',
           left: 0,
@@ -87,20 +87,20 @@ const BASE_STYLE = {
           cursor: 'pointer',
         },
         '&:hover': {
-          '& .cm-collapseUnchangedBarGutterElement': {
+          '& .cm-collapseUnchangedGutterElement': {
             backgroundColor: tailwindColors.sky['100'],
             color: tailwindColors.sky['800'],
           },
         },
         '&:first-child': {
-          '& .cm-collapseUnchangedBarGutterElement': {
+          '& .cm-collapseUnchangedGutterElement': {
             borderTop: 'none',
             marginTop: '-0.5rem',
             backgroundImage: 'url("/assets/images/codemirror/expand-diff-top.svg")',
           },
         },
         '&:last-child': {
-          '& .cm-collapseUnchangedBarGutterElement': {
+          '& .cm-collapseUnchangedGutterElement': {
             borderBottom: 'none',
             marginTop: '0.5rem',
             backgroundImage: 'url("/assets/images/codemirror/expand-diff-bottom.svg")',
@@ -198,30 +198,30 @@ export const codeCraftersDark = [
       },
 
       // Collapse unchanged lines gutter
-      '.cm-collapseUnchangedBarGutter': {
+      '.cm-collapseUnchangedGutter': {
         '& .cm-gutterElement': {
           '&.cm-collapseUnchangedBarSibling': {
-            '& .cm-collapseUnchangedBarGutterElement': {
+            '& .cm-collapseUnchangedGutterElement': {
               borderColor: blendColors(tailwindColors.white, 0.075, blendColors(tailwindColors.sky['900'], 0.4, tailwindColors.slate['800'])),
               backgroundColor: blendColors(tailwindColors.sky['900'], 0.4, tailwindColors.slate['800']),
               backgroundImage: 'url("/assets/images/codemirror/expand-diff-middle-dark.svg")',
             },
 
             '&:hover': {
-              '& .cm-collapseUnchangedBarGutterElement': {
+              '& .cm-collapseUnchangedGutterElement': {
                 backgroundColor: blendColors(tailwindColors.sky['800'], 0.4, tailwindColors.slate['800']),
                 color: tailwindColors.sky['300'],
               },
             },
 
             '&:first-child': {
-              '& .cm-collapseUnchangedBarGutterElement': {
+              '& .cm-collapseUnchangedGutterElement': {
                 backgroundImage: 'url("/assets/images/codemirror/expand-diff-top-dark.svg")',
               },
             },
 
             '&:last-child': {
-              '& .cm-collapseUnchangedBarGutterElement': {
+              '& .cm-collapseUnchangedGutterElement': {
                 backgroundImage: 'url("/assets/images/codemirror/expand-diff-bottom-dark.svg")',
               },
             },

--- a/tests/acceptance/course-admin/view-diffs-test.js
+++ b/tests/acceptance/course-admin/view-diffs-test.js
@@ -114,12 +114,12 @@ module('Acceptance | course-admin | view-diffs', function (hooks) {
       'The first placeholder should be expanded after clicking',
     );
 
-    await submissionsPage.diffTab.changedFiles[0].codeMirror.content.collapsedLinesPlaceholders[0].click();
+    await submissionsPage.diffTab.changedFiles[0].codeMirror.gutters.collapseUnchangedGutter.collapseUnchangedBarSiblings[0].click();
 
     assert.strictEqual(
       submissionsPage.diffTab.changedFiles[0].codeMirror.content.collapsedLinesPlaceholders.length,
       1,
-      'The second placeholder should be expanded after clicking',
+      "The second placeholder should be expanded after clicking on it's gutter sibling",
     );
 
     await submissionsPage.diffTab.changedFiles[0].codeMirror.content.collapsedLinesPlaceholders[0].click();

--- a/tests/pages/components/code-mirror.ts
+++ b/tests/pages/components/code-mirror.ts
@@ -28,6 +28,12 @@ export default create({
           scope: '> .cm-gutter.cm-changeGutter',
           elements: collection('> .cm-gutterElement'),
         },
+
+        collapseUnchangedGutter: {
+          scope: '> .cm-gutter.cm-collapseUnchangedGutter',
+          elements: collection('> .cm-gutterElement'),
+          collapseUnchangedBarSiblings: collection('.cm-collapseUnchangedGutterElement'),
+        },
       },
 
       content: {


### PR DESCRIPTION
Related to #1231 
Follow-up to https://github.com/codecrafters-io/frontend/pull/2525

### Brief

As another step in building the Line Comments extension, this switches our Collapse Unchanged Bar gutter implementation from using [`gutterWidgetClass`](https://codemirror.net/docs/ref/#view.gutterWidgetClass) to using a much simpler [`widgetMarker`](https://codemirror.net/docs/ref/#view.gutter^config.widgetMarker) gutter config option.

### As a result

- `.cm-collapseUnchangedBarSibling` class is only applied to children of `.cm-collapseUnchangedGutter` (`gutterWidgetClass` applied it to children of **all** gutters)
- same for `.cm-collapseUnchangedGutterElement`, which we style and make respond to clicks etc — they are now rendered inside `.cm-collapseUnchangedGutter` only (previously in all gutters)
- A much more simplified naming of classes, styles and variables, stripping unnecessary words and unifying the naming

### Details

- Use [`widgetMarker`](https://codemirror.net/docs/ref/#view.gutter^config.widgetMarker) gutter config option instead of [`gutterWidgetClass`](https://codemirror.net/docs/ref/#view.gutterWidgetClass)
- Renamed `collapseUnchangedGutterWidgetClass` extension to just `collapseUnchangedGutter`
- `collapseUnchangedGutter` is now only rendered when `@collapseUnchanged` option is enabled
- Extract `toDOM` into a separate function for easy reuse (will be useful for the [line comments branch](https://github.com/codecrafters-io/frontend/compare/code-mirror/even-better-collapse-unchanged-gutter...code-mirror/line-comments#diff-86975cefafa78fc1e0fa2342a0c9aaafda067208ec294f1542778847b41a5f82R52))
- Add `isCollapseUnchangedWidget` function for easy comparison (will be useful for the [line comments branch](https://github.com/codecrafters-io/frontend/compare/code-mirror/even-better-collapse-unchanged-gutter...code-mirror/line-comments#diff-86975cefafa78fc1e0fa2342a0c9aaafda067208ec294f1542778847b41a5f82R52))

### Checklist

- [x] I've thoroughly self-reviewed my changes
- [x] I've added tests for my changes, unless they affect admin-only areas (or are otherwise not worth testing)
- [x] I've verified any visual changes using Percy (add a commit with `[percy]` in the message to trigger)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
	- Introduced a new gutter type for managing unchanged code sections in the editor.
  
- **Refactor**
	- Enhanced functionality for handling unchanged code sections in the editor.
	- Updated utility functions and removed obsolete classes related to gutter markers.

- **Style**
	- Streamlined CSS naming conventions for "collapse unchanged" functionality in CodeMirror themes.

- **Tests**
	- Updated tests to reflect changes in interaction with collapsed lines placeholders in the editor.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->