### PR TITLE
Try QUnit Retry

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -175,6 +175,7 @@
         "qunit": "^2.22.0",
         "qunit-assertions-extra": "^1.0",
         "qunit-dom": "^3.4.0",
+        "qunit-retry": "^2.3.0",
         "rgb-hex": "^4.1.0",
         "shiki": "^2.0.3",
         "sinon": "^19.0.2",
@@ -41016,6 +41017,15 @@
       "dev": true,
       "dependencies": {
         "dom-element-descriptors": "^0.5.1"
+      }
+    },
+    "node_modules/qunit-retry": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/qunit-retry/-/qunit-retry-2.3.0.tgz",
+      "integrity": "sha512-p2i3A8CBHeBPU8Bc44yjbBFtd7dHbwdJ8c2G1qX05e0izU9ZPWB8mHcZHPZp7gqJShiiRIMG6A6PQNITzn/fXA==",
+      "dev": true,
+      "dependencies": {
+        "esm": "^3.2.25"
       }
     },
     "node_modules/qunit-theme-ember": {

--- a/package.json
+++ b/package.json
@@ -181,6 +181,7 @@
     "qunit": "^2.22.0",
     "qunit-assertions-extra": "^1.0",
     "qunit-dom": "^3.4.0",
+    "qunit-retry": "^2.3.0",
     "rgb-hex": "^4.1.0",
     "shiki": "^2.0.3",
     "sinon": "^19.0.2",

--- a/tests/integration/components/code-mirror-test.js
+++ b/tests/integration/components/code-mirror-test.js
@@ -1,9 +1,12 @@
 import { module, skip, test } from 'qunit';
+import setupRetry from 'qunit-retry';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { setupRenderingTest } from 'codecrafters-frontend/tests/helpers';
 import codeMirror from 'codecrafters-frontend/tests/pages/components/code-mirror';
 import { codeCraftersDark, codeCraftersLight } from 'codecrafters-frontend/utils/code-mirror-themes';
+
+const retry = setupRetry(test);
 
 module('Integration | Component | code-mirror', function (hooks) {
   setupRenderingTest(hooks);
@@ -327,7 +330,7 @@ module('Integration | Component | code-mirror', function (hooks) {
     });
 
     module('filename', function () {
-      test("it doesn't break the editor when passed", async function (assert) {
+      retry("it doesn't break the editor when passed", async function (assert) {
         this.set('filename', 'javascript.js');
         await render(hbs`<CodeMirror @filename={{this.filename}} />`);
         assert.ok(codeMirror.hasRendered);

--- a/tests/integration/components/code-mirror-test.js
+++ b/tests/integration/components/code-mirror-test.js
@@ -331,6 +331,7 @@ module('Integration | Component | code-mirror', function (hooks) {
 
     module('filename', function () {
       retry("it doesn't break the editor when passed", async function (assert) {
+        assert.timeout(3000);
         this.set('filename', 'javascript.js');
         await render(hbs`<CodeMirror @filename={{this.filename}} />`);
         assert.ok(codeMirror.hasRendered);


### PR DESCRIPTION
### Brief

As an experiment to try fixing a flaky test that often fails on production for mysterious reasons, while never failing locally — try using [`qunit-retry`](https://github.com/mrloop/QUnit-retry), which I have just discovered.

### Details

I had an idea to try and patch qunit and make it retry a flaky test at least once, before actually marking it as failed. Turns out someone already did it! Very curious to see if this majorly improves our test success rate.

### Checklist

- [x] I've thoroughly self-reviewed my changes
- [x] I've added tests for my changes, unless they affect admin-only areas (or are otherwise not worth testing)
- [x] I've verified any visual changes using Percy (add a commit with `[percy]` in the message to trigger)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Added `qunit-retry` package to improve test reliability
- **Tests**
	- Enhanced test robustness by enabling retry mechanism for specific test cases
	- Configured retry functionality for filename-related test scenarios
<!-- end of auto-generated comment: release notes by coderabbit.ai -->