### PR TITLE
Stage 2 experiment: Show Language Guide Before Solution

### DIFF
--- a/app/components/course-page/course-stage-step/second-stage-tutorial-card/implement-solution-step.hbs
+++ b/app/components/course-page/course-stage-step/second-stage-tutorial-card/implement-solution-step.hbs
@@ -13,12 +13,8 @@
 
 {{#if this.canSeeLanguageGuideBeforeSolution}}
   {{#if @languageGuide}}
-    <div class="mt-6 mb-3 prose dark:prose-invert font-semibold">
-      Guide:
-    </div>
-
     <div
-      class="prose dark:prose-invert has-prism-highlighting"
+      class="prose dark:prose-invert has-prism-highlighting mt-4"
       {{highlight-code-blocks @languageGuide.markdownForBeginner}}
       data-test-language-guide-card
     >
@@ -27,10 +23,6 @@
   {{/if}}
 
   {{#if this.solution}}
-    <div class="mt-6 prose prose-compact dark:prose-invert font-semibold">
-      Solution:
-    </div>
-
     <BlurredOverlay
       class="mb-3 group"
       @isBlurred={{this.solutionIsBlurred}}

--- a/app/components/course-page/course-stage-step/second-stage-tutorial-card/implement-solution-step.hbs
+++ b/app/components/course-page/course-stage-step/second-stage-tutorial-card/implement-solution-step.hbs
@@ -11,61 +11,131 @@
   {{/unless}}
 </div>
 
-{{#if this.solution}}
-  <BlurredOverlay
-    class="mb-3 group"
-    @isBlurred={{this.solutionIsBlurred}}
-    @overlayClass="inset-px rounded cursor-pointer group-hover:backdrop-blur-[3px] group-hover:bg-gray-50/20 dark:bg-gray-900/20 dark:group-hover:bg-gray-900/0"
-  >
-    <:content>
-      <div class="grid gap-3 mb-3">
-        {{#each this.solution.changedFiles as |changedFile|}}
-          {{! Extra if condition convinces typescript that solution isn't null }}
-          {{#if this.solution}}
-            <FileDiffCard
-              @filename={{changedFile.filename}}
-              @code={{changedFile.diff}}
-              @language={{this.solution.language.slug}}
-              data-test-file-diff-card
-            />
-          {{/if}}
-        {{/each}}
-      </div>
+{{#if this.canSeeLanguageGuideBeforeSolution}}
+  {{#if @languageGuide}}
+    <div class="mt-6 mb-3 prose dark:prose-invert font-semibold">
+      Guide:
+    </div>
 
-      {{#unless this.solutionIsBlurred}}
-        <TertiaryButton
-          class="w-full mb-6 flex justify-center items-center gap-2 dark:bg-transparent dark:text-gray-200 dark:border-white/5 dark:hover:border-gray-700/60 dark:bg-gray-800 dark:hover:bg-gray-700/50"
-          {{on "click" this.handleHideSolutionButtonClick}}
-          data-test-hide-solution-button
-        >
-          {{svg-jar "eye-off" class="size-4"}}
-          Hide Solution
-        </TertiaryButton>
+    <div
+      class="prose dark:prose-invert has-prism-highlighting"
+      {{highlight-code-blocks @languageGuide.markdownForBeginner}}
+      data-test-language-guide-card
+    >
+      {{markdown-to-html @languageGuide.markdownForBeginner}}
+    </div>
+  {{/if}}
 
-        {{#if @languageGuide}}
-          <div
-            class="prose dark:prose-invert has-prism-highlighting"
-            {{highlight-code-blocks @languageGuide.markdownForBeginner}}
-            data-test-language-guide-card
-          >
-            {{markdown-to-html @languageGuide.markdownForBeginner}}
-          </div>
-        {{/if}}
-      {{/unless}}
-    </:content>
+  {{#if this.solution}}
+    <div class="mt-6 prose prose-compact dark:prose-invert font-semibold">
+      Solution:
+    </div>
 
-    <:overlay>
-      <SecondaryButton
-        class="self-center bg-white group-hover:bg-teal-50 dark:bg-gray-900 dark:group-hover:bg-gray-900/80 backdrop-blur-3xl group-hover:text-teal-600 dark:group-hover:text-teal-400 group-hover:border-teal-600 dark:group-hover:border-teal-400"
-        data-test-reveal-solution-button
-      >
-        <div class="flex items-center gap-2">
-          {{svg-jar "eye" class="size-6"}}
-          <span>Click to reveal solution</span>
+    <BlurredOverlay
+      class="mb-3 group"
+      @isBlurred={{this.solutionIsBlurred}}
+      @overlayClass="inset-px rounded cursor-pointer group-hover:backdrop-blur-[3px] group-hover:bg-gray-50/20 dark:bg-gray-900/20 dark:group-hover:bg-gray-900/0"
+    >
+      <:content>
+        <div class="grid gap-3 mt-6 mb-3">
+
+          {{#each this.solution.changedFiles as |changedFile|}}
+            {{! Extra if condition convinces typescript that solution isn't null }}
+            {{#if this.solution}}
+              <FileDiffCard
+                @filename={{changedFile.filename}}
+                @code={{changedFile.diff}}
+                @language={{this.solution.language.slug}}
+                data-test-file-diff-card
+              />
+            {{/if}}
+          {{/each}}
         </div>
-      </SecondaryButton>
-      <button class="absolute inset-0" type="button" {{on "click" this.handleRevealSolutionButtonClick}} data-test-solution-blurred-overlay>
-      </button>
-    </:overlay>
-  </BlurredOverlay>
+
+        {{#unless this.solutionIsBlurred}}
+          <TertiaryButton
+            class="w-full mb-6 flex justify-center items-center gap-2 dark:bg-transparent dark:text-gray-200 dark:border-white/5 dark:hover:border-gray-700/60 dark:bg-gray-800 dark:hover:bg-gray-700/50"
+            {{on "click" this.handleHideSolutionButtonClick}}
+            data-test-hide-solution-button
+          >
+            {{svg-jar "eye-off" class="size-4"}}
+            Hide Solution
+          </TertiaryButton>
+        {{/unless}}
+      </:content>
+
+      <:overlay>
+        <SecondaryButton
+          class="self-center bg-white group-hover:bg-teal-50 dark:bg-gray-900 dark:group-hover:bg-gray-900/80 backdrop-blur-3xl group-hover:text-teal-600 dark:group-hover:text-teal-400 group-hover:border-teal-600 dark:group-hover:border-teal-400"
+          data-test-reveal-solution-button
+        >
+          <div class="flex items-center gap-2">
+            {{svg-jar "eye" class="size-6"}}
+            <span>Click to reveal solution</span>
+          </div>
+        </SecondaryButton>
+        <button class="absolute inset-0" type="button" {{on "click" this.handleRevealSolutionButtonClick}} data-test-solution-blurred-overlay>
+        </button>
+      </:overlay>
+    </BlurredOverlay>
+  {{/if}}
+{{else}}
+  {{#if this.solution}}
+    <BlurredOverlay
+      class="mb-3 group"
+      @isBlurred={{this.solutionIsBlurred}}
+      @overlayClass="inset-px rounded cursor-pointer group-hover:backdrop-blur-[3px] group-hover:bg-gray-50/20 dark:bg-gray-900/20 dark:group-hover:bg-gray-900/0"
+    >
+      <:content>
+        <div class="grid gap-3 mb-3">
+          {{#each this.solution.changedFiles as |changedFile|}}
+            {{! Extra if condition convinces typescript that solution isn't null }}
+            {{#if this.solution}}
+              <FileDiffCard
+                @filename={{changedFile.filename}}
+                @code={{changedFile.diff}}
+                @language={{this.solution.language.slug}}
+                data-test-file-diff-card
+              />
+            {{/if}}
+          {{/each}}
+        </div>
+
+        {{#unless this.solutionIsBlurred}}
+          <TertiaryButton
+            class="w-full mb-6 flex justify-center items-center gap-2 dark:bg-transparent dark:text-gray-200 dark:border-white/5 dark:hover:border-gray-700/60 dark:bg-gray-800 dark:hover:bg-gray-700/50"
+            {{on "click" this.handleHideSolutionButtonClick}}
+            data-test-hide-solution-button
+          >
+            {{svg-jar "eye-off" class="size-4"}}
+            Hide Solution
+          </TertiaryButton>
+
+          {{#if @languageGuide}}
+            <div
+              class="prose dark:prose-invert has-prism-highlighting"
+              {{highlight-code-blocks @languageGuide.markdownForBeginner}}
+              data-test-language-guide-card
+            >
+              {{markdown-to-html @languageGuide.markdownForBeginner}}
+            </div>
+          {{/if}}
+        {{/unless}}
+      </:content>
+
+      <:overlay>
+        <SecondaryButton
+          class="self-center bg-white group-hover:bg-teal-50 dark:bg-gray-900 dark:group-hover:bg-gray-900/80 backdrop-blur-3xl group-hover:text-teal-600 dark:group-hover:text-teal-400 group-hover:border-teal-600 dark:group-hover:border-teal-400"
+          data-test-reveal-solution-button
+        >
+          <div class="flex items-center gap-2">
+            {{svg-jar "eye" class="size-6"}}
+            <span>Click to reveal solution</span>
+          </div>
+        </SecondaryButton>
+        <button class="absolute inset-0" type="button" {{on "click" this.handleRevealSolutionButtonClick}} data-test-solution-blurred-overlay>
+        </button>
+      </:overlay>
+    </BlurredOverlay>
+  {{/if}}
 {{/if}}

--- a/app/components/course-page/course-stage-step/second-stage-tutorial-card/implement-solution-step.ts
+++ b/app/components/course-page/course-stage-step/second-stage-tutorial-card/implement-solution-step.ts
@@ -2,7 +2,9 @@ import Component from '@glimmer/component';
 import type RepositoryModel from 'codecrafters-frontend/models/repository';
 import type CourseStageModel from 'codecrafters-frontend/models/course-stage';
 import type CourseStageLanguageGuideModel from 'codecrafters-frontend/models/course-stage-language-guide';
+import type FeatureFlagsService from 'codecrafters-frontend/services/feature-flags';
 import { action } from '@ember/object';
+import { inject as service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 
 interface Signature {
@@ -17,7 +19,12 @@ interface Signature {
 }
 
 export default class ImplementSolutionStepComponent extends Component<Signature> {
+  @service declare featureFlags: FeatureFlagsService;
   @tracked solutionIsBlurred = true;
+
+  get canSeeLanguageGuideBeforeSolution() {
+    return this.featureFlags.canSeeLanguageGuideBeforeSolutionForStage2;
+  }
 
   get solution() {
     return this.args.repository.secondStageSolution;

--- a/app/services/feature-flags.ts
+++ b/app/services/feature-flags.ts
@@ -18,6 +18,10 @@ export default class FeatureFlagsService extends Service {
     return Boolean(this.currentUser && (this.currentUser.isStaff || this.currentUser.isConceptAuthor));
   }
 
+  get canSeeLanguageGuideBeforeSolutionForStage2(): boolean {
+    return Boolean(this.currentUser?.isStaff || this.getFeatureFlagValue('can-see-language-guide-before-solution-for-stage-2') === 'test');
+  }
+
   get canSeeSplitUpGitCommandsForStage1(): boolean {
     return Boolean(this.currentUser?.isStaff || this.getFeatureFlagValue('can-see-split-up-git-commands-for-stage-1') === 'test');
   }


### PR DESCRIPTION
**Checklist**:

- [x] I've thoroughly self-reviewed my changes
- [ ] I've added tests for my changes, unless they affect admin-only areas (or are otherwise not worth testing)
- [ ] I've verified any visual changes using Percy (add a commit with `[percy]` in the message to trigger)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a feature flag to conditionally display the language guide before the solution.
  - Introduced a new method to determine user access to the language guide based on roles and feature flags.

- **Improvements**
  - Enhanced the organization of template logic for better clarity and user experience.
  - Streamlined rendering of the solution with improved visibility controls based on user context.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->