### PR TITLE
fix: update isPaid condition for course stages

### DIFF
--- a/mirage/utils/create-course-from-data.js
+++ b/mirage/utils/create-course-from-data.js
@@ -98,7 +98,7 @@ function courseStageAttributesFromData(courseStageData, positionWithinCourse, po
     descriptionMarkdownTemplate: courseStageData.description_md,
     difficulty: courseStageData.difficulty,
     testerSourceCodeUrl: courseStageData.tester_source_code_url,
-    isPaid: positionWithinCourse > 3,
+    isPaid: positionWithinCourse >= 3,
     primaryExtensionSlug: courseStageData.primary_extension_slug,
     secondaryExtensionSlugs: courseStageData.secondary_extension_slugs || [],
   };


### PR DESCRIPTION
Adjust the isPaid condition to include courses at position 3. This 
change ensures that the correct payment status is applied to 
courses that are at the third position or higher.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Adjusted course stage pricing logic to more accurately determine paid stages based on course position.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->