### PR TITLE
refactor: remove split git commands feature flag for stage 1

### DIFF
--- a/app/components/course-page/course-stage-step/first-stage-tutorial-card/submit-code-step.hbs
+++ b/app/components/course-page/course-stage-step/first-stage-tutorial-card/submit-code-step.hbs
@@ -1,58 +1,48 @@
-{{#if this.canSeeSplitUpGitCommandsForStage1}}
-  <div class="mb-6">
-    <div class="prose prose-compact dark:prose-invert mb-3">
-      First, run this command to
-      <span class="font-semibold">commit your changes</span>:
-    </div>
-
-    <CopyableTerminalCommand @commands={{array 'git commit -am "[any message]"'}} class="mb-3" />
-
-    <div class="prose prose-compact dark:prose-invert">
-      <p>
-        The output of the command should look like this:
-      </p>
-
-      <pre class="max-w-2xl"><code class="text-xs">[master 8bc0189] [any message]<br />1 file changed, 1 insertion(+), 1 deletion(-)</code></pre>
-
-      <p class="text-xs">
-        <b>Note:</b>
-        If your output doesn't match the above,
-        <a href="#" {{on "click" (fn (mut this.isCommitModalOpen) true)}}>read this</a>.
-      </p>
-    </div>
+<div class="mb-6">
+  <div class="prose prose-compact dark:prose-invert mb-3">
+    First, run this command to
+    <span class="font-semibold">commit your changes</span>:
   </div>
 
-  <div class="mb-6">
-    <div class="prose prose-compact dark:prose-invert mb-3">
-      Next, run this command to
-      <span class="font-semibold">push your changes</span>:
-    </div>
+  <CopyableTerminalCommand @commands={{array 'git commit -am "[any message]"'}} class="mb-3" />
 
-    <CopyableTerminalCommand @commands={{array "git push origin master"}} class="mb-3" />
-
-    <div class="prose prose-compact dark:prose-invert">
-      <p>
-        The output of the command should look like this:
-      </p>
-
-      <pre class="language-bash max-w-2xl"><code class="text-xs">remote: Welcome to CodeCrafters! Your commit was received successfully.</code></pre>
-
-      <p class="text-xs">
-        <b>Note:</b>
-        If your output doesn't match the above,
-        <a href="#" {{on "click" (fn (mut this.isPushModalOpen) true)}}>read this</a>.
-      </p>
-    </div>
-  </div>
-{{else}}
-  <div class="prose dark:prose-invert mb-3">
+  <div class="prose prose-compact dark:prose-invert">
     <p>
-      Run the following commands to submit your changes:
+      The output of the command should look like this:
+    </p>
+
+    <pre class="max-w-2xl"><code class="text-xs">[master 8bc0189] [any message]<br />1 file changed, 1 insertion(+), 1 deletion(-)</code></pre>
+
+    <p class="text-xs">
+      <b>Note:</b>
+      If your output doesn't match the above,
+      <a href="#" {{on "click" (fn (mut this.isCommitModalOpen) true)}}>read this</a>.
     </p>
   </div>
+</div>
 
-  <CopyableTerminalCommand @commands={{array 'git commit -am "[any message]"' "git push origin master"}} class="mb-3" />
-{{/if}}
+<div class="mb-6">
+  <div class="prose prose-compact dark:prose-invert mb-3">
+    Next, run this command to
+    <span class="font-semibold">push your changes</span>:
+  </div>
+
+  <CopyableTerminalCommand @commands={{array "git push origin master"}} class="mb-3" />
+
+  <div class="prose prose-compact dark:prose-invert">
+    <p>
+      The output of the command should look like this:
+    </p>
+
+    <pre class="language-bash max-w-2xl"><code class="text-xs">remote: Welcome to CodeCrafters! Your commit was received successfully.</code></pre>
+
+    <p class="text-xs">
+      <b>Note:</b>
+      If your output doesn't match the above,
+      <a href="#" {{on "click" (fn (mut this.isPushModalOpen) true)}}>read this</a>.
+    </p>
+  </div>
+</div>
 
 <div class="prose dark:prose-invert">
   <p class={{if @isComplete "line-through"}}>

--- a/app/components/course-page/course-stage-step/first-stage-tutorial-card/submit-code-step.ts
+++ b/app/components/course-page/course-stage-step/first-stage-tutorial-card/submit-code-step.ts
@@ -22,10 +22,6 @@ export default class SubmitCodeStepComponent extends Component<Signature> {
   @tracked isCommitModalOpen: boolean = false;
   @tracked isPushModalOpen: boolean = false;
 
-  get canSeeSplitUpGitCommandsForStage1() {
-    return this.featureFlags.canSeeSplitUpGitCommandsForStage1;
-  }
-
   get currentCourse() {
     return this.args.courseStage.course;
   }

--- a/app/services/feature-flags.ts
+++ b/app/services/feature-flags.ts
@@ -26,10 +26,6 @@ export default class FeatureFlagsService extends Service {
     return Boolean(this.currentUser?.isStaff || this.getFeatureFlagValue('can-see-language-guide-before-solution-for-stage-2') === 'test');
   }
 
-  get canSeeSplitUpGitCommandsForStage1(): boolean {
-    return Boolean(this.currentUser?.isStaff || this.getFeatureFlagValue('can-see-split-up-git-commands-for-stage-1') === 'test');
-  }
-
   get canSeeStage2CompletionDiscount(): boolean {
     return Boolean(this.currentUser?.isStaff || this.getFeatureFlagValue('can-see-stage2-completion-discount') === 'test');
   }


### PR DESCRIPTION
**Checklist**:

- [x] I've thoroughly self-reviewed my changes
- [ ] I've added tests for my changes, unless they affect admin-only areas (or are otherwise not worth testing)
- [ ] I've verified any visual changes using Percy (add a commit with `[percy]` in the message to trigger)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Git command instructions for committing and pushing changes are now always visible. Users will consistently see clear guidance, including expected outputs and notes for handling output discrepancies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->