### PR TITLE
Use `uncollapseUnchanged` effect in `collapseUnchangedGutter`

### DIFF
--- a/app/utils/code-mirror-collapse-unchanged-gutter.ts
+++ b/app/utils/code-mirror-collapse-unchanged-gutter.ts
@@ -11,7 +11,7 @@ function toDOM(_view: EditorView): Node {
     const editor = el.closest('.cm-editor');
     const gutter = el.closest('.cm-gutter');
     const gutterElement = el.closest('.cm-gutterElement');
-    const gutterElementSiblings = gutter?.querySelectorAll('.cm-collapseUnchangedBarSibling');
+    const gutterElementSiblings = gutter?.querySelectorAll('.cm-gutterElement');
 
     if (!editor || !gutter || !gutterElement || !gutterElementSiblings) {
       return;
@@ -30,7 +30,6 @@ function toDOM(_view: EditorView): Node {
 }
 
 export class CollapseUnchangedGutterMarker extends GutterMarker {
-  elementClass = 'cm-collapseUnchangedBarSibling';
   toDOM = toDOM;
 }
 
@@ -38,7 +37,6 @@ export function collapseUnchangedGutter() {
   return [
     gutter({
       class: 'cm-collapseUnchangedGutter',
-      renderEmptyElements: true,
       widgetMarker(_view, widget, _block) {
         return isCollapseUnchangedWidget(widget) ? new CollapseUnchangedGutterMarker() : null;
       },

--- a/app/utils/code-mirror-themes.ts
+++ b/app/utils/code-mirror-themes.ts
@@ -69,42 +69,40 @@ const BASE_STYLE = {
   // Collapse unchanged lines gutter
   '.cm-collapseUnchangedGutter': {
     '& .cm-gutterElement': {
-      '&.cm-collapseUnchangedBarSibling': {
+      '& .cm-collapseUnchangedGutterElement': {
+        content: '""',
+        position: 'absolute',
+        left: 0,
+        right: 0,
+        height: '1.75rem',
+        borderTopWidth: '1px',
+        borderBottomWidth: '1px',
+        borderColor: tailwindColors.sky['100'],
+        backgroundColor: tailwindColors.sky['50'],
+        backgroundImage: 'url("/assets/images/codemirror/expand-diff-middle.svg")',
+        backgroundRepeat: 'no-repeat',
+        backgroundPosition: 'center',
+        backgroundSize: '12px 12px',
+        cursor: 'pointer',
+      },
+      '&:hover': {
         '& .cm-collapseUnchangedGutterElement': {
-          content: '""',
-          position: 'absolute',
-          left: 0,
-          right: 0,
-          height: '1.75rem',
-          borderTopWidth: '1px',
-          borderBottomWidth: '1px',
-          borderColor: tailwindColors.sky['100'],
-          backgroundColor: tailwindColors.sky['50'],
-          backgroundImage: 'url("/assets/images/codemirror/expand-diff-middle.svg")',
-          backgroundRepeat: 'no-repeat',
-          backgroundPosition: 'center',
-          backgroundSize: '12px 12px',
-          cursor: 'pointer',
+          backgroundColor: tailwindColors.sky['100'],
+          color: tailwindColors.sky['800'],
         },
-        '&:hover': {
-          '& .cm-collapseUnchangedGutterElement': {
-            backgroundColor: tailwindColors.sky['100'],
-            color: tailwindColors.sky['800'],
-          },
+      },
+      '&:first-child': {
+        '& .cm-collapseUnchangedGutterElement': {
+          borderTop: 'none',
+          marginTop: '-0.5rem',
+          backgroundImage: 'url("/assets/images/codemirror/expand-diff-top.svg")',
         },
-        '&:first-child': {
-          '& .cm-collapseUnchangedGutterElement': {
-            borderTop: 'none',
-            marginTop: '-0.5rem',
-            backgroundImage: 'url("/assets/images/codemirror/expand-diff-top.svg")',
-          },
-        },
-        '&:last-child': {
-          '& .cm-collapseUnchangedGutterElement': {
-            borderBottom: 'none',
-            marginTop: '0.5rem',
-            backgroundImage: 'url("/assets/images/codemirror/expand-diff-bottom.svg")',
-          },
+      },
+      '&:last-child': {
+        '& .cm-collapseUnchangedGutterElement': {
+          borderBottom: 'none',
+          marginTop: '0.5rem',
+          backgroundImage: 'url("/assets/images/codemirror/expand-diff-bottom.svg")',
         },
       },
     },
@@ -200,30 +198,28 @@ export const codeCraftersDark = [
       // Collapse unchanged lines gutter
       '.cm-collapseUnchangedGutter': {
         '& .cm-gutterElement': {
-          '&.cm-collapseUnchangedBarSibling': {
+          '& .cm-collapseUnchangedGutterElement': {
+            borderColor: blendColors(tailwindColors.white, 0.075, blendColors(tailwindColors.sky['900'], 0.4, tailwindColors.slate['800'])),
+            backgroundColor: blendColors(tailwindColors.sky['900'], 0.4, tailwindColors.slate['800']),
+            backgroundImage: 'url("/assets/images/codemirror/expand-diff-middle-dark.svg")',
+          },
+
+          '&:hover': {
             '& .cm-collapseUnchangedGutterElement': {
-              borderColor: blendColors(tailwindColors.white, 0.075, blendColors(tailwindColors.sky['900'], 0.4, tailwindColors.slate['800'])),
-              backgroundColor: blendColors(tailwindColors.sky['900'], 0.4, tailwindColors.slate['800']),
-              backgroundImage: 'url("/assets/images/codemirror/expand-diff-middle-dark.svg")',
+              backgroundColor: blendColors(tailwindColors.sky['800'], 0.4, tailwindColors.slate['800']),
+              color: tailwindColors.sky['300'],
             },
+          },
 
-            '&:hover': {
-              '& .cm-collapseUnchangedGutterElement': {
-                backgroundColor: blendColors(tailwindColors.sky['800'], 0.4, tailwindColors.slate['800']),
-                color: tailwindColors.sky['300'],
-              },
+          '&:first-child': {
+            '& .cm-collapseUnchangedGutterElement': {
+              backgroundImage: 'url("/assets/images/codemirror/expand-diff-top-dark.svg")',
             },
+          },
 
-            '&:first-child': {
-              '& .cm-collapseUnchangedGutterElement': {
-                backgroundImage: 'url("/assets/images/codemirror/expand-diff-top-dark.svg")',
-              },
-            },
-
-            '&:last-child': {
-              '& .cm-collapseUnchangedGutterElement': {
-                backgroundImage: 'url("/assets/images/codemirror/expand-diff-bottom-dark.svg")',
-              },
+          '&:last-child': {
+            '& .cm-collapseUnchangedGutterElement': {
+              backgroundImage: 'url("/assets/images/codemirror/expand-diff-bottom-dark.svg")',
             },
           },
         },

--- a/app/utils/code-mirror-themes.ts
+++ b/app/utils/code-mirror-themes.ts
@@ -70,7 +70,6 @@ const BASE_STYLE = {
   '.cm-collapseUnchangedGutter': {
     '& .cm-gutterElement': {
       '& .cm-collapseUnchangedGutterElement': {
-        content: '""',
         position: 'absolute',
         left: 0,
         right: 0,
@@ -84,25 +83,24 @@ const BASE_STYLE = {
         backgroundPosition: 'center',
         backgroundSize: '12px 12px',
         cursor: 'pointer',
-      },
-      '&:hover': {
-        '& .cm-collapseUnchangedGutterElement': {
-          backgroundColor: tailwindColors.sky['100'],
-          color: tailwindColors.sky['800'],
-        },
-      },
-      '&:first-child': {
-        '& .cm-collapseUnchangedGutterElement': {
+
+        '&.cm-collapseUnchangedGutterElementFirst': {
           borderTop: 'none',
           marginTop: '-0.5rem',
           backgroundImage: 'url("/assets/images/codemirror/expand-diff-top.svg")',
         },
-      },
-      '&:last-child': {
-        '& .cm-collapseUnchangedGutterElement': {
+
+        '&.cm-collapseUnchangedGutterElementLast': {
           borderBottom: 'none',
           marginTop: '0.5rem',
           backgroundImage: 'url("/assets/images/codemirror/expand-diff-bottom.svg")',
+        },
+      },
+
+      '&:hover': {
+        '& .cm-collapseUnchangedGutterElement': {
+          backgroundColor: tailwindColors.sky['100'],
+          color: tailwindColors.sky['800'],
         },
       },
     },
@@ -202,24 +200,20 @@ export const codeCraftersDark = [
             borderColor: blendColors(tailwindColors.white, 0.075, blendColors(tailwindColors.sky['900'], 0.4, tailwindColors.slate['800'])),
             backgroundColor: blendColors(tailwindColors.sky['900'], 0.4, tailwindColors.slate['800']),
             backgroundImage: 'url("/assets/images/codemirror/expand-diff-middle-dark.svg")',
+
+            '&.cm-collapseUnchangedGutterElementFirst': {
+              backgroundImage: 'url("/assets/images/codemirror/expand-diff-top-dark.svg")',
+            },
+
+            '&.cm-collapseUnchangedGutterElementLast': {
+              backgroundImage: 'url("/assets/images/codemirror/expand-diff-bottom-dark.svg")',
+            },
           },
 
           '&:hover': {
             '& .cm-collapseUnchangedGutterElement': {
               backgroundColor: blendColors(tailwindColors.sky['800'], 0.4, tailwindColors.slate['800']),
               color: tailwindColors.sky['300'],
-            },
-          },
-
-          '&:first-child': {
-            '& .cm-collapseUnchangedGutterElement': {
-              backgroundImage: 'url("/assets/images/codemirror/expand-diff-top-dark.svg")',
-            },
-          },
-
-          '&:last-child': {
-            '& .cm-collapseUnchangedGutterElement': {
-              backgroundImage: 'url("/assets/images/codemirror/expand-diff-bottom-dark.svg")',
             },
           },
         },


### PR DESCRIPTION
Related to #1231 
Follow-up to https://github.com/codecrafters-io/frontend/pull/2535

### Brief

This adds latest improvements to the `collapseUnchangedGutter`, extracted from the [line comments PR](https://github.com/codecrafters-io/frontend/pull/2549), to greatly improve the former, and simplify & shrink the latter.

### Details

- Instead of rendering empty elements for each line in the `collapseUnchangedGutter` — render only the necessary ones (for each Collapse Unchanged Bar widget)
- Use native `uncollapseUnchanged` effect instead of custom ninja-DOM-searching logic to expand corresponding lines when `collapseUnchangedGutter` elements are clicked
- Better first/last gutter element detection & styling system instead of relying on `:first-child` and `:last-child`
- Simpler styling & classNames system

### Checklist

- [x] I've thoroughly self-reviewed my changes
- [x] I've added tests for my changes, unless they affect admin-only areas (or are otherwise not worth testing)
- [x] I've verified any visual changes using Percy (add a commit with `[percy]` in the message to trigger)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced functionality for collapsing and uncollapsing unchanged code lines in the code editor.
	- Improved gutter element rendering with more detailed line tracking.

- **Style**
	- Updated CodeMirror theme styling for the unchanged lines gutter.
	- Added specific styling for the first and last gutter elements.
	- Refined hover effects for gutter elements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->