### PR TITLE
feat: add default OG metadata for contests

### DIFF
--- a/middleware.js
+++ b/middleware.js
@@ -89,6 +89,10 @@ export default async function middleware(request) {
       pageImageUrl = `/assets/images/contest-og-images/og-amazon-contest-1.png`;
       pageTitle = `CodeCrafters x Amazon`;
       pageDescription = `Compete in the first ever contest exclusively for Amazonians on CodeCrafters.`;
+    } else {
+      pageImageUrl = `/assets/images/contest-og-images/og-amazon-contest-1.png`;
+      pageTitle = `CodeCrafters Contests`;
+      pageDescription = `Compete in this contest only on CodeCrafters.`;
     }
   }
 


### PR DESCRIPTION
**Checklist**:

- [x] I've thoroughly self-reviewed my changes
- [ ] I've added tests for my changes, unless they affect admin-only areas (or are otherwise not worth testing)
- [ ] I've verified any visual changes using Percy (add a commit with `[percy]` in the message to trigger)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved contest page handling by introducing a fallback that displays default content when a specific contest isn’t recognized, ensuring a consistent and complete user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->