### PR TITLE
fix: update tooltip message for banned users

### DIFF
--- a/app/components/contest-page/leaderboard-entry.hbs
+++ b/app/components/contest-page/leaderboard-entry.hbs
@@ -26,6 +26,6 @@
   </div>
 
   {{#if (and this.isCurrentUserEntry @entry.isBanned)}}
-    <EmberTooltip @text="You've been banned from contests. If you think this is a mistake, contact us at hello@codecrafters.io." />
+    <EmberTooltip @text="You are not eligible for this contest. If you think this is a mistake, please contact us at hello@codecrafters.io." />
   {{/if}}
 </a>


### PR DESCRIPTION
Change the tooltip message displayed for banned users on the 
contest leaderboard entry. The new message clarifies that the 
user is not eligible for the contest and provides contact 
information for further inquiries. This improves user 
understanding and support communication.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Updated the tooltip message for contest participation to clarify eligibility, ensuring that users are informed of their contest status and are provided with contact instructions if there are concerns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->