### PR TITLE
refactor: update static options in ember-cli-build.js

### DIFF
--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -88,9 +88,7 @@ module.exports = function (defaults) {
   const compiledApp = require('@embroider/compat').compatBuild(app, Webpack, {
     staticAddonTestSupportTrees: true,
     staticAddonTrees: true,
-    staticHelpers: true,
-    staticModifiers: true,
-    staticComponents: true,
+    staticInvokables: true,
     splitAtRoutes: ['badges', 'concept', 'code-walkthrough', 'course', 'course-admin', 'concept-admin', 'demo'], // can also be a RegExp
     packagerOptions: {
       publicAssetURL: '/',


### PR DESCRIPTION
Remove staticHelpers, staticModifiers, and staticComponents options.  
Add staticInvokables option to improve compatibility with  
Embroider and streamline the build process.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Simplified build configuration by consolidating static helper, modifier, and component options into a single `staticInvokables` setting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->