### PR TITLE
Launch Split Up Git Commands For Stage 1 experiment

### DIFF
--- a/app/components/course-page/course-stage-step/first-stage-tutorial-card.hbs
+++ b/app/components/course-page/course-stage-step/first-stage-tutorial-card.hbs
@@ -21,7 +21,11 @@
           @isComplete={{this.uncommentCodeStepIsComplete}}
         />
       {{else if (eq stepList.expandedStep.id "submit-code")}}
-        <CoursePage::CourseStageStep::FirstStageTutorialCard::SubmitCodeStep @isComplete={{this.submitCodeStepIsComplete}} />
+        <CoursePage::CourseStageStep::FirstStageTutorialCard::SubmitCodeStep
+          @courseStage={{@courseStage}}
+          @filename={{this.filename}}
+          @isComplete={{this.submitCodeStepIsComplete}}
+        />
       {{/if}}
     </ExpandableStepList>
 

--- a/app/components/course-page/course-stage-step/first-stage-tutorial-card.ts
+++ b/app/components/course-page/course-stage-step/first-stage-tutorial-card.ts
@@ -9,7 +9,6 @@ import type { Step } from 'codecrafters-frontend/components/expandable-step-list
 import type CourseStageStep from 'codecrafters-frontend/utils/course-page-step-list/course-stage-step';
 import { action } from '@ember/object';
 import { inject as service } from '@ember/service';
-import { tracked } from '@glimmer/tracking';
 
 interface Signature {
   Element: HTMLDivElement;
@@ -74,7 +73,11 @@ export default class FirstStageTutorialCardComponent extends Component<Signature
   @service declare featureFlags: FeatureFlagsService;
   @service declare store: Store;
 
-  @tracked isTerminalInstructionsPingingClicked = false;
+  get filename() {
+    const solution = this.args.courseStage.solutions.find((solution) => solution.language === this.args.repository.language);
+
+    return solution?.changedFiles[0]?.filename;
+  }
 
   get hasPassedTests() {
     return this.args.currentStep.testsStatus === 'passed' || this.args.currentStep.status === 'complete';
@@ -130,11 +133,6 @@ export default class FirstStageTutorialCardComponent extends Component<Signature
         repository_id: this.args.repository.id,
       });
     }
-  }
-
-  @action
-  handleTerminalClick() {
-    this.isTerminalInstructionsPingingClicked = true;
   }
 
   @action

--- a/app/components/course-page/course-stage-step/first-stage-tutorial-card/submit-code-step.hbs
+++ b/app/components/course-page/course-stage-step/first-stage-tutorial-card/submit-code-step.hbs
@@ -1,21 +1,5 @@
-{{#if this.isCommitModalOpen}}
-  <ModalBackdrop class="cursor-pointer">
-    <ModalBody @allowManualClose={{true}} @onClose={{fn (mut this.isCommitModalOpen) false}} @isWide={{true}} class="w-full cursor-default">
-      <div class="prose prose-compact dark:prose-invert has-prism-highlighting">
-        <p>
-          If you see output like this:
-        </p>
-        <pre class="language-bash max-w-2xl"><code class="text-xs">On branch master
-Your branch is up to date with 'origin/master'.
-
-nothing to commit, working tree clean</code></pre>
-      </div>
-    </ModalBody>
-  </ModalBackdrop>
-{{/if}}
-
 {{#if this.canSeeSplitUpGitCommandsForStage1}}
-  <div class="mb-5">
+  <div class="mb-6">
     <div class="prose prose-compact dark:prose-invert mb-3">
       First, run this command to
       <span class="font-semibold">commit your changes</span>:
@@ -28,7 +12,7 @@ nothing to commit, working tree clean</code></pre>
         The output of the command should look like this:
       </p>
 
-      <pre class="language-bash max-w-2xl"><code class="text-xs">[master 8bc0189] [any message]<br />1 file changed, 1 insertion(+), 1 deletion(-)</code></pre>
+      <pre class="max-w-2xl"><code class="text-xs">[master 8bc0189] [any message]<br />1 file changed, 1 insertion(+), 1 deletion(-)</code></pre>
 
       <p class="text-xs">
         <b>Note:</b>
@@ -38,7 +22,7 @@ nothing to commit, working tree clean</code></pre>
     </div>
   </div>
 
-  <div class="mb-5">
+  <div class="mb-6">
     <div class="prose prose-compact dark:prose-invert mb-3">
       Next, run this command to
       <span class="font-semibold">push your changes</span>:
@@ -56,7 +40,7 @@ nothing to commit, working tree clean</code></pre>
       <p class="text-xs">
         <b>Note:</b>
         If your output doesn't match the above,
-        <a href="#">read this</a>.
+        <a href="#" {{on "click" (fn (mut this.isPushModalOpen) true)}}>read this</a>.
       </p>
     </div>
   </div>
@@ -94,3 +78,109 @@ nothing to commit, working tree clean</code></pre>
     to troubleshoot.
   </p>
 {{/unless}}
+
+{{#if this.isCommitModalOpen}}
+  <ModalBackdrop class="cursor-pointer">
+    <ModalBody @allowManualClose={{true}} @onClose={{this.handleCommitModalClose}} @isWide={{true}} class="w-full cursor-default">
+      <div class="prose prose-compact dark:prose-invert has-prism-highlighting">
+        <div>
+          <h3>Nothing to commit</h3>
+          <p>
+            If you see output like this:
+          </p>
+          <pre class="language-bash max-full"><code class="text-xs">On branch master<br />Your branch is up to date with 'origin/master'.<br /><br
+              />nothing to commit, working tree clean</code></pre>
+          <ol class="space-y-4">
+            <li>
+              <p>Double-check if you’ve saved the changes.</p>
+              <p>Then run <code>git commit -am "[saved]"</code> again.</p>
+            </li>
+            <li>
+              <p>
+                Check the file content in the latest commit:
+              </p>
+              <code>git show HEAD:{{@filename}}{{unless @filename "path-to-your-file"}}</code>
+            </li>
+            <li>
+              <p>
+                If the file content looks correct, make an empty commit:
+              </p>
+              <code>git commit --allow-empty -m 'empty'</code>
+            </li>
+          </ol>
+        </div>
+      </div>
+
+      <div class="prose dark:prose-invert prose-sm prose-compact mt-10">
+        <p>
+          Need help?
+          <a
+            href="https://forum.codecrafters.io/new-topic?category=Challenges&tags=challenge%3A{{this.currentCourse.slug}}&title=%5B{{this.currentCourse.shortName}}%5D%20How%20to%20pass%20the%20first%20stage%3F&body=Checklist%3A%0A%0A1.%20%E2%9C%85%20or%20%E2%9D%8C%3A%20I%27ve%20uncommented%20the%20code.%0A2.%20%E2%9C%85%20or%20%E2%9D%8C%3A%20I%27ve%20saved%20the%20changes.%0A3.%20%E2%9C%85%20or%20%E2%9D%8C%3A%20I%27ve%20run%20the%20git%20commands%3A%0A%0A%60%60%60%0Agit%20commit%20-am%20%22%5Bseeking%20help%20on%20forum%5D%22%0Agit%20push%20origin%20master%0A%60%60%60%0A%0A---%0A%0AHere%E2%80%99s%20a%20screenshot%20showing%20the%20output%20from%20running%20the%20Git%20commands%3A%0A%0A%5BAttach%20screenshot%20here%5D%0A%0A%5BShare%20other%20details%20here%5D"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            Post your issue</a>
+          on the forum —
+          <img
+            alt="avatar"
+            src="https://avatars.githubusercontent.com/u/1450947"
+            class="inline-block ml-1 mr-1.5 my-0 -translate-y-px overflow-hidden rounded-full size-4 filter drop-shadow-sm ring-1 ring-white dark:ring-white/5 shadow"
+          />Andy usually replies within 6 hours.
+        </p>
+      </div>
+    </ModalBody>
+  </ModalBackdrop>
+{{/if}}
+
+{{#if this.isPushModalOpen}}
+  <ModalBackdrop class="cursor-pointer">
+    <ModalBody @allowManualClose={{true}} @onClose={{this.handlePushModalClose}} @isWide={{true}} class="w-full cursor-default">
+      <div class="prose prose-compact dark:prose-invert has-prism-highlighting">
+        <div>
+          <h3>Everything up-to-date</h3>
+          <p>
+            If you see output like this:
+          </p>
+          <pre class="language-bash max-full"><code class="text-xs">Everything up-to-date</code></pre>
+          <ol class="space-y-4">
+            <li>
+              <p>
+                Check the file content in the latest commit:
+              </p>
+              <code>git show HEAD:{{@filename}}{{unless @filename "path-to-your-file"}}</code>
+            </li>
+            <li>
+              <p>
+                If the file content looks correct, make an empty commit:
+              </p>
+              <code>git commit --allow-empty -m 'empty'</code>
+            </li>
+            <li>
+              Run
+              <code>git push origin master</code>
+              again.
+            </li>
+          </ol>
+        </div>
+      </div>
+
+      <div class="prose dark:prose-invert prose-sm prose-compact mt-10">
+        <p>
+          Need help?
+          <a
+            href="https://forum.codecrafters.io/new-topic?category=Challenges&tags=challenge%3A{{this.currentCourse.slug}}&title=%5B{{this.currentCourse.shortName}}%5D%20How%20to%20pass%20the%20first%20stage%3F&body=Checklist%3A%0A%0A1.%20%E2%9C%85%20or%20%E2%9D%8C%3A%20I%27ve%20uncommented%20the%20code.%0A2.%20%E2%9C%85%20or%20%E2%9D%8C%3A%20I%27ve%20saved%20the%20changes.%0A3.%20%E2%9C%85%20or%20%E2%9D%8C%3A%20I%27ve%20run%20the%20git%20commands%3A%0A%0A%60%60%60%0Agit%20commit%20-am%20%22%5Bseeking%20help%20on%20forum%5D%22%0Agit%20push%20origin%20master%0A%60%60%60%0A%0A---%0A%0AHere%E2%80%99s%20a%20screenshot%20showing%20the%20output%20from%20running%20the%20Git%20commands%3A%0A%0A%5BAttach%20screenshot%20here%5D%0A%0A%5BShare%20other%20details%20here%5D"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            Post your issue</a>
+          on the forum —
+          <img
+            alt="avatar"
+            src="https://avatars.githubusercontent.com/u/1450947"
+            class="inline-block ml-1 mr-1.5 my-0 -translate-y-px overflow-hidden rounded-full size-4 filter drop-shadow-sm ring-1 ring-white dark:ring-white/5 shadow"
+          />Andy usually replies within 6 hours.
+        </p>
+      </div>
+    </ModalBody>
+  </ModalBackdrop>
+{{/if}}

--- a/app/components/course-page/course-stage-step/first-stage-tutorial-card/submit-code-step.hbs
+++ b/app/components/course-page/course-stage-step/first-stage-tutorial-card/submit-code-step.hbs
@@ -7,7 +7,7 @@
 
     <CopyableTerminalCommand @commands={{array 'git commit -am "[any message]"'}} class="mb-3" />
 
-    <div class="prose prose-compact dark:prose-invert has-prism-highlighting">
+    <div class="prose prose-compact dark:prose-invert">
       <p>
         The output of the command should look like this:
       </p>
@@ -30,7 +30,7 @@
 
     <CopyableTerminalCommand @commands={{array "git push origin master"}} class="mb-3" />
 
-    <div class="prose prose-compact dark:prose-invert has-prism-highlighting">
+    <div class="prose prose-compact dark:prose-invert">
       <p>
         The output of the command should look like this:
       </p>
@@ -81,34 +81,51 @@
 
 {{#if this.isCommitModalOpen}}
   <ModalBackdrop class="cursor-pointer">
-    <ModalBody @allowManualClose={{true}} @onClose={{this.handleCommitModalClose}} @isWide={{true}} class="w-full cursor-default">
-      <div class="prose prose-compact dark:prose-invert has-prism-highlighting">
-        <div>
-          <h3>Nothing to commit</h3>
-          <p>
-            If you see output like this:
-          </p>
-          <pre class="language-bash max-full"><code class="text-xs">On branch master<br />Your branch is up to date with 'origin/master'.<br /><br
-              />nothing to commit, working tree clean</code></pre>
-          <ol class="space-y-4">
-            <li>
-              <p>Double-check if you’ve saved the changes.</p>
-              <p>Then run <code>git commit -am "[saved]"</code> again.</p>
-            </li>
-            <li>
-              <p>
-                Check the file content in the latest commit:
-              </p>
-              <code>git show HEAD:{{@filename}}{{unless @filename "path-to-your-file"}}</code>
-            </li>
-            <li>
-              <p>
-                If the file content looks correct, make an empty commit:
-              </p>
-              <code>git commit --allow-empty -m 'empty'</code>
-            </li>
-          </ol>
-        </div>
+    <ModalBody @allowManualClose={{true}} @onClose={{this.handleCommitModalClose}} @isWide={{true}} class="w-fit cursor-default">
+      <div class="mb-6 font-semibold text-2xl text-gray-800 dark:text-gray-200 mr-8">
+        Commit changes
+      </div>
+
+      <div class="prose prose-compact dark:prose-invert mb-3">
+        Run this command to
+        <span class="font-semibold">commit your changes</span>:
+      </div>
+
+      <CopyableTerminalCommand @commands={{array 'git commit -am "[any message]"'}} class="w-full mb-3" />
+
+      <div class="prose prose-compact dark:prose-invert has-prism-highlighting mb-3">
+        <p>
+          The output of the command should look like this:
+        </p>
+
+        <pre class="max-w-2xl"><code class="text-xs">[master 8bc0189] [any message]<br />1 file changed, 1 insertion(+), 1 deletion(-)</code></pre>
+      </div>
+
+      <div class="prose prose-compact dark:prose-invert has-prism-highlighting mt-6">
+        <h3>Nothing to commit</h3>
+        <p>
+          If you see output like this instead:
+        </p>
+        <pre class="language-bash max-full max-w-2xl"><code class="text-xs">On branch master<br />Your branch is up to date with 'origin/master'.<br
+            /><br />nothing to commit, working tree clean</code></pre>
+        <ol class="space-y-4">
+          <li>
+            <p>Double-check if you’ve saved the changes.</p>
+            <p>Then run <code>git commit -am "[saved]"</code> again.</p>
+          </li>
+          <li>
+            <p>
+              Check the file content in the latest commit:
+            </p>
+            <code>git show HEAD:{{@filename}}{{unless @filename "path-to-your-file"}}</code>
+          </li>
+          <li>
+            <p>
+              If the file content looks correct, make an empty commit:
+            </p>
+            <code>git commit --allow-empty -m 'empty'</code>
+          </li>
+        </ol>
       </div>
 
       <div class="prose dark:prose-invert prose-sm prose-compact mt-10">
@@ -134,34 +151,51 @@
 
 {{#if this.isPushModalOpen}}
   <ModalBackdrop class="cursor-pointer">
-    <ModalBody @allowManualClose={{true}} @onClose={{this.handlePushModalClose}} @isWide={{true}} class="w-full cursor-default">
-      <div class="prose prose-compact dark:prose-invert has-prism-highlighting">
-        <div>
-          <h3>Everything up-to-date</h3>
-          <p>
-            If you see output like this:
-          </p>
-          <pre class="language-bash max-full"><code class="text-xs">Everything up-to-date</code></pre>
-          <ol class="space-y-4">
-            <li>
-              <p>
-                Check the file content in the latest commit:
-              </p>
-              <code>git show HEAD:{{@filename}}{{unless @filename "path-to-your-file"}}</code>
-            </li>
-            <li>
-              <p>
-                If the file content looks correct, make an empty commit:
-              </p>
-              <code>git commit --allow-empty -m 'empty'</code>
-            </li>
-            <li>
-              Run
-              <code>git push origin master</code>
-              again.
-            </li>
-          </ol>
-        </div>
+    <ModalBody @allowManualClose={{true}} @onClose={{this.handlePushModalClose}} @isWide={{true}} class="w-fit cursor-default">
+      <div class="mb-6 font-semibold text-2xl text-gray-800 dark:text-gray-200 mr-8">
+        Push changes
+      </div>
+
+      <div class="prose prose-compact dark:prose-invert mb-3">
+        Run this command to
+        <span class="font-semibold">push your changes</span>:
+      </div>
+
+      <CopyableTerminalCommand @commands={{array "git push origin master"}} class="w-full mb-3" />
+
+      <div class="prose prose-compact dark:prose-invert mb-3">
+        <p>
+          The output of the command should look like this:
+        </p>
+
+        <pre class="max-w-2xl"><code class="text-xs">remote: Welcome to CodeCrafters! Your commit was received successfully.</code></pre>
+      </div>
+
+      <div class="prose prose-compact dark:prose-invert mt-6">
+        <h3>Everything up-to-date</h3>
+        <p>
+          If you see output like this instead:
+        </p>
+        <pre class="language-bash max-full max-w-2xl"><code class="text-xs">Everything up-to-date</code></pre>
+        <ol class="space-y-4">
+          <li>
+            <p>
+              Check the file content in the latest commit:
+            </p>
+            <code>git show HEAD:{{@filename}}{{unless @filename "path-to-your-file"}}</code>
+          </li>
+          <li>
+            <p>
+              If the file content looks correct, make an empty commit:
+            </p>
+            <code>git commit --allow-empty -m 'empty'</code>
+          </li>
+          <li>
+            Run
+            <code>git push origin master</code>
+            again.
+          </li>
+        </ol>
       </div>
 
       <div class="prose dark:prose-invert prose-sm prose-compact mt-10">

--- a/app/components/course-page/course-stage-step/first-stage-tutorial-card/submit-code-step.hbs
+++ b/app/components/course-page/course-stage-step/first-stage-tutorial-card/submit-code-step.hbs
@@ -1,12 +1,14 @@
 {{#if this.isCommitModalOpen}}
   <ModalBackdrop class="cursor-pointer">
-    <ModalBody @allowManualClose={{true}} @onClose={{fn (mut this.isCommitModalOpen) false}} class="w-full cursor-default">
+    <ModalBody @allowManualClose={{true}} @onClose={{fn (mut this.isCommitModalOpen) false}} @isWide={{true}} class="w-full cursor-default">
       <div class="prose prose-compact dark:prose-invert has-prism-highlighting">
         <p>
           If you see output like this:
         </p>
-        <pre class="language-bash max-w-2xl"><code class="text-xs">On branch master<br />Your branch is up to date with 'origin/master'.<br />nothing to
-            commit, working tree clean</code></pre>
+        <pre class="language-bash max-w-2xl"><code class="text-xs">On branch master
+Your branch is up to date with 'origin/master'.
+
+nothing to commit, working tree clean</code></pre>
       </div>
     </ModalBody>
   </ModalBackdrop>
@@ -15,7 +17,8 @@
 {{#if this.canSeeSplitUpGitCommandsForStage1}}
   <div class="mb-5">
     <div class="prose prose-compact dark:prose-invert mb-3">
-      First, run this command to <span class="font-semibold">commit your changes</span>:
+      First, run this command to
+      <span class="font-semibold">commit your changes</span>:
     </div>
 
     <CopyableTerminalCommand @commands={{array 'git commit -am "[any message]"'}} class="mb-3" />
@@ -30,14 +33,15 @@
       <p class="text-xs">
         <b>Note:</b>
         If your output doesn't match the above,
-        <a href="#">read this</a>.
+        <a href="#" {{on "click" (fn (mut this.isCommitModalOpen) true)}}>read this</a>.
       </p>
     </div>
   </div>
 
   <div class="mb-5">
     <div class="prose prose-compact dark:prose-invert mb-3">
-      Next, run this command to <span class="font-semibold">push your changes</span>:
+      Next, run this command to
+      <span class="font-semibold">push your changes</span>:
     </div>
 
     <CopyableTerminalCommand @commands={{array "git push origin master"}} class="mb-3" />

--- a/app/components/course-page/course-stage-step/first-stage-tutorial-card/submit-code-step.hbs
+++ b/app/components/course-page/course-stage-step/first-stage-tutorial-card/submit-code-step.hbs
@@ -5,7 +5,7 @@
         <p>
           If you see output like this:
         </p>
-        <pre class="text-sm language-bash max-w-2xl"><code>On branch master<br />Your branch is up to date with 'origin/master'.<br />nothing to
+        <pre class="language-bash max-w-2xl"><code class="text-xs">On branch master<br />Your branch is up to date with 'origin/master'.<br />nothing to
             commit, working tree clean</code></pre>
       </div>
     </ModalBody>
@@ -14,19 +14,18 @@
 
 {{#if this.canSeeSplitUpGitCommandsForStage1}}
   <div class="mb-5">
-    <div class="prose dark:prose-invert mb-3">
-      <div class="inline-flex items-center gap-1">
-        <b class="text-teal-600">1.</b>
-        Commit your changes
-      </div>
+    <div class="prose prose-compact dark:prose-invert mb-3">
+      First, run this command to <span class="font-semibold">commit your changes</span>:
     </div>
+
     <CopyableTerminalCommand @commands={{array 'git commit -am "[any message]"'}} class="mb-3" />
 
-    <div class="prose prose-compact prose-sm dark:prose-sm dark:prose-invert has-prism-highlighting">
+    <div class="prose prose-compact dark:prose-invert has-prism-highlighting">
       <p>
-        Then you should see output like this:
+        The output of the command should look like this:
       </p>
-      <pre class="language-bash max-w-2xl"><code>[master 8bc0189] [any message]<br />1 file changed, 1 insertion(+), 1 deletion(-)</code></pre>
+
+      <pre class="language-bash max-w-2xl"><code class="text-xs">[master 8bc0189] [any message]<br />1 file changed, 1 insertion(+), 1 deletion(-)</code></pre>
 
       <p class="text-xs">
         <b>Note:</b>
@@ -37,20 +36,18 @@
   </div>
 
   <div class="mb-5">
-    <div class="prose dark:prose-invert mb-3">
-      <div class="inline-flex items-center gap-1">
-        <b class="text-teal-600">2.</b>
-        Push your changes
-      </div>
+    <div class="prose prose-compact dark:prose-invert mb-3">
+      Next, run this command to <span class="font-semibold">push your changes</span>:
     </div>
+
     <CopyableTerminalCommand @commands={{array "git push origin master"}} class="mb-3" />
 
-    <div class="prose prose-compact prose-sm dark:prose-sm dark:prose-invert has-prism-highlighting">
+    <div class="prose prose-compact dark:prose-invert has-prism-highlighting">
       <p>
-        Then you should see output like this:
+        The output of the command should look like this:
       </p>
 
-      <pre class="language-bash max-w-2xl"><code>remote: Welcome to CodeCrafters! Your commit was received successfully.</code></pre>
+      <pre class="language-bash max-w-2xl"><code class="text-xs">remote: Welcome to CodeCrafters! Your commit was received successfully.</code></pre>
 
       <p class="text-xs">
         <b>Note:</b>

--- a/app/components/course-page/course-stage-step/first-stage-tutorial-card/submit-code-step.hbs
+++ b/app/components/course-page/course-stage-step/first-stage-tutorial-card/submit-code-step.hbs
@@ -1,10 +1,70 @@
-<div class="prose dark:prose-invert mb-3">
-  <p>
-    Run the following commands to submit your changes:
-  </p>
-</div>
+{{#if this.isCommitModalOpen}}
+  <ModalBackdrop class="cursor-pointer">
+    <ModalBody @allowManualClose={{true}} @onClose={{fn (mut this.isCommitModalOpen) false}} class="w-full cursor-default">
+      <div class="prose prose-compact dark:prose-invert has-prism-highlighting">
+        <p>
+          If you see output like this:
+        </p>
+        <pre class="text-sm language-bash max-w-2xl"><code>On branch master<br />Your branch is up to date with 'origin/master'.<br />nothing to
+            commit, working tree clean</code></pre>
+      </div>
+    </ModalBody>
+  </ModalBackdrop>
+{{/if}}
 
-<CopyableTerminalCommand @commands={{array 'git commit -am "[any message]"' "git push origin master"}} class="mb-3" />
+{{#if this.canSeeSplitUpGitCommandsForStage1}}
+  <div class="mb-5">
+    <div class="prose dark:prose-invert mb-3">
+      <div class="inline-flex items-center gap-1">
+        <b class="text-teal-600">1.</b>
+        Commit your changes
+      </div>
+    </div>
+    <CopyableTerminalCommand @commands={{array 'git commit -am "[any message]"'}} class="mb-3" />
+
+    <div class="prose prose-compact prose-sm dark:prose-sm dark:prose-invert has-prism-highlighting">
+      <p>
+        Then you should see output like this:
+      </p>
+      <pre class="language-bash max-w-2xl"><code>[master 8bc0189] [any message]<br />1 file changed, 1 insertion(+), 1 deletion(-)</code></pre>
+
+      <button {{on "click" (fn (mut this.isCommitModalOpen) true)}} type="button" class="flex items-center gap-1">
+        Help! My output is different.
+        {{svg-jar "question-mark-circle" class="size-4 text-blue-500"}}
+      </button>
+    </div>
+  </div>
+
+  <div class="mb-5">
+    <div class="prose dark:prose-invert mb-3">
+      <div class="inline-flex items-center gap-1">
+        <b class="text-teal-600">2.</b>
+        Push your changes
+      </div>
+    </div>
+    <CopyableTerminalCommand @commands={{array "git push origin master"}} class="mb-3" />
+
+    <div class="prose prose-compact prose-sm dark:prose-sm dark:prose-invert has-prism-highlighting">
+      <p>
+        Then you should see output like this:
+      </p>
+
+      <pre class="language-bash max-w-2xl"><code>remote: Welcome to CodeCrafters! Your commit was received successfully.</code></pre>
+      <button type="button" class="flex items-center gap-1">
+        Help! My output is different.
+        {{svg-jar "question-mark-circle" class="size-4 text-blue-500"}}
+      </button>
+    </div>
+  </div>
+{{else}}
+  <div class="prose dark:prose-invert mb-3">
+    <p>
+      Run the following commands to submit your changes:
+    </p>
+  </div>
+
+  <CopyableTerminalCommand @commands={{array 'git commit -am "[any message]"' "git push origin master"}} class="mb-3" />
+{{/if}}
 
 <div class="prose dark:prose-invert">
   <p class={{if @isComplete "line-through"}}>

--- a/app/components/course-page/course-stage-step/first-stage-tutorial-card/submit-code-step.hbs
+++ b/app/components/course-page/course-stage-step/first-stage-tutorial-card/submit-code-step.hbs
@@ -28,10 +28,11 @@
       </p>
       <pre class="language-bash max-w-2xl"><code>[master 8bc0189] [any message]<br />1 file changed, 1 insertion(+), 1 deletion(-)</code></pre>
 
-      <button {{on "click" (fn (mut this.isCommitModalOpen) true)}} type="button" class="flex items-center gap-1">
-        Help! My output is different.
-        {{svg-jar "question-mark-circle" class="size-4 text-blue-500"}}
-      </button>
+      <p class="text-xs">
+        <b>Note:</b>
+        If your output doesn't match the above,
+        <a href="#">read this</a>.
+      </p>
     </div>
   </div>
 
@@ -50,10 +51,12 @@
       </p>
 
       <pre class="language-bash max-w-2xl"><code>remote: Welcome to CodeCrafters! Your commit was received successfully.</code></pre>
-      <button type="button" class="flex items-center gap-1">
-        Help! My output is different.
-        {{svg-jar "question-mark-circle" class="size-4 text-blue-500"}}
-      </button>
+
+      <p class="text-xs">
+        <b>Note:</b>
+        If your output doesn't match the above,
+        <a href="#">read this</a>.
+      </p>
     </div>
   </div>
 {{else}}

--- a/app/components/course-page/course-stage-step/first-stage-tutorial-card/submit-code-step.ts
+++ b/app/components/course-page/course-stage-step/first-stage-tutorial-card/submit-code-step.ts
@@ -1,7 +1,9 @@
 import { action } from '@ember/object';
 import { service } from '@ember/service';
 import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
 import type CoursePageStateService from 'codecrafters-frontend/services/course-page-state';
+import type FeatureFlagsService from 'codecrafters-frontend/services/feature-flags';
 
 interface Signature {
   Element: HTMLDivElement;
@@ -13,6 +15,14 @@ interface Signature {
 
 export default class SubmitCodeStepComponent extends Component<Signature> {
   @service declare coursePageState: CoursePageStateService;
+  @service declare featureFlags: FeatureFlagsService;
+
+  @tracked isCommitModalOpen = false;
+  @tracked isPushModalOpen = false;
+
+  get canSeeSplitUpGitCommandsForStage1() {
+    return this.featureFlags.canSeeSplitUpGitCommandsForStage1;
+  }
 
   @action
   handleViewLogsButtonClick() {

--- a/app/components/course-page/course-stage-step/first-stage-tutorial-card/submit-code-step.ts
+++ b/app/components/course-page/course-stage-step/first-stage-tutorial-card/submit-code-step.ts
@@ -2,13 +2,15 @@ import { action } from '@ember/object';
 import { service } from '@ember/service';
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
+import type CourseStageModel from 'codecrafters-frontend/models/course-stage';
 import type CoursePageStateService from 'codecrafters-frontend/services/course-page-state';
 import type FeatureFlagsService from 'codecrafters-frontend/services/feature-flags';
-
 interface Signature {
   Element: HTMLDivElement;
 
   Args: {
+    courseStage: CourseStageModel;
+    filename: string | undefined;
     isComplete: boolean;
   };
 }
@@ -17,12 +19,25 @@ export default class SubmitCodeStepComponent extends Component<Signature> {
   @service declare coursePageState: CoursePageStateService;
   @service declare featureFlags: FeatureFlagsService;
 
-  @tracked isCommitModalOpen = false;
-  @tracked isPushModalOpen = false;
+  @tracked isCommitModalOpen: boolean = false;
+  @tracked isPushModalOpen: boolean = false;
 
   get canSeeSplitUpGitCommandsForStage1() {
-    return true;
-    // return this.featureFlags.canSeeSplitUpGitCommandsForStage1;
+    return this.featureFlags.canSeeSplitUpGitCommandsForStage1;
+  }
+
+  get currentCourse() {
+    return this.args.courseStage.course;
+  }
+
+  @action
+  handleCommitModalClose() {
+    this.isCommitModalOpen = false;
+  }
+
+  @action
+  handlePushModalClose() {
+    this.isPushModalOpen = false;
   }
 
   @action

--- a/app/components/course-page/course-stage-step/first-stage-tutorial-card/submit-code-step.ts
+++ b/app/components/course-page/course-stage-step/first-stage-tutorial-card/submit-code-step.ts
@@ -21,7 +21,8 @@ export default class SubmitCodeStepComponent extends Component<Signature> {
   @tracked isPushModalOpen = false;
 
   get canSeeSplitUpGitCommandsForStage1() {
-    return this.featureFlags.canSeeSplitUpGitCommandsForStage1;
+    return true;
+    // return this.featureFlags.canSeeSplitUpGitCommandsForStage1;
   }
 
   @action

--- a/app/components/course-page/course-stage-step/second-stage-tutorial-card.ts
+++ b/app/components/course-page/course-stage-step/second-stage-tutorial-card.ts
@@ -9,7 +9,6 @@ import type CourseStageModel from 'codecrafters-frontend/models/course-stage';
 import type FeatureFlagsService from 'codecrafters-frontend/services/feature-flags';
 import { action } from '@ember/object';
 import type { Step } from 'codecrafters-frontend/components/expandable-step-list';
-import { tracked } from '@glimmer/tracking';
 
 interface Signature {
   Element: HTMLDivElement;
@@ -54,8 +53,6 @@ export default class SecondStageTutorialCardComponent extends Component<Signatur
   @service declare coursePageState: CoursePageStateService;
   @service declare featureFlags: FeatureFlagsService;
   @service declare store: Store;
-
-  @tracked isTerminalInstructionsPingingClicked = false;
 
   get implementSolutionStepIsComplete() {
     return (
@@ -115,11 +112,6 @@ export default class SecondStageTutorialCardComponent extends Component<Signatur
         repository_id: this.args.repository.id,
       });
     }
-  }
-
-  @action
-  handleTerminalClick() {
-    this.isTerminalInstructionsPingingClicked = true;
   }
 
   @action

--- a/app/services/feature-flags.js
+++ b/app/services/feature-flags.js
@@ -14,6 +14,10 @@ export default class FeatureFlagsService extends Service {
     return this.currentUser && (this.currentUser.isStaff || this.currentUser.isConceptAuthor);
   }
 
+  get canSeeSplitUpGitCommandsForStage1() {
+    return this.currentUser?.isStaff || this.getFeatureFlagValue('can-see-split-up-git-commands-for-stage-1') === 'test';
+  }
+
   get currentUser() {
     return this.authenticator.currentUser;
   }


### PR DESCRIPTION
**Checklist**:

- [x] I've thoroughly self-reviewed my changes
- [ ] I've added tests for my changes, unless they affect admin-only areas (or are otherwise not worth testing)
- [x] I've verified any visual changes using Percy (add a commit with `[percy]` in the message to trigger)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced Git command instructions with split-view option for Stage 1.
	- Added dynamic filename retrieval for tutorial cards.

- **Bug Fixes**
	- Removed unused terminal instructions tracking.

- **Chores**
	- Updated component interfaces to support new feature flag functionality.
	- Introduced modal management for Git command instructions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->