### PR TITLE
fix: enable user synchronization on upgrade prompt

### DIFF
--- a/app/components/course-page/upgrade-prompt.ts
+++ b/app/components/course-page/upgrade-prompt.ts
@@ -101,7 +101,7 @@ export default class UpgradePromptComponent extends Component<Signature> {
   @waitFor
   async handleDidInsert(): Promise<void> {
     this.regionalDiscount = await this.store.createRecord('regional-discount').fetchCurrent();
-    // await this.authenticator.syncCurrentUser();
+    await this.authenticator.syncCurrentUser();
     this.isLoadingDiscounts = false;
   }
 }


### PR DESCRIPTION
Enables user synchronization in the upgrade prompt component 
by uncommenting the syncCurrentUser method. This ensures that 
the current user's data is properly synchronized when the 
component is inserted, improving the accuracy of user-related 
information displayed on the course page.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved user synchronization process during component initialization
	- Ensured current user is properly synchronized with authenticator service

<!-- end of auto-generated comment: release notes by coderabbit.ai -->