### PR TITLE
Refactor header authentication and upgrade button logic

### DIFF
--- a/app/components/header/index.hbs
+++ b/app/components/header/index.hbs
@@ -45,31 +45,24 @@
           <OutdatedClientBadge class="mr-4" />
         {{/if}}
 
+        <FeedbackButton @source="header" class="mr-4" as |dd|>
+          <div
+            role="button"
+            class="rounded border
+              {{if dd.isOpen 'border-gray-500 dark:border-gray-500' 'border-gray-200 dark:border-white/10'}}
+              text-gray-600 dark:text-gray-400 hover:border-gray-500 dark:hover:border-gray-500 px-2 py-1 text-xs"
+            data-test-feedback-button
+          >
+            Feedback
+          </div>
+        </FeedbackButton>
+
+        <BillingStatusBadge @size="small" class="mr-3" />
+
         {{#if this.authenticator.isAuthenticated}}
-          <FeedbackButton @source="header" class="mr-4" as |dd|>
-            <div
-              role="button"
-              class="rounded border
-                {{if dd.isOpen 'border-gray-500 dark:border-gray-500' 'border-gray-200 dark:border-white/10'}}
-                text-gray-600 dark:text-gray-400 hover:border-gray-500 dark:hover:border-gray-500 px-2 py-1 text-xs"
-              data-test-feedback-button
-            >
-              Feedback
-            </div>
-          </FeedbackButton>
-
-          <BillingStatusBadge @size="small" class="mr-3" />
-
           <Header::AccountDropdown />
         {{else}}
-          <div class="flex items-center ml-6">
-            <PrimaryLinkButton @size="extra-small" @route="pay" class="mr-4" data-test-upgrade-button>
-              <span class="flex items-center gap-x-1">
-                <span>Upgrade</span>
-                {{svg-jar "lock-open" class="w-4"}}
-              </span>
-            </PrimaryLinkButton>
-
+          <div class="flex items-center">
             {{! @glint-expect-error not ts-ified yet }}
             <Header::SignInWithGithubButton />
           </div>

--- a/tests/acceptance/header-test.js
+++ b/tests/acceptance/header-test.js
@@ -11,12 +11,16 @@ module('Acceptance | header-test', function (hooks) {
   setupApplicationTest(hooks);
   setupAnimationTest(hooks);
 
-  test('header should show sign-in button if user is not authenticated', async function (assert) {
+  test('header should show sign-in & upgrade button if user is unauthenticated', async function (assert) {
     testScenario(this.server);
 
     await catalogPage.visit();
 
     assert.true(catalogPage.header.signInButton.isVisible, 'expect sign-in button to be visible');
+    assert.true(catalogPage.header.upgradeButton.isVisible, 'expect billing status  badge to be visible');
+    await catalogPage.header.upgradeButton.click();
+
+    assert.strictEqual(currentURL(), '/pay', 'expect to be redirected to pay page');
   });
 
   test('header should show upgrade button if user does not have an active subscription', async function (assert) {

--- a/tests/acceptance/header-test.js
+++ b/tests/acceptance/header-test.js
@@ -5,11 +5,31 @@ import { currentURL } from '@ember/test-helpers';
 import { module, test } from 'qunit';
 import { setupAnimationTest } from 'ember-animated/test-support';
 import { setupApplicationTest } from 'codecrafters-frontend/tests/helpers';
-import { signInAsSubscriber } from 'codecrafters-frontend/tests/support/authentication-helpers';
+import { signIn, signInAsSubscriber } from 'codecrafters-frontend/tests/support/authentication-helpers';
 
 module('Acceptance | header-test', function (hooks) {
   setupApplicationTest(hooks);
   setupAnimationTest(hooks);
+
+  test('header should show sign-in button if user is not authenticated', async function (assert) {
+    testScenario(this.server);
+
+    await catalogPage.visit();
+
+    assert.true(catalogPage.header.signInButton.isVisible, 'expect sign-in button to be visible');
+  });
+
+  test('header should show upgrade button if user does not have an active subscription', async function (assert) {
+    testScenario(this.server);
+    signIn(this.owner, this.server);
+
+    await catalogPage.visit();
+
+    assert.true(catalogPage.header.upgradeButton.isVisible, 'expect billing status  badge to be visible');
+    await catalogPage.header.upgradeButton.click();
+
+    assert.strictEqual(currentURL(), '/pay', 'expect to be redirected to pay page');
+  });
 
   test('header should show member badge if user has an active subscription', async function (assert) {
     testScenario(this.server);

--- a/tests/acceptance/submit-site-feedback-test.js
+++ b/tests/acceptance/submit-site-feedback-test.js
@@ -49,7 +49,6 @@ module('Acceptance | submit-site-feedback', function (hooks) {
     const feedbackSubmission = server.schema.siteFeedbackSubmissions.first();
     assert.strictEqual(feedbackSubmission.source, 'header');
     assert.strictEqual(JSON.stringify(feedbackSubmission.sourceMetadata), '{}');
-    console.log(feedbackSubmission.explanation);
     assert.strictEqual(feedbackSubmission.explanation, feedbackMessage);
 
     await percySnapshot('Feedback widget - after submission');

--- a/tests/pages/components/header.js
+++ b/tests/pages/components/header.js
@@ -22,6 +22,10 @@ export default {
 
   scope: '[data-test-header]',
 
+  signInButton: {
+    scope: '[data-test-sign-in-with-github-button]',
+  },
+
   upgradeButton: BillingStatusBadge.upgradeButton,
 
   vipBadge: BillingStatusBadge.vipBadge,


### PR DESCRIPTION
Simplify the header authentication logic and streamline the upgrade button implementation for better readability and maintainability.

**Checklist**:

- [x] I've thoroughly self-reviewed my changes
- [x] I've added tests for my changes, unless they affect admin-only areas (or are otherwise not worth testing)
- [ ] I've verified any visual changes using Percy (add a commit with `[percy]` in the message to trigger)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced header displays: unauthenticated users now see a sign-in option while authenticated users access an account dropdown.
  - Feedback and subscription status elements are now always visible, offering consistent access.
  - Streamlined feedback submission adapts smoothly to both authenticated and guest users.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->