### PR TITLE
feat: add configurable Helpscout Beacon with route-based visibility

### DIFF
--- a/app/components/helpscout-beacon.hbs
+++ b/app/components/helpscout-beacon.hbs
@@ -1,0 +1,5 @@
+{{! Invoke the initialization when the component is inserted into the DOM }}
+<div {{did-insert this.initBeacon}}></div>
+
+{{! Invoke the destruction when the component is removed from the DOM }}
+<div {{will-destroy this.destroyBeacon}}></div>

--- a/app/components/helpscout-beacon.js
+++ b/app/components/helpscout-beacon.js
@@ -1,0 +1,23 @@
+import Component from '@glimmer/component';
+import { action } from '@ember/object';
+import { loadBeaconScript } from '../utils/load-helpscout-beacon';
+
+export default class HelpscoutBeaconComponent extends Component {
+  @action
+  destroyBeacon() {
+    // Clean up Beacon when component is destroyed
+    if (window.Beacon) {
+      window.Beacon('destroy');
+    }
+  }
+
+  @action
+  async initBeacon() {
+    await loadBeaconScript();
+
+    // Apply any configuration passed to the component
+    if (this.args.config) {
+      window.Beacon('config', this.args.config);
+    }
+  }
+}

--- a/app/index.html
+++ b/app/index.html
@@ -18,10 +18,6 @@
     <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;500;600;700;800&display=swap" rel="stylesheet">
     <link href="https://fonts.cdnfonts.com/css/monaco" rel="stylesheet">
 
-    <script type="text/javascript">!function(e,t,n){function a(){var e=t.getElementsByTagName("script")[0],n=t.createElement("script");n.type="text/javascript",n.async=!0,n.src="https://beacon-v2.helpscout.net",e.parentNode.insertBefore(n,e)}if(e.Beacon=n=function(t,n,a){e.Beacon.readyQueue.push({method:t,options:n,data:a})},n.readyQueue=[],"complete"===t.readyState)return a();e.attachEvent?e.attachEvent("onload",a):e.addEventListener("load",a,!1)}(window,document,window.Beacon||function(){});
-    </script>
-
-    <script type="text/javascript">window.Beacon('init', 'bb089ae9-a4ae-4114-8f7a-b660f6310158')</script>
     <script async src="https://metabase.codecrafters.io/app/iframeResizer.js"></script>
 
     <!-- Don't think we need this anymore? -->

--- a/app/routes/concepts.js
+++ b/app/routes/concepts.js
@@ -1,10 +1,15 @@
 import { inject as service } from '@ember/service';
 import BaseRoute from 'codecrafters-frontend/utils/base-route';
+import RouteInfoMetadata, { HelpscoutBeaconVisibility } from 'codecrafters-frontend/utils/route-info-metadata';
 import { hash as RSVPHash } from 'rsvp';
 
 export default class ConceptsRoute extends BaseRoute {
   allowsAnonymousAccess = true;
   @service store;
+
+  buildRouteInfoMetadata() {
+    return new RouteInfoMetadata({ beaconVisibility: HelpscoutBeaconVisibility.Hide });
+  }
 
   async model() {
     if (this.authenticator.isAuthenticated) {

--- a/app/services/beacon.ts
+++ b/app/services/beacon.ts
@@ -1,0 +1,36 @@
+import Service, { service } from '@ember/service';
+import type RouterService from '@ember/routing/router-service';
+import type RouteInfo from '@ember/routing/route-info';
+import RouteInfoMetadata, { HelpscoutBeaconVisibility } from 'codecrafters-frontend/utils/route-info-metadata';
+
+export default class BeaconService extends Service {
+  @service declare router: RouterService;
+
+  get shouldShowBeacon(): boolean {
+    let currentRoute: RouteInfo | null = this.router.currentRoute;
+
+    while (currentRoute) {
+      const metadata = currentRoute.metadata;
+
+      if (metadata instanceof RouteInfoMetadata) {
+        if (metadata.beaconVisibility === HelpscoutBeaconVisibility.Hide) {
+          return false;
+        } else if (metadata.beaconVisibility === HelpscoutBeaconVisibility.Show) {
+          return true;
+        }
+      }
+
+      currentRoute = currentRoute.parent;
+    }
+
+    // Default to showing the beacon if no route specifies otherwise
+    return true;
+  }
+}
+
+// Type declaration for service injection
+declare module '@ember/service' {
+  interface Registry {
+    beacon: BeaconService;
+  }
+}

--- a/app/templates/application.hbs
+++ b/app/templates/application.hbs
@@ -19,6 +19,10 @@
   {{#if this.layout.shouldShowFooter}}
     <Footer />
   {{/if}}
+
+  {{#if this.beacon.shouldShowBeacon}}
+    <HelpscoutBeacon />
+  {{/if}}
 </div>
 
 <LoadingIndicatorRemover />

--- a/app/utils/load-helpscout-beacon.js
+++ b/app/utils/load-helpscout-beacon.js
@@ -1,0 +1,34 @@
+export function loadBeaconScript() {
+  return new Promise((resolve) => {
+    (function (window, document, Beacon) {
+      function loadBeaconScript() {
+        var firstScript = document.getElementsByTagName('script')[0];
+        var beaconScript = document.createElement('script');
+        beaconScript.type = 'text/javascript';
+        beaconScript.async = true;
+        beaconScript.src = 'https://beacon-v2.helpscout.net';
+        firstScript.parentNode.insertBefore(beaconScript, firstScript);
+        beaconScript.onload = resolve;
+      }
+
+      if (
+        ((window.Beacon = Beacon =
+          function (method, options, data) {
+            window.Beacon.readyQueue.push({ method, options, data });
+          }),
+        (Beacon.readyQueue = []),
+        document.readyState === 'complete')
+      ) {
+        return loadBeaconScript();
+      }
+
+      if (window.attachEvent) {
+        window.attachEvent('onload', loadBeaconScript);
+      } else {
+        window.addEventListener('load', loadBeaconScript, false);
+      }
+    })(window, document, window.Beacon || function () {});
+
+    window.Beacon('init', 'bb089ae9-a4ae-4114-8f7a-b660f6310158');
+  });
+}

--- a/app/utils/route-info-metadata.ts
+++ b/app/utils/route-info-metadata.ts
@@ -4,10 +4,20 @@ export enum RouteColorScheme {
   Both,
 }
 
+export enum HelpscoutBeaconVisibility {
+  Show,
+  Hide,
+}
+
 export default class RouteInfoMetadata {
   colorScheme: RouteColorScheme = RouteColorScheme.Light;
+  beaconVisibility: HelpscoutBeaconVisibility = HelpscoutBeaconVisibility.Show;
 
-  constructor({ colorScheme = RouteColorScheme.Light }: { colorScheme?: RouteColorScheme } = {}) {
+  constructor({
+    colorScheme = RouteColorScheme.Light,
+    beaconVisibility = HelpscoutBeaconVisibility.Show,
+  }: { colorScheme?: RouteColorScheme; beaconVisibility?: HelpscoutBeaconVisibility } = {}) {
     this.colorScheme = colorScheme;
+    this.beaconVisibility = beaconVisibility;
   }
 }


### PR DESCRIPTION
**Checklist**:

- [ ] I've thoroughly self-reviewed my changes
- [ ] I've added tests for my changes, unless they affect admin-only areas (or are otherwise not worth testing)
- [ ] I've verified any visual changes using Percy (add a commit with `[percy]` in the message to trigger)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a revamped Help Scout Beacon integration that dynamically initializes, configures, and cleans up for improved customer support.
  - Enabled conditional display of the Beacon based on page-specific settings.
  - Implemented asynchronous loading to enhance performance.

- **Chores**
  - Removed legacy Beacon scripts from the main HTML to streamline the integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->