### PR TITLE
fix: reorder 'bittorrent' and 'kafka' in sortPositionForTrack method

### DIFF
--- a/app/models/course.ts
+++ b/app/models/course.ts
@@ -146,7 +146,7 @@ export default class CourseModel extends Model {
   }
 
   get sortPositionForTrack() {
-    const orderedSlugs = ['shell', 'grep', 'interpreter', 'http-server', 'redis', 'kafka', 'git', 'sqlite', 'bittorrent', 'dns-server'];
+    const orderedSlugs = ['shell', 'grep', 'interpreter', 'http-server', 'redis', 'bittorrent', 'kafka', 'git', 'sqlite', 'dns-server'];
     const index = orderedSlugs.indexOf(this.slug);
 
     return index === -1 ? 100 : index;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
	- Updated the order of course slugs in the sorting method to reflect a new preferred sequence.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->