### PR TITLE
bump(version): update version number to 29.0

### DIFF
--- a/config/environment.js
+++ b/config/environment.js
@@ -48,7 +48,7 @@ module.exports = function (environment) {
 
       // Update the major version number to force all clients to update.
       // The minor version doesn't do anything at the moment, might use in the future.
-      version: `28.0.${process.env.VERCEL_GIT_COMMIT_SHA?.slice(0, 7) || 'dev'}`,
+      version: `29.0.${process.env.VERCEL_GIT_COMMIT_SHA?.slice(0, 7) || 'dev'}`,
     },
     fastboot: {
       hostWhitelist: [/^localhost:\d+$/],


### PR DESCRIPTION
Updates the version number in the environment configuration 
to 29.0 to ensure all clients are prompted to update. This 
change prepares the application for future enhancements and 
maintains versioning consistency.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated application version from 28.0 to 29.0

<!-- end of auto-generated comment: release notes by coderabbit.ai -->