### PR TITLE
chore: update copyright year to 2025

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -6,7 +6,7 @@ FSL-1.1-MIT
 
 ## Notice
 
-Copyright 2021-2024 CodeCrafters, Inc.
+Copyright 2021-2025 CodeCrafters, Inc.
 
 ## Terms and Conditions
 

--- a/app/components/footer.hbs
+++ b/app/components/footer.hbs
@@ -57,7 +57,7 @@
       </div>
       <div class="mt-12 border-t border-white/5 pt-8">
         <p class="text-base text-gray-600 xl:text-center">
-          &copy; 2024 CodeCrafters, Inc. All rights reserved.
+          &copy; 2025 CodeCrafters, Inc. All rights reserved.
         </p>
       </div>
     </div>


### PR DESCRIPTION
**Checklist**:

- [x] I've thoroughly self-reviewed my changes
- [ ] I've added tests for my changes, unless they affect admin-only areas (or are otherwise not worth testing)
- [ ] I've verified any visual changes using Percy (add a commit with `[percy]` in the message to trigger)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated the licensing text to extend copyright coverage through 2025.
- **Chores**
	- Modified the footer display to show the updated copyright year (2025) for enhanced accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->