### PR TITLE
refactor: move UpgradePrompt component to new location

### DIFF
--- a/app/components/course-page/course-stage-step/inaccessible-community-solutions-list.hbs
+++ b/app/components/course-page/course-stage-step/inaccessible-community-solutions-list.hbs
@@ -15,7 +15,7 @@
   </:content>
   <:overlay>
     <div class="pt-4 px-4 sm:pt-8 sm:px-8 w-full">
-      <CoursePage::CourseStageStep::UpgradePrompt @featureSlugToHighlight="code-examples" class="w-full shadow-lg" />
+      <CoursePage::UpgradePrompt @featureSlugToHighlight="code-examples" class="w-full shadow-lg" />
     </div>
   </:overlay>
 </BlurredOverlay>

--- a/app/components/course-page/upgrade-prompt.hbs
+++ b/app/components/course-page/upgrade-prompt.hbs
@@ -11,7 +11,7 @@
       </div>
 
       <div class="prose dark:prose-invert prose-compact prose-sm @[640px]:prose-base py-3" data-test-upgrade-prompt-secondary-copy>
-        {{#if this.isLoadingRegionalDiscount}}
+        {{#if this.isLoadingDiscounts}}
           <p>
             Plans start at $30/month when billed annually.
           </p>

--- a/app/components/course-page/upgrade-prompt.ts
+++ b/app/components/course-page/upgrade-prompt.ts
@@ -101,7 +101,7 @@ export default class UpgradePromptComponent extends Component<Signature> {
   @waitFor
   async handleDidInsert(): Promise<void> {
     this.regionalDiscount = await this.store.createRecord('regional-discount').fetchCurrent();
-    await this.authenticator.syncCurrentUser();
+    // await this.authenticator.syncCurrentUser();
     this.isLoadingDiscounts = false;
   }
 }

--- a/app/components/course-page/upgrade-prompt.ts
+++ b/app/components/course-page/upgrade-prompt.ts
@@ -60,7 +60,7 @@ export default class UpgradePromptComponent extends Component<Signature> {
   @service declare authenticator: AuthenticatorService;
   @service declare store: Store;
 
-  @tracked isLoadingRegionalDiscount: boolean = true;
+  @tracked isLoadingDiscounts: boolean = true;
   @tracked regionalDiscount: RegionalDiscountModel | null = null;
 
   get activeDiscountForYearlyPlan() {
@@ -101,12 +101,13 @@ export default class UpgradePromptComponent extends Component<Signature> {
   @waitFor
   async handleDidInsert(): Promise<void> {
     this.regionalDiscount = await this.store.createRecord('regional-discount').fetchCurrent();
-    this.isLoadingRegionalDiscount = false;
+    await this.authenticator.syncCurrentUser();
+    this.isLoadingDiscounts = false;
   }
 }
 
 declare module '@glint/environment-ember-loose/registry' {
   export default interface Registry {
-    'CoursePage::CourseStageStep::UpgradePrompt': typeof UpgradePromptComponent;
+    'CoursePage::UpgradePrompt': typeof UpgradePromptComponent;
   }
 }

--- a/app/components/upgrade-modal.hbs
+++ b/app/components/upgrade-modal.hbs
@@ -5,7 +5,7 @@
   {{did-insert this.handleDidInsert}}
   ...attributes
 >
-  <CoursePage::CourseStageStep::UpgradePrompt @featureSlugToHighlight={{@featureSlugToHighlight}} class="w-full" />
+  <CoursePage::UpgradePrompt @featureSlugToHighlight={{@featureSlugToHighlight}} class="w-full" />
 
   <div class="absolute right-0 top-0">
     <button type="button" class="w-12 h-12 flex items-center justify-center" {{on "click" @onClose}}>

--- a/app/components/upgrade-modal.ts
+++ b/app/components/upgrade-modal.ts
@@ -1,5 +1,5 @@
 import Component from '@glimmer/component';
-import type { Signature as UpgradePromptSignature } from './course-page/course-stage-step/upgrade-prompt';
+import type { Signature as UpgradePromptSignature } from './course-page/upgrade-prompt';
 import { action } from '@ember/object';
 import type AnalyticsEventTrackerService from 'codecrafters-frontend/services/analytics-event-tracker';
 import { service } from '@ember/service';

--- a/app/templates/course/stage/instructions.hbs
+++ b/app/templates/course/stage/instructions.hbs
@@ -5,7 +5,7 @@
 >
   <div class="pt-6 pb-32 px-3 md:px-6 lg:px-10" {{did-update this.handleDidUpdateTestsStatus this.currentStep.testsStatus}}>
     {{#if this.shouldShowUpgradePrompt}}
-      <CoursePage::CourseStageStep::UpgradePrompt @featureSlugToHighlight="content" class="mb-6" />
+      <CoursePage::UpgradePrompt @featureSlugToHighlight="content" class="mb-6" />
     {{/if}}
 
     {{#if this.shouldShowFeedbackPrompt}}


### PR DESCRIPTION
Moves the UpgradePrompt component from the course-stage-step 
directory to the course-page directory. This change improves 
the organization of components by grouping related files 
together, enhancing maintainability and clarity in the codebase.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Simplified component structure by moving `UpgradePrompt` to a higher-level namespace
	- Updated component references across multiple files to reflect new component location
	- Renamed loading state variable to be more generic (`isLoadingDiscounts`)

- **Chores**
	- Updated import paths and component registrations to match new component structure

<!-- end of auto-generated comment: release notes by coderabbit.ai -->