### PR TITLE
chore: update version number and refine discount logic

### DIFF
--- a/app/controllers/pay.ts
+++ b/app/controllers/pay.ts
@@ -29,7 +29,7 @@ export default class PayController extends Controller {
   get additionalCheckoutSessionProperties() {
     return {
       pricingFrequency: this.selectedPricingFrequency,
-      promotionalDiscount: this.activeDiscountForYearlyPlan,
+      promotionalDiscount: this.selectedPricingFrequency === 'yearly' ? this.activeDiscountForYearlyPlan : null,
       regionalDiscount: this.shouldApplyRegionalDiscount ? this.model.regionalDiscount : null,
     };
   }

--- a/config/environment.js
+++ b/config/environment.js
@@ -48,7 +48,7 @@ module.exports = function (environment) {
 
       // Update the major version number to force all clients to update.
       // The minor version doesn't do anything at the moment, might use in the future.
-      version: `27.0.${process.env.VERCEL_GIT_COMMIT_SHA?.slice(0, 7) || 'dev'}`,
+      version: `28.0.${process.env.VERCEL_GIT_COMMIT_SHA?.slice(0, 7) || 'dev'}`,
     },
     fastboot: {
       hostWhitelist: [/^localhost:\d+$/],


### PR DESCRIPTION
Update the version number in the environment configuration to 
28.0 to ensure clients are prompted to update. Refine the logic 
for promotional discounts in the PayController to apply the 
discount only for yearly plans, improving clarity and 
functionality.