### PR TITLE
fix(tests): correct typo in testimonial text for clarity

### DIFF
--- a/app/utils/testimonials-data.js
+++ b/app/utils/testimonials-data.js
@@ -78,7 +78,7 @@ const testimonials = {
     authorName: 'Jonathan Lorimer',
     authorDesignation: 'Lead SWE at Mercury Bank',
     authorAvatarImage: jonathanImage,
-    text: `I was really impressed that they support Haskell, and will probably usethis to learn Rust! The git-based workflow is :chefkiss:`,
+    text: `I was really impressed that they support Haskell, and will probably use this to learn Rust! The git-based workflow is :chefkiss:`,
   },
 
   'patrick-burris': {


### PR DESCRIPTION
Corrects a typo in the testimonial text by adding a space between 
"use" and "this" to improve readability and maintain professionalism.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Fixed a minor typo in a testimonial text to improve readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->