### PR TITLE
fix: change header level for accessibility improvement

### DIFF
--- a/app/templates/catalog.hbs
+++ b/app/templates/catalog.hbs
@@ -22,7 +22,7 @@
   </div>
 
   <div class="border-b dark:border-white/5 pb-2 mb-6">
-    <h1 class="text-3xl text-gray-700 dark:text-gray-300 font-bold tracking-tighter">Language Tracks</h1>
+    <h2 class="text-3xl text-gray-700 dark:text-gray-300 font-bold tracking-tighter">Language Tracks</h2>
   </div>
 
   <div class="grid grid-cols-1 gap-3 md:grid-cols-2 lg:grid-cols-3 mb-8">


### PR DESCRIPTION
Update the header from h1 to h2 in the catalog template to 
improve accessibility and semantic structure of the HTML. This 
change ensures better compliance with web standards and 
enhances the document outline for screen readers.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Updated heading hierarchy for "Language Tracks" section from `<h1>` to `<h2>`

<!-- end of auto-generated comment: release notes by coderabbit.ai -->