### PR TITLE
[CC-1514] feat: add buildpack version management to submission details

### DIFF
--- a/app/components/course-admin/submissions-page/submission-details/header-container.hbs
+++ b/app/components/course-admin/submissions-page/submission-details/header-container.hbs
@@ -90,10 +90,10 @@
           </div>
         </CourseAdmin::SubmissionsPage::SubmissionDetails::HeaderContainerRow>
 
-        <CourseAdmin::SubmissionsPage::SubmissionDetails::HeaderContainerRow @title="Build Pack">
+        <CourseAdmin::SubmissionsPage::SubmissionDetails::HeaderContainerRow @title="Buildpack">
           <div class="flex items-center">
-            <span class="mr-2 text-gray-600">
-              {{this.buildpackLanguageVersion}}
+            <span class="text-gray-600">
+              {{this.buildpackSlug}}
             </span>
 
             {{#if @submission.repository.buildpack.isLatest}}

--- a/app/components/course-admin/submissions-page/submission-details/header-container.hbs
+++ b/app/components/course-admin/submissions-page/submission-details/header-container.hbs
@@ -90,6 +90,27 @@
           </div>
         </CourseAdmin::SubmissionsPage::SubmissionDetails::HeaderContainerRow>
 
+        <CourseAdmin::SubmissionsPage::SubmissionDetails::HeaderContainerRow @title="Build Pack">
+          <div class="flex items-center">
+            <span class="mr-2 text-gray-600">
+              {{this.buildpackLanguageVersion}}
+            </span>
+
+            {{#if @submission.repository.buildpack.isLatest}}
+              <span class="ml-1 text-gray-400 text-sm">(active)</span>
+            {{else}}
+              <TertiaryButtonWithSpinner
+                @shouldShowSpinner={{this.isUpdatingBuildpack}}
+                @size="extra-small"
+                class="ml-2"
+                {{on "click" this.handleBuildpackUpdateButtonClick}}
+              >
+                Update to active version
+              </TertiaryButtonWithSpinner>
+            {{/if}}
+          </div>
+        </CourseAdmin::SubmissionsPage::SubmissionDetails::HeaderContainerRow>
+
         <CourseAdmin::SubmissionsPage::SubmissionDetails::HeaderContainerRow @title="Commit SHA" data-test-commit-sha>
           <div class="flex items-center">
             <span class="mr-2 text-gray-600">

--- a/app/components/course-admin/submissions-page/submission-details/header-container.ts
+++ b/app/components/course-admin/submissions-page/submission-details/header-container.ts
@@ -21,12 +21,8 @@ export default class HeaderContainerComponent extends Component<Signature> {
   @service declare authenticator: AuthenticatorService;
   @service declare router: RouterService;
 
-  get buildpackLanguageVersion() {
-    if (this.args.submission.repository.buildpack) {
-      return this.args.submission.repository.buildpack.languageVersion;
-    } else {
-      return 'Unknown';
-    }
+  get buildpackSlug() {
+    return this.args.submission.repository.buildpack.slug;
   }
 
   get durationInMilliseconds() {

--- a/app/components/course-admin/submissions-page/submission-details/header-container.ts
+++ b/app/components/course-admin/submissions-page/submission-details/header-container.ts
@@ -22,7 +22,11 @@ export default class HeaderContainerComponent extends Component<Signature> {
   @service declare router: RouterService;
 
   get buildpackSlug() {
-    return this.args.submission.repository.buildpack.slug;
+    if (this.args.submission.repository.buildpack) {
+      return this.args.submission.repository.buildpack.slug;
+    } else {
+      return 'Unknown';
+    }
   }
 
   get durationInMilliseconds() {

--- a/app/components/course-admin/submissions-page/submission-details/header-container.ts
+++ b/app/components/course-admin/submissions-page/submission-details/header-container.ts
@@ -14,11 +14,20 @@ export interface Signature {
 }
 
 export default class HeaderContainerComponent extends Component<Signature> {
+  @tracked isUpdatingBuildpack = false;
   @tracked isUpdatingTesterVersion = false;
   @tracked isForking = false;
 
   @service declare authenticator: AuthenticatorService;
   @service declare router: RouterService;
+
+  get buildpackLanguageVersion() {
+    if (this.args.submission.repository.buildpack) {
+      return this.args.submission.repository.buildpack.languageVersion;
+    } else {
+      return 'Unknown';
+    }
+  }
 
   get durationInMilliseconds() {
     return this.args.submission.evaluations[0]!.createdAt.getTime() - this.args.submission.createdAt.getTime();
@@ -54,6 +63,13 @@ export default class HeaderContainerComponent extends Component<Signature> {
     } else {
       return 'Unknown';
     }
+  }
+
+  @action
+  async handleBuildpackUpdateButtonClick() {
+    this.isUpdatingBuildpack = true;
+    await this.args.submission.repository.updateBuildpack({});
+    this.isUpdatingBuildpack = false;
   }
 
   @action

--- a/app/models/repository.ts
+++ b/app/models/repository.ts
@@ -11,6 +11,7 @@ import RepositoryStageListModel from 'codecrafters-frontend/models/repository-st
 import SubmissionModel from 'codecrafters-frontend/models/submission';
 import UserModel from 'codecrafters-frontend/models/user';
 import type AutofixRequestModel from './autofix-request';
+import type BuildpackModel from './buildpack';
 import type CourseExtensionModel from './course-extension';
 import type CourseStageSolutionModel from './course-stage-solution';
 import type Store from '@ember-data/store';
@@ -41,6 +42,7 @@ export default class RepositoryModel extends Model {
   };
 
   @hasMany('autofix-request', { async: false, inverse: 'repository' }) declare autofixRequests: AutofixRequestModel[];
+  @belongsTo('buildpack', { async: false, inverse: null }) declare buildpack: BuildpackModel;
   @belongsTo('course', { async: false, inverse: null }) declare course: CourseModel;
   @hasMany('course-extension-activation', { async: false, inverse: 'repository' }) declare extensionActivations: CourseExtensionActivation[];
   @hasMany('course-stage-completion', { async: false, inverse: 'repository' }) declare courseStageCompletions: CourseStageCompletionModel[];
@@ -248,6 +250,7 @@ export default class RepositoryModel extends Model {
   }
 
   declare fork: (this: Model, payload: unknown) => Promise<{ data: { id: string } }>;
+  declare updateBuildpack: (this: Model, payload: unknown) => Promise<void>;
   declare updateTesterVersion: (this: Model, payload: unknown) => Promise<void>;
 }
 

--- a/app/models/repository.ts
+++ b/app/models/repository.ts
@@ -254,6 +254,11 @@ export default class RepositoryModel extends Model {
   declare updateTesterVersion: (this: Model, payload: unknown) => Promise<void>;
 }
 
+RepositoryModel.prototype.updateBuildpack = memberAction({
+  path: 'update-buildpack',
+  type: 'post',
+});
+
 RepositoryModel.prototype.updateTesterVersion = memberAction({
   path: 'update-tester-version',
   type: 'post',

--- a/app/routes/course-admin/submissions.js
+++ b/app/routes/course-admin/submissions.js
@@ -39,6 +39,7 @@ export default class CourseAdminSubmissionsRoute extends BaseRoute {
       ...{
         include: [
           'evaluations',
+          'repository.buildpack',
           'repository.language',
           'repository.user',
           'course-stage',


### PR DESCRIPTION
**Checklist**:

- [x] I've thoroughly self-reviewed my changes
- [ ] I've added tests for my changes, unless they affect admin-only areas (or are otherwise not worth testing)
- [ ] I've verified any visual changes using Percy (add a commit with `[percy]` in the message to trigger)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a new section on the submissions detail page that displays buildpack information, including the current version.
  - Users can see whether the buildpack is active or needs updating, and interact via a responsive update button with a loading indicator.
  - Enhanced data integration ensures comprehensive buildpack details are included as part of submission information.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->