### PR TITLE
chore: update version number to 27.0 for clients

### DIFF
--- a/config/environment.js
+++ b/config/environment.js
@@ -48,7 +48,7 @@ module.exports = function (environment) {
 
       // Update the major version number to force all clients to update.
       // The minor version doesn't do anything at the moment, might use in the future.
-      version: `26.0.${process.env.VERCEL_GIT_COMMIT_SHA?.slice(0, 7) || 'dev'}`,
+      version: `27.0.${process.env.VERCEL_GIT_COMMIT_SHA?.slice(0, 7) || 'dev'}`,
     },
     fastboot: {
       hostWhitelist: [/^localhost:\d+$/],


### PR DESCRIPTION
Updates the version number in the environment configuration 
to 27.0 to ensure all clients are prompted to update. This 
change prepares the project for future enhancements and 
maintains versioning consistency.