### PR TITLE
refactor: improve caching of node_modules in CI workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,7 +30,7 @@ jobs:
       # Caching node_modules is faster than using setup-node's cache: 'npm' (https://www.voorhoede.nl/en/blog/super-fast-npm-install-on-github-actions/)
       - id: cache
         name: Cache dependencies
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ./node_modules
           key: modules-v1-${{ hashFiles('package-lock.json') }}
@@ -133,7 +133,7 @@ jobs:
       # Caching node_modules is faster than using setup-node's cache: 'npm' (https://www.voorhoede.nl/en/blog/super-fast-npm-install-on-github-actions/)
       - id: cache
         name: Cache dependencies
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ./node_modules
           key: modules-v1-${{ hashFiles('package-lock.json') }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,9 +26,18 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: '20'
-          cache: 'npm'
 
-      - run: npm ci --prefer-offline --ignore-scripts --no-audit --no-fund
+      # Caching node_modules is faster than using setup-node's cache: 'npm' (https://www.voorhoede.nl/en/blog/super-fast-npm-install-on-github-actions/)
+      - id: cache
+        name: Cache dependencies
+        uses: actions/cache@v3
+        with:
+          path: ./node_modules
+          key: modules-v1-${{ hashFiles('package-lock.json') }}
+
+      - name: Install dependencies
+        if: steps.cache.outputs.cache-hit != 'true'
+        run: npm ci --ignore-scripts
 
       - run: git fetch origin ${{ github.event.pull_request.head.sha }}
 
@@ -120,8 +129,18 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: '20'
-          cache: 'npm'
 
-      - run: npm ci --prefer-offline --ignore-scripts --no-audit --no-fund
+      # Caching node_modules is faster than using setup-node's cache: 'npm' (https://www.voorhoede.nl/en/blog/super-fast-npm-install-on-github-actions/)
+      - id: cache
+        name: Cache dependencies
+        uses: actions/cache@v3
+        with:
+          path: ./node_modules
+          key: modules-v1-${{ hashFiles('package-lock.json') }}
+
+      - name: Install dependencies
+        if: steps.cache.outputs.cache-hit != 'true'
+        run: npm ci --ignore-scripts
+
       - run: npm run tailwind:build
       - run: npm run lint


### PR DESCRIPTION
Enhance the GitHub Actions workflow by replacing the default npm cache 
with a dedicated caching step for node_modules. This change speeds up 
dependency installation by utilizing the actions/cache@v3 action, 
which caches the node_modules directory based on the package-lock.json 
hash. The installation command is updated to run only if the cache 
is not hit, optimizing the CI process.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
	- Updated GitHub Actions workflow to optimize dependency caching.
	- Improved CI process efficiency by implementing a smarter dependency installation strategy.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->