### PR TITLE
Add discount timer badge to header

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,9 @@
 /npm-debug.log*
 /testem.log
 /yarn-error.log
+/.history/
+/.lh/
+/.idea/
 
 # ember-try
 /.node_modules.ember-try/

--- a/.prettierignore
+++ b/.prettierignore
@@ -21,3 +21,6 @@
 # index.html ends up weirdly formatted
 /app/index.html
 /tests/index.html
+
+# code-mirror-gutter-rs is cloned from @codemirror/view
+/app/utils/code-mirror-gutter-rs.ts

--- a/app/components/billing-status-badge/discount-timer-badge.hbs
+++ b/app/components/billing-status-badge/discount-timer-badge.hbs
@@ -1,0 +1,26 @@
+<LinkTo
+  @route="pay"
+  class="flex bg-gradient-to-b from-gray-600 to-gray-900 border border-yellow-600 rounded shadow-sm
+    {{if (eq @size 'small') 'px-1.5 py-1'}}
+    {{if (eq @size 'large') 'px-2 py-1.5'}}"
+  data-test-discount-timer-badge
+  ...attributes
+>
+  <span class="flex items-center gap-x-1">
+    <div class="flex-shrink-0">
+      <img src={{this.iconImage}} alt="treasure" class="w-4 animate-spin-once" />
+    </div>
+    <span class="bg-gradient-to-b from-yellow-100 to-amber-500 text-transparent bg-clip-text inline-block text-xs font-semibold flex-shrink-0">
+      43 hours left
+      {{! 1 hour left }}
+      {{! 59 minutes left }}
+      {{! 5 minutes left }}
+      {{! 1 minute left }}
+      {{! 59 seconds left }}
+      {{! 1 second left }}
+      {{! should not be rendered afterwards! }}
+    </span>
+  </span>
+
+  <EmberTooltip @text={{this.tooltipText}} />
+</LinkTo>

--- a/app/components/billing-status-badge/discount-timer-badge.hbs
+++ b/app/components/billing-status-badge/discount-timer-badge.hbs
@@ -11,7 +11,8 @@
       <img src={{this.iconImage}} alt="treasure" class="w-4 animate-spin-once" />
     </div>
     <span class="bg-gradient-to-b from-yellow-100 to-amber-500 text-transparent bg-clip-text inline-block text-xs font-semibold flex-shrink-0">
-      {{this.timeLeft}} left
+      {{this.timeLeft}}
+      left
     </span>
   </span>
 

--- a/app/components/billing-status-badge/discount-timer-badge.hbs
+++ b/app/components/billing-status-badge/discount-timer-badge.hbs
@@ -11,14 +11,7 @@
       <img src={{this.iconImage}} alt="treasure" class="w-4 animate-spin-once" />
     </div>
     <span class="bg-gradient-to-b from-yellow-100 to-amber-500 text-transparent bg-clip-text inline-block text-xs font-semibold flex-shrink-0">
-      43 hours left
-      {{! 1 hour left }}
-      {{! 59 minutes left }}
-      {{! 5 minutes left }}
-      {{! 1 minute left }}
-      {{! 59 seconds left }}
-      {{! 1 second left }}
-      {{! should not be rendered afterwards! }}
+      {{this.timeLeft}} left
     </span>
   </span>
 

--- a/app/components/billing-status-badge/discount-timer-badge.ts
+++ b/app/components/billing-status-badge/discount-timer-badge.ts
@@ -2,7 +2,7 @@ import Component from '@glimmer/component';
 import iconImage from '/assets/images/icons/money.svg';
 import { service } from '@ember/service';
 import type TimeService from 'codecrafters-frontend/services/time';
-import { formatTimeLeft } from 'codecrafters-frontend/utils/time-formatting';
+import { formatTimeDurationForCoundown } from 'codecrafters-frontend/utils/time-formatting';
 
 interface Signature {
   Element: HTMLAnchorElement;
@@ -21,7 +21,7 @@ export default class DiscountTimerBadgeComponent extends Component<Signature> {
   expiresAt = new Date(new Date().getTime() + 23 * 60 * 60 * 1000);
 
   get tooltipText() {
-    return `Upgrade in ${formatTimeLeft(this.expiresAt, this.time.currentTime)} to get 40% off the annual plan. Click to view details.`;
+    return `Upgrade in ${formatTimeDurationForCoundown(this.expiresAt, this.time.currentTime)} to get 40% off the annual plan. Click to view details.`;
   }
 }
 

--- a/app/components/billing-status-badge/discount-timer-badge.ts
+++ b/app/components/billing-status-badge/discount-timer-badge.ts
@@ -2,7 +2,7 @@ import Component from '@glimmer/component';
 import iconImage from '/assets/images/icons/money.svg';
 import { service } from '@ember/service';
 import type TimeService from 'codecrafters-frontend/services/time';
-import { formatTimeDurationForBadge, formatTimeDurationForCoundown } from 'codecrafters-frontend/utils/time-formatting';
+import { formatTimeDurationForBadge, formatTimeDurationForCountdown } from 'codecrafters-frontend/utils/time-formatting';
 import type PromotionalDiscountModel from 'codecrafters-frontend/models/promotional-discount';
 
 interface Signature {
@@ -32,7 +32,7 @@ export default class DiscountTimerBadgeComponent extends Component<Signature> {
   }
 
   get tooltipText() {
-    return `Upgrade in ${formatTimeDurationForCoundown(this.expiresAt, this.time.currentTime)} to get 40% off the annual plan. Click to view details.`;
+    return `Upgrade in ${formatTimeDurationForCountdown(this.expiresAt, this.time.currentTime)} to get 40% off the annual plan. Click to view details.`;
   }
 }
 

--- a/app/components/billing-status-badge/discount-timer-badge.ts
+++ b/app/components/billing-status-badge/discount-timer-badge.ts
@@ -1,0 +1,32 @@
+import Component from '@glimmer/component';
+import iconImage from '/assets/images/icons/money.svg';
+import { service } from '@ember/service';
+import type TimeService from 'codecrafters-frontend/services/time';
+import { formatTimeLeft } from 'codecrafters-frontend/utils/time-formatting';
+
+interface Signature {
+  Element: HTMLAnchorElement;
+
+  Args: {
+    size: 'small' | 'large'; // small is used for the menu bar, large is used for the course page header
+  };
+}
+
+export default class DiscountTimerBadgeComponent extends Component<Signature> {
+  iconImage = iconImage;
+
+  @service declare time: TimeService;
+
+  // (TODO: Use actual discount expiration date)
+  expiresAt = new Date(new Date().getTime() + 23 * 60 * 60 * 1000);
+
+  get tooltipText() {
+    return `Upgrade in ${formatTimeLeft(this.expiresAt, this.time.currentTime)} to get 40% off the annual plan. Click to view details.`;
+  }
+}
+
+declare module '@glint/environment-ember-loose/registry' {
+  export default interface Registry {
+    'BillingStatusBadge::DiscountTimerBadge': typeof DiscountTimerBadgeComponent;
+  }
+}

--- a/app/components/billing-status-badge/discount-timer-badge.ts
+++ b/app/components/billing-status-badge/discount-timer-badge.ts
@@ -2,12 +2,14 @@ import Component from '@glimmer/component';
 import iconImage from '/assets/images/icons/money.svg';
 import { service } from '@ember/service';
 import type TimeService from 'codecrafters-frontend/services/time';
-import { formatTimeDurationForCoundown } from 'codecrafters-frontend/utils/time-formatting';
+import { formatTimeDurationForBadge, formatTimeDurationForCoundown } from 'codecrafters-frontend/utils/time-formatting';
+import type PromotionalDiscountModel from 'codecrafters-frontend/models/promotional-discount';
 
 interface Signature {
   Element: HTMLAnchorElement;
 
   Args: {
+    discount: PromotionalDiscountModel;
     size: 'small' | 'large'; // small is used for the menu bar, large is used for the course page header
   };
 }
@@ -17,8 +19,17 @@ export default class DiscountTimerBadgeComponent extends Component<Signature> {
 
   @service declare time: TimeService;
 
-  // (TODO: Use actual discount expiration date)
-  expiresAt = new Date(new Date().getTime() + 23 * 60 * 60 * 1000);
+  get expiresAt() {
+    return this.args.discount.expiresAt;
+  }
+
+  get isExpired() {
+    return this.args.discount.isExpired;
+  }
+
+  get timeLeft() {
+    return formatTimeDurationForBadge(this.expiresAt, this.time.currentTime);
+  }
 
   get tooltipText() {
     return `Upgrade in ${formatTimeDurationForCoundown(this.expiresAt, this.time.currentTime)} to get 40% off the annual plan. Click to view details.`;

--- a/app/components/code-mirror.ts
+++ b/app/components/code-mirror.ts
@@ -38,6 +38,7 @@ import { languages } from '@codemirror/language-data';
 import { markdown } from '@codemirror/lang-markdown';
 import { highlightNewlines } from 'codecrafters-frontend/utils/code-mirror-highlight-newlines';
 import { collapseUnchangedGutter } from 'codecrafters-frontend/utils/code-mirror-collapse-unchanged-gutter';
+import { highlightActiveLineGutter as highlightActiveLineGutterRS } from 'codecrafters-frontend/utils/code-mirror-gutter-rs';
 
 function generateHTMLElement(src: string): HTMLElement {
   const div = document.createElement('div');
@@ -66,7 +67,8 @@ const OPTION_HANDLERS: { [key: string]: OptionHandler } = {
   drawSelection: ({ drawSelection: enabled }) => (enabled ? [drawSelection()] : []),
   dropCursor: ({ dropCursor: enabled }) => (enabled ? [dropCursor()] : []),
   editable: ({ editable }) => [EditorView.editable.of(!!editable)],
-  highlightActiveLine: ({ highlightActiveLine: enabled }) => (enabled ? [highlightActiveLine(), highlightActiveLineGutter()] : []),
+  highlightActiveLine: ({ highlightActiveLine: enabled }) =>
+    enabled ? [highlightActiveLine(), highlightActiveLineGutter(), highlightActiveLineGutterRS()] : [],
   highlightNewlines: ({ highlightNewlines: enabled }) => (enabled ? [highlightNewlines()] : []),
   highlightSelectionMatches: ({ highlightSelectionMatches: enabled }) => (enabled ? [highlightSelectionMatches()] : []),
   highlightSpecialChars: ({ highlightSpecialChars: enabled }) => (enabled ? [highlightSpecialChars()] : []),

--- a/app/components/course-page/header/navigation-controls.hbs
+++ b/app/components/course-page/header/navigation-controls.hbs
@@ -28,10 +28,14 @@
       {{/if}}
 
       {{! TODO: Extract this into BillingStatusBadgeComponent, re-use in course page header and here? }}
-      {{!-- {{#if this.billingStatusDisplay.shouldShowVipBadge}}
+      {{#if this.billingStatusDisplay.shouldShowVipBadge}}
         <Header::VipBadge />
       {{else if this.billingStatusDisplay.shouldShowMemberBadge}}
         <Header::MemberBadge />
+      {{else if this.activeDiscountForYearlyPlan}}
+        {{#if this.canSeeDiscountCountdown}}
+          <BillingStatusBadge::DiscountTimerBadge @discount={{this.activeDiscountForYearlyPlan}} @size="large" />
+        {{/if}}
       {{else if this.billingStatusDisplay.shouldShowFreeWeeksLeftButton}}
         <Header::FreeWeeksLeftButton />
       {{else if this.billingStatusDisplay.shouldShowUpgradeButton}}
@@ -41,10 +45,6 @@
             {{svg-jar "lock-open" class="w-4"}}
           </span>
         </PrimaryLinkButton>
-      {{/if}} --}}
-
-      {{#if this.activeDiscountForYearlyPlan}}
-        <BillingStatusBadge::DiscountTimerBadge @discount={{this.activeDiscountForYearlyPlan}} @size="large" />
       {{/if}}
 
       <LinkTo

--- a/app/components/course-page/header/navigation-controls.hbs
+++ b/app/components/course-page/header/navigation-controls.hbs
@@ -43,7 +43,9 @@
         </PrimaryLinkButton>
       {{/if}} --}}
 
-      <BillingStatusBadge::DiscountTimerBadge @size="large" />
+      {{#if this.activeDiscountForYearlyPlan}}
+        <BillingStatusBadge::DiscountTimerBadge @discount={{this.activeDiscountForYearlyPlan}} @size="large" />
+      {{/if}}
 
       <LinkTo
         @route="catalog"

--- a/app/components/course-page/header/navigation-controls.hbs
+++ b/app/components/course-page/header/navigation-controls.hbs
@@ -27,7 +27,8 @@
         </TertiaryLinkButton>
       {{/if}}
 
-      {{#if this.billingStatusDisplay.shouldShowVipBadge}}
+      {{! TODO: Extract this into BillingStatusBadgeComponent, re-use in course page header and here? }}
+      {{!-- {{#if this.billingStatusDisplay.shouldShowVipBadge}}
         <Header::VipBadge />
       {{else if this.billingStatusDisplay.shouldShowMemberBadge}}
         <Header::MemberBadge />
@@ -40,7 +41,9 @@
             {{svg-jar "lock-open" class="w-4"}}
           </span>
         </PrimaryLinkButton>
-      {{/if}}
+      {{/if}} --}}
+
+      <BillingStatusBadge::DiscountTimerBadge @size="large" />
 
       <LinkTo
         @route="catalog"

--- a/app/components/course-page/header/navigation-controls.ts
+++ b/app/components/course-page/header/navigation-controls.ts
@@ -8,6 +8,7 @@ import { inject as service } from '@ember/service';
 import CourseStageStep from 'codecrafters-frontend/utils/course-page-step-list/course-stage-step';
 import type AuthenticatorService from 'codecrafters-frontend/services/authenticator';
 import type FeatureFlagsService from 'codecrafters-frontend/services/feature-flags';
+import type PromotionalDiscountModel from 'codecrafters-frontend/models/promotional-discount';
 
 interface Signature {
   Element: HTMLDivElement;
@@ -27,6 +28,10 @@ export default class NavigationControlsComponent extends Component<Signature> {
   @service declare billingStatusDisplay: BillingStatusDisplayService;
   @service declare featureFlags: FeatureFlagsService;
   @service declare router: RouterService;
+
+  get activeDiscountForYearlyPlan(): PromotionalDiscountModel | null {
+    return this.currentUser?.activeDiscountForYearlyPlan || null;
+  }
 
   get currentStepAsCourseStageStep() {
     return this.args.currentStep as CourseStageStep;

--- a/app/components/course-page/header/navigation-controls.ts
+++ b/app/components/course-page/header/navigation-controls.ts
@@ -33,6 +33,10 @@ export default class NavigationControlsComponent extends Component<Signature> {
     return this.currentUser?.activeDiscountForYearlyPlan || null;
   }
 
+  get canSeeDiscountCountdown() {
+    return this.featureFlags.canSeeDiscountCountdown;
+  }
+
   get currentStepAsCourseStageStep() {
     return this.args.currentStep as CourseStageStep;
   }

--- a/app/components/header.hbs
+++ b/app/components/header.hbs
@@ -59,10 +59,14 @@
           </FeedbackButton>
 
           {{! TODO: Extract this into BillingStatusBadgeComponent, re-use in course page header and here? }}
-          {{!-- {{#if this.billingStatusDisplay.shouldShowVipBadge}}
+          {{#if this.billingStatusDisplay.shouldShowVipBadge}}
             <Header::VipBadge class="mr-3" />
           {{else if this.billingStatusDisplay.shouldShowMemberBadge}}
             <Header::MemberBadge class="mr-3" />
+          {{else if this.activeDiscountForYearlyPlan}}
+            {{#if this.canSeeDiscountCountdown}}
+              <BillingStatusBadge::DiscountTimerBadge @discount={{this.activeDiscountForYearlyPlan}} @size="small" class="mr-3" />
+            {{/if}}
           {{else if this.billingStatusDisplay.shouldShowFreeWeeksLeftButton}}
             <Header::FreeWeeksLeftButton class="mr-3" />
           {{else if this.billingStatusDisplay.shouldShowUpgradeButton}}
@@ -72,10 +76,6 @@
                 {{svg-jar "lock-open" class="w-4"}}
               </span>
             </PrimaryLinkButton>
-          {{/if}} --}}
-
-          {{#if this.activeDiscountForYearlyPlan}}
-            <BillingStatusBadge::DiscountTimerBadge @discount={{this.activeDiscountForYearlyPlan}} @size="small" class="mr-3" />
           {{/if}}
 
           <Header::AccountDropdown />

--- a/app/components/header.hbs
+++ b/app/components/header.hbs
@@ -58,7 +58,8 @@
             </div>
           </FeedbackButton>
 
-          {{#if this.billingStatusDisplay.shouldShowVipBadge}}
+          {{! TODO: Extract this into BillingStatusBadgeComponent, re-use in course page header and here? }}
+          {{!-- {{#if this.billingStatusDisplay.shouldShowVipBadge}}
             <Header::VipBadge class="mr-3" />
           {{else if this.billingStatusDisplay.shouldShowMemberBadge}}
             <Header::MemberBadge class="mr-3" />
@@ -71,7 +72,9 @@
                 {{svg-jar "lock-open" class="w-4"}}
               </span>
             </PrimaryLinkButton>
-          {{/if}}
+          {{/if}} --}}
+
+          <BillingStatusBadge::DiscountTimerBadge @size="small" class="mr-3" />
 
           <Header::AccountDropdown />
         {{else}}

--- a/app/components/header.hbs
+++ b/app/components/header.hbs
@@ -75,7 +75,7 @@
           {{/if}} --}}
 
           {{#if this.activeDiscountForYearlyPlan}}
-            <BillingStatusBadge::DiscountTimerBadge @size="small" @discount={{this.activeDiscountForYearlyPlan}} class="mr-3" />
+            <BillingStatusBadge::DiscountTimerBadge @discount={{this.activeDiscountForYearlyPlan}} @size="small" class="mr-3" />
           {{/if}}
 
           <Header::AccountDropdown />

--- a/app/components/header.hbs
+++ b/app/components/header.hbs
@@ -74,7 +74,9 @@
             </PrimaryLinkButton>
           {{/if}} --}}
 
-          <BillingStatusBadge::DiscountTimerBadge @size="small" class="mr-3" />
+          {{#if this.activeDiscountForYearlyPlan}}
+            <BillingStatusBadge::DiscountTimerBadge @size="small" @discount={{this.activeDiscountForYearlyPlan}} class="mr-3" />
+          {{/if}}
 
           <Header::AccountDropdown />
         {{else}}

--- a/app/components/header.ts
+++ b/app/components/header.ts
@@ -10,6 +10,7 @@ import type ContainerWidthService from 'codecrafters-frontend/services/container
 import type FeatureFlagsService from 'codecrafters-frontend/services/feature-flags';
 import type RouterService from '@ember/routing/router-service';
 import type VersionTrackerService from 'codecrafters-frontend/services/version-tracker';
+import PromotionalDiscountModel from 'codecrafters-frontend/models/promotional-discount';
 
 interface Signature {
   Element: HTMLDivElement;
@@ -26,6 +27,10 @@ export default class HeaderComponent extends Component<Signature> {
   @service declare versionTracker: VersionTrackerService;
 
   @tracked mobileMenuIsExpanded = false;
+
+  get activeDiscountForYearlyPlan(): PromotionalDiscountModel | null {
+    return this.currentUser?.activeDiscountForYearlyPlan || null;
+  }
 
   get adminPanelLink() {
     return `${config.x.backendUrl}/admin`;

--- a/app/components/header.ts
+++ b/app/components/header.ts
@@ -36,6 +36,10 @@ export default class HeaderComponent extends Component<Signature> {
     return `${config.x.backendUrl}/admin`;
   }
 
+  get canSeeDiscountCountdown() {
+    return this.featureFlags.canSeeDiscountCountdown;
+  }
+
   get currentUser() {
     return this.authenticator.currentUser;
   }

--- a/app/components/pay-page/experimental-referral-discount-notice.ts
+++ b/app/components/pay-page/experimental-referral-discount-notice.ts
@@ -3,7 +3,7 @@ import type PromotionalDiscountModel from 'codecrafters-frontend/models/promotio
 import iconImage from '/assets/images/icons/money.svg';
 import { service } from '@ember/service';
 import type TimeService from 'codecrafters-frontend/services/time';
-import { formatTimeDurationForCoundown } from 'codecrafters-frontend/utils/time-formatting';
+import { formatTimeDurationForCountdown } from 'codecrafters-frontend/utils/time-formatting';
 
 interface Signature {
   Element: HTMLDivElement;
@@ -19,7 +19,7 @@ export default class ReferralDiscountNoticeComponent extends Component<Signature
   @service declare time: TimeService;
 
   get timeLeftText() {
-    return formatTimeDurationForCoundown(this.args.discount.expiresAt, this.time.currentTime);
+    return formatTimeDurationForCountdown(this.args.discount.expiresAt, this.time.currentTime);
   }
 }
 

--- a/app/components/pay-page/experimental-signup-discount-notice.ts
+++ b/app/components/pay-page/experimental-signup-discount-notice.ts
@@ -3,7 +3,7 @@ import PromotionalDiscountModel from 'codecrafters-frontend/models/promotional-d
 import iconImage from '/assets/images/icons/money.svg';
 import { service } from '@ember/service';
 import type TimeService from 'codecrafters-frontend/services/time';
-import { formatTimeDurationForCoundown } from 'codecrafters-frontend/utils/time-formatting';
+import { formatTimeDurationForCountdown } from 'codecrafters-frontend/utils/time-formatting';
 interface Signature {
   Element: HTMLDivElement;
 
@@ -18,7 +18,7 @@ export default class SignupDiscountNoticeComponent extends Component<Signature> 
   @service declare time: TimeService;
 
   get timeLeftText() {
-    return formatTimeDurationForCoundown(this.args.discount.expiresAt, this.time.currentTime);
+    return formatTimeDurationForCountdown(this.args.discount.expiresAt, this.time.currentTime);
   }
 }
 

--- a/app/utils/code-mirror-collapse-unchanged-gutter.ts
+++ b/app/utils/code-mirror-collapse-unchanged-gutter.ts
@@ -1,5 +1,6 @@
 import { BlockInfo, EditorView, gutter, GutterMarker, type WidgetType } from '@codemirror/view';
 import { uncollapseUnchanged } from '@codemirror/merge';
+import { gutter as gutterRS, GutterMarker as GutterMarkerRS } from 'codecrafters-frontend/utils/code-mirror-gutter-rs';
 
 function isCollapseUnchangedWidget(widget: WidgetType) {
   return 'type' in widget && widget.type === 'collapsed-unchanged-code';
@@ -43,6 +44,23 @@ export class CollapseUnchangedGutterMarker extends GutterMarker {
   }
 }
 
+export class CollapseUnchangedGutterMarkerRS extends GutterMarkerRS {
+  line: BlockInfo;
+  view: EditorView;
+  widget: WidgetType;
+
+  constructor(view: EditorView, widget: WidgetType, line: BlockInfo) {
+    super();
+    this.line = line;
+    this.view = view;
+    this.widget = widget;
+  }
+
+  toDOM(view: EditorView) {
+    return renderGutterElement(view, this.widget, this.line);
+  }
+}
+
 export function collapseUnchangedGutter() {
   return [
     gutter({
@@ -50,6 +68,14 @@ export function collapseUnchangedGutter() {
 
       widgetMarker(view, widget, line) {
         return isCollapseUnchangedWidget(widget) ? new CollapseUnchangedGutterMarker(view, widget, line) : null;
+      },
+    }),
+
+    gutterRS({
+      class: 'cm-collapseUnchangedGutter',
+
+      widgetMarker(view, widget, line) {
+        return isCollapseUnchangedWidget(widget) ? new CollapseUnchangedGutterMarkerRS(view, widget, line) : null;
       },
     }),
   ];

--- a/app/utils/code-mirror-gutter-rs.ts
+++ b/app/utils/code-mirror-gutter-rs.ts
@@ -1,10 +1,20 @@
-import {combineConfig, MapMode, Facet, Extension, EditorState,
-        RangeValue, RangeSet, RangeCursor} from "@codemirror/state"
-import {EditorView} from "./editorview"
-import {ViewPlugin, ViewUpdate} from "./extension"
-import {BlockType, WidgetType} from "./decoration"
-import {BlockInfo} from "./heightmap"
-import {Direction} from "./bidi"
+///
+/// Copied from https://github.com/codemirror/view/blob/6.36.2/src/gutter.ts
+///
+
+// @ts-nocheck
+/* eslint-disable */
+
+import { combineConfig, MapMode, Facet, type Extension, EditorState, RangeValue, RangeSet, type RangeCursor } from '@codemirror/state';
+import { EditorView, ViewPlugin, ViewUpdate, BlockType, WidgetType, BlockInfo, Direction } from '@codemirror/view';
+
+// import {combineConfig, MapMode, Facet, Extension, EditorState,
+//         RangeValue, RangeSet, RangeCursor} from "@codemirror/state"
+// import {EditorView} from "./editorview"
+// import {ViewPlugin, ViewUpdate} from "./extension"
+// import {BlockType, WidgetType} from "./decoration"
+// import {BlockInfo} from "./heightmap"
+// import {Direction} from "./bidi"
 
 /// A gutter marker represents a bit of information attached to a line
 /// in a specific gutter. Your own custom markers have to extend this
@@ -126,9 +136,10 @@ const gutterView = ViewPlugin.fromClass(class {
   constructor(readonly view: EditorView) {
     this.prevViewport = view.viewport
     this.dom = document.createElement("div")
-    this.dom.className = "cm-gutters"
+    this.dom.className = "cm-gutters cm-gutters-rs"
     this.dom.setAttribute("aria-hidden", "true")
     this.dom.style.minHeight = (this.view.contentHeight / this.view.scaleY) + "px"
+    this.dom.style.right = "0";
     this.gutters = view.state.facet(activeGutters).map(conf => new SingleGutterView(view, conf))
     for (let gutter of this.gutters) this.dom.appendChild(gutter.dom)
     this.fixed = !view.state.facet(unfixGutters)
@@ -139,7 +150,7 @@ const gutterView = ViewPlugin.fromClass(class {
       this.dom.style.position = "sticky"
     }
     this.syncGutters(false)
-    view.scrollDOM.insertBefore(this.dom, view.contentDOM)
+    view.scrollDOM.insertBefore(this.dom, view.contentDOM.nextSibling)
   }
 
   update(update: ViewUpdate) {
@@ -188,7 +199,13 @@ const gutterView = ViewPlugin.fromClass(class {
       }
     }
     for (let cx of contexts) cx.finish()
-    if (detach) this.view.scrollDOM.insertBefore(this.dom, after)
+    if (detach) {
+      if (after) {
+        this.view.scrollDOM.insertBefore(this.dom, after)
+      } else {
+        this.view.scrollDOM.appendChild(this.dom)
+      }
+    }
   }
 
   updateGutters(update: ViewUpdate) {

--- a/app/utils/code-mirror-gutter-rs.ts
+++ b/app/utils/code-mirror-gutter-rs.ts
@@ -1,0 +1,514 @@
+import {combineConfig, MapMode, Facet, Extension, EditorState,
+        RangeValue, RangeSet, RangeCursor} from "@codemirror/state"
+import {EditorView} from "./editorview"
+import {ViewPlugin, ViewUpdate} from "./extension"
+import {BlockType, WidgetType} from "./decoration"
+import {BlockInfo} from "./heightmap"
+import {Direction} from "./bidi"
+
+/// A gutter marker represents a bit of information attached to a line
+/// in a specific gutter. Your own custom markers have to extend this
+/// class.
+export abstract class GutterMarker extends RangeValue {
+  /// @internal
+  compare(other: GutterMarker) {
+    return this == other || this.constructor == other.constructor && this.eq(other)
+  }
+
+  /// Compare this marker to another marker of the same type.
+  eq(other: GutterMarker): boolean { return false }
+
+  /// Render the DOM node for this marker, if any.
+  toDOM?(view: EditorView): Node
+
+  /// This property can be used to add CSS classes to the gutter
+  /// element that contains this marker.
+  elementClass!: string
+
+  /// Called if the marker has a `toDOM` method and its representation
+  /// was removed from a gutter.
+  destroy(dom: Node) {}
+}
+
+GutterMarker.prototype.elementClass = ""
+GutterMarker.prototype.toDOM = undefined
+GutterMarker.prototype.mapMode = MapMode.TrackBefore
+GutterMarker.prototype.startSide = GutterMarker.prototype.endSide = -1
+GutterMarker.prototype.point = true
+
+/// Facet used to add a class to all gutter elements for a given line.
+/// Markers given to this facet should _only_ define an
+/// [`elementclass`](#view.GutterMarker.elementClass), not a
+/// [`toDOM`](#view.GutterMarker.toDOM) (or the marker will appear
+/// in all gutters for the line).
+export const gutterLineClass = Facet.define<RangeSet<GutterMarker>>()
+
+/// Facet used to add a class to all gutter elements next to a widget.
+/// Should not provide widgets with a `toDOM` method.
+export const gutterWidgetClass =
+  Facet.define<(view: EditorView, widget: WidgetType, block: BlockInfo) => GutterMarker | null>()
+
+type Handlers = {[event: string]: (view: EditorView, line: BlockInfo, event: Event) => boolean}
+
+interface GutterConfig {
+  /// An extra CSS class to be added to the wrapper (`cm-gutter`)
+  /// element.
+  class?: string
+  /// Controls whether empty gutter elements should be rendered.
+  /// Defaults to false.
+  renderEmptyElements?: boolean
+  /// Retrieve a set of markers to use in this gutter.
+  markers?: (view: EditorView) => (RangeSet<GutterMarker> | readonly RangeSet<GutterMarker>[])
+  /// Can be used to optionally add a single marker to every line.
+  lineMarker?: (view: EditorView, line: BlockInfo, otherMarkers: readonly GutterMarker[]) => GutterMarker | null
+  /// Associate markers with block widgets in the document.
+  widgetMarker?: (view: EditorView, widget: WidgetType, block: BlockInfo) => GutterMarker | null
+  /// If line or widget markers depend on additional state, and should
+  /// be updated when that changes, pass a predicate here that checks
+  /// whether a given view update might change the line markers.
+  lineMarkerChange?: null | ((update: ViewUpdate) => boolean)
+  /// Add a hidden spacer element that gives the gutter its base
+  /// width.
+  initialSpacer?: null | ((view: EditorView) => GutterMarker)
+  /// Update the spacer element when the view is updated.
+  updateSpacer?: null | ((spacer: GutterMarker, update: ViewUpdate) => GutterMarker)
+  /// Supply event handlers for DOM events on this gutter.
+  domEventHandlers?: Handlers,
+}
+
+const defaults = {
+  class: "",
+  renderEmptyElements: false,
+  elementStyle: "",
+  markers: () => RangeSet.empty,
+  lineMarker: () => null,
+  widgetMarker: () => null,
+  lineMarkerChange: null,
+  initialSpacer: null,
+  updateSpacer: null,
+  domEventHandlers: {}
+}
+
+const activeGutters = Facet.define<Required<GutterConfig>>()
+
+/// Define an editor gutter. The order in which the gutters appear is
+/// determined by their extension priority.
+export function gutter(config: GutterConfig): Extension {
+  return [gutters(), activeGutters.of({...defaults, ...config})]
+}
+
+const unfixGutters = Facet.define<boolean, boolean>({
+  combine: values => values.some(x => x)
+})
+
+/// The gutter-drawing plugin is automatically enabled when you add a
+/// gutter, but you can use this function to explicitly configure it.
+///
+/// Unless `fixed` is explicitly set to `false`, the gutters are
+/// fixed, meaning they don't scroll along with the content
+/// horizontally (except on Internet Explorer, which doesn't support
+/// CSS [`position:
+/// sticky`](https://developer.mozilla.org/en-US/docs/Web/CSS/position#sticky)).
+export function gutters(config?: {fixed?: boolean}): Extension {
+  let result: Extension[] = [
+    gutterView,
+  ]
+  if (config && config.fixed === false) result.push(unfixGutters.of(true))
+  return result
+}
+
+const gutterView = ViewPlugin.fromClass(class {
+  gutters: SingleGutterView[]
+  dom: HTMLElement
+  fixed: boolean
+  prevViewport: {from: number, to: number}
+
+  constructor(readonly view: EditorView) {
+    this.prevViewport = view.viewport
+    this.dom = document.createElement("div")
+    this.dom.className = "cm-gutters"
+    this.dom.setAttribute("aria-hidden", "true")
+    this.dom.style.minHeight = (this.view.contentHeight / this.view.scaleY) + "px"
+    this.gutters = view.state.facet(activeGutters).map(conf => new SingleGutterView(view, conf))
+    for (let gutter of this.gutters) this.dom.appendChild(gutter.dom)
+    this.fixed = !view.state.facet(unfixGutters)
+    if (this.fixed) {
+      // FIXME IE11 fallback, which doesn't support position: sticky,
+      // by using position: relative + event handlers that realign the
+      // gutter (or just force fixed=false on IE11?)
+      this.dom.style.position = "sticky"
+    }
+    this.syncGutters(false)
+    view.scrollDOM.insertBefore(this.dom, view.contentDOM)
+  }
+
+  update(update: ViewUpdate) {
+    if (this.updateGutters(update)) {
+      // Detach during sync when the viewport changed significantly
+      // (such as during scrolling), since for large updates that is
+      // faster.
+      let vpA = this.prevViewport, vpB = update.view.viewport
+      let vpOverlap = Math.min(vpA.to, vpB.to) - Math.max(vpA.from, vpB.from)
+      this.syncGutters(vpOverlap < (vpB.to - vpB.from) * 0.8)
+    }
+    if (update.geometryChanged) {
+      this.dom.style.minHeight = (this.view.contentHeight / this.view.scaleY) + "px"
+    }
+    if (this.view.state.facet(unfixGutters) != !this.fixed) {
+      this.fixed = !this.fixed
+      this.dom.style.position = this.fixed ? "sticky" : ""
+    }
+    this.prevViewport = update.view.viewport
+  }
+
+  syncGutters(detach: boolean) {
+    let after = this.dom.nextSibling
+    if (detach) this.dom.remove()
+    let lineClasses = RangeSet.iter(this.view.state.facet(gutterLineClass), this.view.viewport.from)
+    let classSet: GutterMarker[] = []
+    let contexts = this.gutters.map(gutter => new UpdateContext(gutter, this.view.viewport, -this.view.documentPadding.top))
+    for (let line of this.view.viewportLineBlocks) {
+      if (classSet.length) classSet = []
+      if (Array.isArray(line.type)) {
+        let first = true
+        for (let b of line.type) {
+          if (b.type == BlockType.Text && first) {
+            advanceCursor(lineClasses, classSet, b.from)
+            for (let cx of contexts) cx.line(this.view, b, classSet)
+            first = false
+          } else if (b.widget) {
+            for (let cx of contexts) cx.widget(this.view, b)
+          }
+        }
+      } else if (line.type == BlockType.Text) {
+        advanceCursor(lineClasses, classSet, line.from)
+        for (let cx of contexts) cx.line(this.view, line, classSet)
+      } else if (line.widget) {
+        for (let cx of contexts) cx.widget(this.view, line)
+      }
+    }
+    for (let cx of contexts) cx.finish()
+    if (detach) this.view.scrollDOM.insertBefore(this.dom, after)
+  }
+
+  updateGutters(update: ViewUpdate) {
+    let prev = update.startState.facet(activeGutters), cur = update.state.facet(activeGutters)
+    let change = update.docChanged || update.heightChanged || update.viewportChanged ||
+      !RangeSet.eq(update.startState.facet(gutterLineClass), update.state.facet(gutterLineClass),
+                   update.view.viewport.from, update.view.viewport.to)
+    if (prev == cur) {
+      for (let gutter of this.gutters) if (gutter.update(update)) change = true
+    } else {
+      change = true
+      let gutters = []
+      for (let conf of cur) {
+        let known = prev.indexOf(conf)
+        if (known < 0) {
+          gutters.push(new SingleGutterView(this.view, conf))
+        } else {
+          this.gutters[known].update(update)
+          gutters.push(this.gutters[known])
+        }
+      }
+      for (let g of this.gutters) {
+        g.dom.remove()
+        if (gutters.indexOf(g) < 0) g.destroy()
+      }
+      for (let g of gutters) this.dom.appendChild(g.dom)
+      this.gutters = gutters
+    }
+    return change
+  }
+
+  destroy() {
+    for (let view of this.gutters) view.destroy()
+    this.dom.remove()
+  }
+}, {
+  provide: plugin => EditorView.scrollMargins.of(view => {
+    let value = view.plugin(plugin)
+    if (!value || value.gutters.length == 0 || !value.fixed) return null
+    return view.textDirection == Direction.LTR
+      ? {left: value.dom.offsetWidth * view.scaleX}
+      : {right: value.dom.offsetWidth * view.scaleX}
+  })
+})
+
+function asArray<T>(val: T | readonly T[]) { return (Array.isArray(val) ? val : [val]) as readonly T[] }
+
+function advanceCursor(cursor: RangeCursor<GutterMarker>, collect: GutterMarker[], pos: number) {
+  while (cursor.value && cursor.from <= pos) {
+    if (cursor.from == pos) collect.push(cursor.value)
+    cursor.next()
+  }
+}
+
+class UpdateContext {
+  cursor: RangeCursor<GutterMarker>
+  i = 0
+
+  constructor(readonly gutter: SingleGutterView, viewport: {from: number, to: number}, public height: number) {
+    this.cursor = RangeSet.iter(gutter.markers, viewport.from)
+  }
+
+  addElement(view: EditorView, block: BlockInfo, markers: readonly GutterMarker[]) {
+    let {gutter} = this, above = (block.top - this.height) / view.scaleY, height = block.height / view.scaleY
+    if (this.i == gutter.elements.length) {
+      let newElt = new GutterElement(view, height, above, markers)
+      gutter.elements.push(newElt)
+      gutter.dom.appendChild(newElt.dom)
+    } else {
+      gutter.elements[this.i].update(view, height, above, markers)
+    }
+    this.height = block.bottom
+    this.i++
+  }
+
+  line(view: EditorView, line: BlockInfo, extraMarkers: readonly GutterMarker[]) {
+    let localMarkers: GutterMarker[] = []
+    advanceCursor(this.cursor, localMarkers, line.from)
+    if (extraMarkers.length) localMarkers = localMarkers.concat(extraMarkers)
+    let forLine = this.gutter.config.lineMarker(view, line, localMarkers)
+    if (forLine) localMarkers.unshift(forLine)
+
+    let gutter = this.gutter
+    if (localMarkers.length == 0 && !gutter.config.renderEmptyElements) return
+    this.addElement(view, line, localMarkers)
+  }
+
+  widget(view: EditorView, block: BlockInfo) {
+    let marker = this.gutter.config.widgetMarker(view, block.widget!, block), markers = marker ? [marker] : null
+    for (let cls of view.state.facet(gutterWidgetClass)) {
+      let marker = cls(view, block.widget!, block)
+      if (marker) (markers || (markers = [])).push(marker)
+    }
+    if (markers) this.addElement(view, block, markers)
+  }
+
+  finish() {
+    let gutter = this.gutter
+    while (gutter.elements.length > this.i) {
+      let last = gutter.elements.pop()!
+      gutter.dom.removeChild(last.dom)
+      last.destroy()
+    }
+  }
+}
+
+class SingleGutterView {
+  dom: HTMLElement
+  elements: GutterElement[] = []
+  markers: readonly RangeSet<GutterMarker>[]
+  spacer: GutterElement | null = null
+
+  constructor(public view: EditorView, public config: Required<GutterConfig>) {
+    this.dom = document.createElement("div")
+    this.dom.className = "cm-gutter" + (this.config.class ? " " + this.config.class : "")
+    for (let prop in config.domEventHandlers) {
+      this.dom.addEventListener(prop, (event: Event) => {
+        let target = event.target as HTMLElement, y
+        if (target != this.dom && this.dom.contains(target)) {
+          while (target.parentNode != this.dom) target = target.parentNode as HTMLElement
+          let rect = target.getBoundingClientRect()
+          y = (rect.top + rect.bottom) / 2
+        } else {
+          y = (event as MouseEvent).clientY
+        }
+        let line = view.lineBlockAtHeight(y - view.documentTop)
+        if (config.domEventHandlers[prop](view, line, event)) event.preventDefault()
+      })
+    }
+    this.markers = asArray(config.markers(view))
+    if (config.initialSpacer) {
+      this.spacer = new GutterElement(view, 0, 0, [config.initialSpacer(view)])
+      this.dom.appendChild(this.spacer.dom)
+      this.spacer.dom.style.cssText += "visibility: hidden; pointer-events: none"
+    }
+  }
+
+  update(update: ViewUpdate) {
+    let prevMarkers = this.markers
+    this.markers = asArray(this.config.markers(update.view))
+    if (this.spacer && this.config.updateSpacer) {
+      let updated = this.config.updateSpacer(this.spacer.markers[0], update)
+      if (updated != this.spacer.markers[0]) this.spacer.update(update.view, 0, 0, [updated])
+    }
+    let vp = update.view.viewport
+    return !RangeSet.eq(this.markers, prevMarkers, vp.from, vp.to) ||
+      (this.config.lineMarkerChange ? this.config.lineMarkerChange(update) : false)
+  }
+
+  destroy() {
+    for (let elt of this.elements) elt.destroy()
+  }
+}
+
+class GutterElement {
+  dom: HTMLElement
+  height: number = -1
+  above: number = 0
+  markers: readonly GutterMarker[] = []
+
+  constructor(view: EditorView, height: number, above: number, markers: readonly GutterMarker[]) {
+    this.dom = document.createElement("div")
+    this.dom.className = "cm-gutterElement"
+    this.update(view, height, above, markers)
+  }
+
+  update(view: EditorView, height: number, above: number, markers: readonly GutterMarker[]) {
+    if (this.height != height) {
+      this.height = height
+      this.dom.style.height = height + "px"
+    }
+    if (this.above != above)
+      this.dom.style.marginTop = (this.above = above) ? above + "px" : ""
+    if (!sameMarkers(this.markers, markers)) this.setMarkers(view, markers)
+  }
+
+  setMarkers(view: EditorView, markers: readonly GutterMarker[]) {
+    let cls = "cm-gutterElement", domPos = this.dom.firstChild
+    for (let iNew = 0, iOld = 0;;) {
+      let skipTo = iOld, marker = iNew < markers.length ? markers[iNew++] : null, matched = false
+      if (marker) {
+        let c = marker.elementClass
+        if (c) cls += " " + c
+        for (let i = iOld; i < this.markers.length; i++)
+          if (this.markers[i].compare(marker)) { skipTo = i; matched = true; break }
+      } else {
+        skipTo = this.markers.length
+      }
+      while (iOld < skipTo) {
+        let next = this.markers[iOld++]
+        if (next.toDOM) {
+          next.destroy(domPos!)
+          let after = domPos!.nextSibling
+          domPos!.remove()
+          domPos = after
+        }
+      }
+      if (!marker) break
+      if (marker.toDOM) {
+        if (matched) domPos = domPos!.nextSibling
+        else this.dom.insertBefore(marker.toDOM(view), domPos)
+      }
+      if (matched) iOld++
+    }
+    this.dom.className = cls
+    this.markers = markers
+  }
+
+  destroy() {
+    this.setMarkers(null as any, []) // First argument not used unless creating markers
+  }
+}
+
+function sameMarkers(a: readonly GutterMarker[], b: readonly GutterMarker[]): boolean {
+  if (a.length != b.length) return false
+  for (let i = 0; i < a.length; i++) if (!a[i].compare(b[i])) return false
+  return true
+}
+
+interface LineNumberConfig {
+  /// How to display line numbers. Defaults to simply converting them
+  /// to string.
+  formatNumber?: (lineNo: number, state: EditorState) => string
+  /// Supply event handlers for DOM events on this gutter.
+  domEventHandlers?: Handlers
+}
+
+/// Facet used to provide markers to the line number gutter.
+export const lineNumberMarkers = Facet.define<RangeSet<GutterMarker>>()
+
+/// Facet used to create markers in the line number gutter next to widgets.
+export const lineNumberWidgetMarker = Facet.define<(view: EditorView, widget: WidgetType, block: BlockInfo) => GutterMarker | null>()
+
+const lineNumberConfig = Facet.define<LineNumberConfig, Required<LineNumberConfig>>({
+  combine(values) {
+    return combineConfig<Required<LineNumberConfig>>(values, {formatNumber: String, domEventHandlers: {}}, {
+      domEventHandlers(a: Handlers, b: Handlers) {
+        let result: Handlers = Object.assign({}, a)
+        for (let event in b) {
+          let exists = result[event], add = b[event]
+          result[event] = exists ? (view, line, event) => exists(view, line, event) || add(view, line, event) : add
+        }
+        return result
+      }
+    })
+  }
+})
+
+class NumberMarker extends GutterMarker {
+  constructor(readonly number: string) { super() }
+
+  eq(other: NumberMarker) { return this.number == other.number }
+
+  toDOM() { return document.createTextNode(this.number) }
+}
+
+function formatNumber(view: EditorView, number: number) {
+  return view.state.facet(lineNumberConfig).formatNumber(number, view.state)
+}
+
+const lineNumberGutter = activeGutters.compute([lineNumberConfig], state => ({
+  class: "cm-lineNumbers",
+  renderEmptyElements: false,
+  markers(view: EditorView) { return view.state.facet(lineNumberMarkers) },
+  lineMarker(view, line, others) {
+    if (others.some(m => m.toDOM)) return null
+    return new NumberMarker(formatNumber(view, view.state.doc.lineAt(line.from).number))
+  },
+  widgetMarker: (view, widget, block) => {
+    for (let m of view.state.facet(lineNumberWidgetMarker)) {
+      let result = m(view, widget, block)
+      if (result) return result
+    }
+    return null
+  },
+  lineMarkerChange: update => update.startState.facet(lineNumberConfig) != update.state.facet(lineNumberConfig),
+  initialSpacer(view: EditorView) {
+    return new NumberMarker(formatNumber(view, maxLineNumber(view.state.doc.lines)))
+  },
+  updateSpacer(spacer: GutterMarker, update: ViewUpdate) {
+    let max = formatNumber(update.view, maxLineNumber(update.view.state.doc.lines))
+    return max == (spacer as NumberMarker).number ? spacer : new NumberMarker(max)
+  },
+  domEventHandlers: state.facet(lineNumberConfig).domEventHandlers
+}))
+
+/// Create a line number gutter extension.
+export function lineNumbers(config: LineNumberConfig = {}): Extension {
+  return [
+    lineNumberConfig.of(config),
+    gutters(),
+    lineNumberGutter
+  ]
+}
+
+function maxLineNumber(lines: number) {
+  let last = 9
+  while (last < lines) last = last * 10 + 9
+  return last
+}
+
+const activeLineGutterMarker = new class extends GutterMarker {
+  elementClass = "cm-activeLineGutter"
+}
+
+const activeLineGutterHighlighter = gutterLineClass.compute(["selection"], state => {
+  let marks = [], last = -1
+  for (let range of state.selection.ranges) {
+    let linePos = state.doc.lineAt(range.head).from
+    if (linePos > last) {
+      last = linePos
+      marks.push(activeLineGutterMarker.range(linePos))
+    }
+  }
+  return RangeSet.of(marks)
+})
+
+/// Returns an extension that adds a `cm-activeLineGutter` class to
+/// all gutter elements on the [active
+/// line](#view.highlightActiveLine).
+export function highlightActiveLineGutter() {
+  return activeLineGutterHighlighter
+}

--- a/app/utils/time-formatting.ts
+++ b/app/utils/time-formatting.ts
@@ -38,6 +38,9 @@ export function formatTimeDurationForBadge(laterDate: Date, earlierDate: Date): 
   const minutesLeft = Math.floor(distanceInSeconds / 60) - hoursLeft * 60;
   const secondsLeft = distanceInSeconds - hoursLeft * 60 * 60 - minutesLeft * 60;
 
+  // TODO:
+  // More time > 24 hours we need to show `X days left`
+  // And round up to the nearest day
   if (distanceInSeconds < 0) {
     return '0 second';
   }

--- a/app/utils/time-formatting.ts
+++ b/app/utils/time-formatting.ts
@@ -31,3 +31,32 @@ export function formatTimeDurationForCoundown(laterDate: Date, earlierDate: Date
 
   return `${secondsLeftStr}`;
 }
+
+export function formatTimeDurationForBadge(laterDate: Date, earlierDate: Date): string {
+  const distanceInSeconds = Math.floor((laterDate.getTime() - earlierDate.getTime()) / 1000);
+  const hoursLeft = Math.floor(distanceInSeconds / 60 / 60);
+  const minutesLeft = Math.floor(distanceInSeconds / 60) - hoursLeft * 60;
+  const secondsLeft = distanceInSeconds - hoursLeft * 60 * 60 - minutesLeft * 60;
+
+  if (distanceInSeconds < 0) {
+    return '0 second';
+  }
+
+  if (hoursLeft > 0) {
+    return formatTimeDurationSingularOrPlural(hoursLeft, 'hour');
+  }
+
+  if (minutesLeft > 0) {
+    return formatTimeDurationSingularOrPlural(minutesLeft, 'minute');
+  }
+
+  return formatTimeDurationSingularOrPlural(secondsLeft, 'second');
+}
+
+export function formatTimeDurationSingularOrPlural(duration: number, unit: string): string {
+  if (duration === 1) {
+    return `1 ${unit}`;
+  }
+
+  return `${duration} ${unit}s`;
+}

--- a/app/utils/time-formatting.ts
+++ b/app/utils/time-formatting.ts
@@ -1,6 +1,6 @@
 import * as Sentry from '@sentry/ember';
 
-export function formatTimeDurationForCoundown(laterDate: Date, earlierDate: Date): string {
+export function formatTimeDurationForCountdown(laterDate: Date, earlierDate: Date): string {
   const distanceInSeconds = Math.floor((laterDate.getTime() - earlierDate.getTime()) / 1000);
   const hoursLeft = Math.floor(distanceInSeconds / 60 / 60);
   const minutesLeft = Math.floor(distanceInSeconds / 60) - hoursLeft * 60;

--- a/tests/acceptance/view-discount-countdown-test.js
+++ b/tests/acceptance/view-discount-countdown-test.js
@@ -36,6 +36,8 @@ module('Acceptance | view-discount-countdown', function (hooks) {
     });
 
     await catalogPage.visit();
+    // TODO:
+    // CANT USE assert.dom in tests
     assert.dom('[data-test-discount-timer-badge]').exists('Discount timer badge is visible');
     assert.dom('[data-test-discount-timer-badge]').hasText('1 hour left', 'Shows correct time remaining');
   });

--- a/tests/acceptance/view-discount-countdown-test.js
+++ b/tests/acceptance/view-discount-countdown-test.js
@@ -1,0 +1,28 @@
+import testScenario from 'codecrafters-frontend/mirage/scenarios/test';
+import { module, test } from 'qunit';
+import { setupApplicationTest } from 'codecrafters-frontend/tests/helpers';
+import { signIn } from 'codecrafters-frontend/tests/support/authentication-helpers';
+import { currentURL, visit } from '@ember/test-helpers';
+
+module('Acceptance | view-discount-countdown', function (hooks) {
+  setupApplicationTest(hooks);
+
+  hooks.beforeEach(async function () {
+    testScenario(this.server);
+    this.currentUser = signIn(this.owner, this.server);
+  });
+
+  test('it redirects to /tracks page', async function (assert) {
+    this.server.schema.promotionalDiscounts.create({
+      user: this.currentUser,
+      type: 'signup',
+      percentageOff: 40,
+      expiresAt: new Date(new Date().getTime() + 1 * 60 * 60 * 1000),
+    });
+
+    await visit('/');
+    assert.strictEqual(currentURL(), '/catalog');
+
+    // await this.pauseTest();
+  });
+});

--- a/tests/acceptance/view-discount-countdown-test.js
+++ b/tests/acceptance/view-discount-countdown-test.js
@@ -1,7 +1,7 @@
 import testScenario from 'codecrafters-frontend/mirage/scenarios/test';
 import { module, test } from 'qunit';
 import { setupApplicationTest } from 'codecrafters-frontend/tests/helpers';
-import { signIn } from 'codecrafters-frontend/tests/support/authentication-helpers';
+import { signInAsStaff } from 'codecrafters-frontend/tests/support/authentication-helpers';
 import { currentURL, visit } from '@ember/test-helpers';
 import { assertTooltipContent } from 'ember-tooltips/test-support';
 import catalogPage from 'codecrafters-frontend/tests/pages/catalog-page';
@@ -12,7 +12,7 @@ module('Acceptance | view-discount-countdown', function (hooks) {
 
   hooks.beforeEach(async function () {
     testScenario(this.server);
-    this.currentUser = signIn(this.owner, this.server);
+    this.currentUser = signInAsStaff(this.owner, this.server);
   });
 
   test('it redirects to /tracks page', async function (assert) {

--- a/tests/acceptance/view-discount-countdown-test.js
+++ b/tests/acceptance/view-discount-countdown-test.js
@@ -3,6 +3,9 @@ import { module, test } from 'qunit';
 import { setupApplicationTest } from 'codecrafters-frontend/tests/helpers';
 import { signIn } from 'codecrafters-frontend/tests/support/authentication-helpers';
 import { currentURL, visit } from '@ember/test-helpers';
+import { assertTooltipContent } from 'ember-tooltips/test-support';
+import catalogPage from 'codecrafters-frontend/tests/pages/catalog-page';
+import coursePage from 'codecrafters-frontend/tests/pages/course-page';
 
 module('Acceptance | view-discount-countdown', function (hooks) {
   setupApplicationTest(hooks);
@@ -22,7 +25,76 @@ module('Acceptance | view-discount-countdown', function (hooks) {
 
     await visit('/');
     assert.strictEqual(currentURL(), '/catalog');
+  });
 
-    // await this.pauseTest();
+  test('discount timer badge is visible in header when discount is active', async function (assert) {
+    this.server.schema.promotionalDiscounts.create({
+      user: this.currentUser,
+      type: 'signup',
+      percentageOff: 40,
+      expiresAt: new Date(new Date().getTime() + 1 * 60 * 60 * 1000), // 1 hour from now
+    });
+
+    await catalogPage.visit();
+    assert.dom('[data-test-discount-timer-badge]').exists('Discount timer badge is visible');
+    assert.dom('[data-test-discount-timer-badge]').hasText('1 hour left', 'Shows correct time remaining');
+  });
+
+  test('discount timer badge shows correct tooltip', async function (assert) {
+    this.server.schema.promotionalDiscounts.create({
+      user: this.currentUser,
+      type: 'signup',
+      percentageOff: 40,
+      expiresAt: new Date(new Date().getTime() + 30 * 60 * 1000), // 30 minutes from now
+    });
+
+    await catalogPage.visit();
+    await catalogPage.header.discountTimerBadge.hover();
+
+    assertTooltipContent(assert, {
+      contentString: 'Upgrade in 30m:00s to get 40% off the annual plan. Click to view details.',
+    });
+  });
+
+  test('discount timer badge redirects to payment page when clicked', async function (assert) {
+    this.server.schema.promotionalDiscounts.create({
+      user: this.currentUser,
+      type: 'signup',
+      percentageOff: 40,
+      expiresAt: new Date(new Date().getTime() + 1 * 60 * 60 * 1000),
+    });
+
+    await catalogPage.visit();
+    await catalogPage.header.discountTimerBadge.click();
+
+    assert.strictEqual(currentURL(), '/pay', 'Redirects to payment page when clicked');
+  });
+
+  test('discount timer badge appears in both catalog and course pages', async function (assert) {
+    this.server.schema.promotionalDiscounts.create({
+      user: this.currentUser,
+      type: 'signup',
+      percentageOff: 40,
+      expiresAt: new Date(new Date().getTime() + 1 * 60 * 60 * 1000),
+    });
+
+    // Check catalog page
+    await catalogPage.visit();
+    assert.dom('[data-test-discount-timer-badge]').exists('Badge visible on catalog page');
+    assert.dom('[data-test-discount-timer-badge]').hasClass(/px-1\.5/, 'Has small size on catalog page');
+
+    // Check course page
+    await catalogPage.clickOnCourse('Build your own Redis');
+    assert.dom('[data-test-discount-timer-badge]').exists('Badge visible on course page');
+    assert.dom('[data-test-discount-timer-badge]').hasClass(/px-1\.5/, 'Has small size on course page');
+
+    await coursePage.visit({ course_slug: 'redis' });
+    assert.dom('[data-test-discount-timer-badge]').exists('Badge visible on course page');
+    assert.dom('[data-test-discount-timer-badge]').hasClass(/px-2/, 'Has large size on course page');
+  });
+
+  test('discount timer badge is not visible when no active discount', async function (assert) {
+    await catalogPage.visit();
+    assert.dom('[data-test-discount-timer-badge]').doesNotExist('Discount timer badge is not visible without active discount');
   });
 });

--- a/tests/pages/components/header.js
+++ b/tests/pages/components/header.js
@@ -3,6 +3,12 @@ import { clickOnText, clickable, fillable, isVisible, triggerable } from 'ember-
 export default {
   clickOnHeaderLink: clickOnText('[data-test-header-link]'),
 
+  discountTimerBadge: {
+    scope: '[data-test-discount-timer-badge]',
+    hover: triggerable('mouseenter'),
+    click: clickable(),
+  },
+
   feedbackDropdown: {
     clickOnSendButton: clickable('[data-test-send-button]'),
     fillInExplanation: fillable('textarea'),

--- a/tests/unit/utils/time-formatting-test.ts
+++ b/tests/unit/utils/time-formatting-test.ts
@@ -1,4 +1,4 @@
-import { formatTimeDurationForCoundown } from 'codecrafters-frontend/utils/time-formatting';
+import { formatTimeDurationForCountdown } from 'codecrafters-frontend/utils/time-formatting';
 import { module, test } from 'qunit';
 
 module('Unit | Utility | time-formatting', function () {
@@ -7,29 +7,29 @@ module('Unit | Utility | time-formatting', function () {
 
     // Test hours:minutes:seconds format
     assert.strictEqual(
-      formatTimeDurationForCoundown(new Date('2024-01-01T02:34:56Z'), currentTime),
+      formatTimeDurationForCountdown(new Date('2024-01-01T02:34:56Z'), currentTime),
       '02h:34m:56s',
       'formats hours, minutes and seconds correctly',
     );
 
     // Test minutes:seconds format
     assert.strictEqual(
-      formatTimeDurationForCoundown(new Date('2024-01-01T00:34:56Z'), currentTime),
+      formatTimeDurationForCountdown(new Date('2024-01-01T00:34:56Z'), currentTime),
       '34m:56s',
       'formats minutes and seconds correctly when hours is 0',
     );
 
     // Test seconds only format
     assert.strictEqual(
-      formatTimeDurationForCoundown(new Date('2024-01-01T00:00:45Z'), currentTime),
+      formatTimeDurationForCountdown(new Date('2024-01-01T00:00:45Z'), currentTime),
       '45s',
       'formats seconds only when hours and minutes are 0',
     );
 
     // Test negative time difference
-    assert.strictEqual(formatTimeDurationForCoundown(new Date('2023-12-31T23:59:59Z'), currentTime), '00s', 'returns 00s for expired time');
+    assert.strictEqual(formatTimeDurationForCountdown(new Date('2023-12-31T23:59:59Z'), currentTime), '00s', 'returns 00s for expired time');
 
     // Test zero seconds
-    assert.strictEqual(formatTimeDurationForCoundown(new Date('2024-01-01T00:00:00Z'), currentTime), '00s', 'formats zero seconds correctly');
+    assert.strictEqual(formatTimeDurationForCountdown(new Date('2024-01-01T00:00:00Z'), currentTime), '00s', 'formats zero seconds correctly');
   });
 });


### PR DESCRIPTION
Prototype for discount timer badge

<!-- GitButler Footer Boundary Top -->
---
This is **part 2 of 2 in a stack** made with GitButler:
- <kbd>&nbsp;2&nbsp;</kbd> #2583 👈 
- <kbd>&nbsp;1&nbsp;</kbd> #2579 
<!-- GitButler Footer Boundary Bottom -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Added a discount timer badge to display promotional discounts for yearly plans.
	- Implemented countdown timer for active discounts across header and course page.
	- Introduced new time formatting utilities for displaying discount durations.

- **Bug Fixes**
	- Improved handling of time duration formatting.

- **Chores**
	- Updated `.gitignore` to exclude IDE and development tool-specific directories.
	- Added comprehensive acceptance tests for the discount countdown feature.
	- Added new entry to `.prettierignore` to exclude specific TypeScript files from formatting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->