### PR TITLE
Fix `lint:css` task by upgrading to `stylelint@16.13.2`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -178,7 +178,7 @@
         "rgb-hex": "^4.1.0",
         "shiki": "^1.17.7",
         "sinon": "^19.0.2",
-        "stylelint": "^16.13.0",
+        "stylelint": "^16.13.2",
         "stylelint-config-standard": "^36.0.1",
         "stylelint-prettier": "^5.0.2",
         "tailwindcss": "^3.4.16",
@@ -43706,9 +43706,9 @@
       "dev": true
     },
     "node_modules/stylelint": {
-      "version": "16.13.0",
-      "resolved": "https://registry.npmjs.org/stylelint/-/stylelint-16.13.0.tgz",
-      "integrity": "sha512-muxVjMhZB8BrDFSKNva0dmvD2tM0o/szrvuZuXYcAnN9a8nQmbGLqNUOemSgumaCMCPQ+0USYyG3hA5vJjUC1Q==",
+      "version": "16.13.2",
+      "resolved": "https://registry.npmjs.org/stylelint/-/stylelint-16.13.2.tgz",
+      "integrity": "sha512-wDlgh0mRO9RtSa3TdidqHd0nOG8MmUyVKl+dxA6C1j8aZRzpNeEgdhFmU5y4sZx4Fc6r46p0fI7p1vR5O2DZqA==",
       "dev": true,
       "funding": [
         {
@@ -43739,7 +43739,7 @@
         "globby": "^11.1.0",
         "globjoin": "^0.1.4",
         "html-tags": "^3.3.1",
-        "ignore": "^7.0.0",
+        "ignore": "^7.0.1",
         "imurmurhash": "^0.1.4",
         "is-plain-object": "^5.0.0",
         "known-css-properties": "^0.35.0",

--- a/package.json
+++ b/package.json
@@ -184,7 +184,7 @@
     "rgb-hex": "^4.1.0",
     "shiki": "^1.17.7",
     "sinon": "^19.0.2",
-    "stylelint": "^16.13.0",
+    "stylelint": "^16.13.2",
     "stylelint-config-standard": "^36.0.1",
     "stylelint-prettier": "^5.0.2",
     "tailwindcss": "^3.4.16",


### PR DESCRIPTION
### Brief

After upgrading `stylelint` to `16.13.0` — an error started happening when running `npm run lint:css`. Upgrading to [`16.13.2`](https://github.com/stylelint/stylelint/releases/tag/16.13.2) fixes it.

### Checklist

- [x] I've thoroughly self-reviewed my changes
- [x] I've added tests for my changes, unless they affect admin-only areas (or are otherwise not worth testing)
- [x] I've verified any visual changes using Percy (add a commit with `[percy]` in the message to trigger)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated `stylelint` dependency to the latest minor version for potential bug fixes and improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->