### PR TITLE
remove lifetime promotion [percy]

### DIFF
--- a/app/templates/pay.hbs
+++ b/app/templates/pay.hbs
@@ -51,7 +51,6 @@
 
       <PayPage::PricingCard
         @actualPrice={{1490}}
-        @discountedPrice={{990}}
         @footerText="Pay once, access for life."
         @onStartMembershipButtonClick={{this.handleStartMembershipButtonClick}}
         @isRecommended={{false}}
@@ -59,8 +58,6 @@
         @regionalDiscount={{if this.shouldApplyRegionalDiscount @model.regionalDiscount}}
         @shouldShowAmortizedMonthlyPrice={{false}}
         @title="Lifetime access"
-        @temporaryNoticeText="Price increases on Jan 15"
-        @temporaryNoticeTooltipText="The price for the lifetime plan will increase from $990 to $1,490 on January 15, 2025."
         data-test-lifetime-pricing-card
       />
     </div>

--- a/app/templates/pay.hbs
+++ b/app/templates/pay.hbs
@@ -51,6 +51,7 @@
 
       <PayPage::PricingCard
         @actualPrice={{1490}}
+        @discountedPrice={{null}}
         @footerText="Pay once, access for life."
         @onStartMembershipButtonClick={{this.handleStartMembershipButtonClick}}
         @isRecommended={{false}}


### PR DESCRIPTION
**Checklist**:

- [ ] I've thoroughly self-reviewed my changes
- [ ] I've added tests for my changes, unless they affect admin-only areas (or are otherwise not worth testing)
- [ ] I've verified any visual changes using Percy (add a commit with `[percy]` in the message to trigger)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Removed temporary pricing notice for lifetime access option
- **Bug Fixes**
	- Updated pricing display for lifetime access plan by removing discounted price indication
	- Removed outdated price increase information from the pricing card
<!-- end of auto-generated comment: release notes by coderabbit.ai -->