### PR TITLE
feat(tailwind): add xxs font size for better readability

### DIFF
--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -57,6 +57,9 @@ module.exports = {
           925: '#0A1120',
         },
       },
+      fontSize: {
+        xxs: ['0.625rem', '0.75rem'], // 10px font size with 12px line height
+      },
       typography: {
         DEFAULT: {
           css: {


### PR DESCRIPTION
Adds a new font size 'xxs' with a value of 0.625rem and a line height 
of 0.75rem to the Tailwind configuration. This change improves 
readability for smaller text elements in the design.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
	- Added an extra-extra small (`xxs`) font size option to the typography configuration, providing more granular text sizing control.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->