### PR TITLE
fix(header): increase max width of track description

### DIFF
--- a/app/components/track-page/header/index.hbs
+++ b/app/components/track-page/header/index.hbs
@@ -10,7 +10,7 @@
       </div>
     </div>
 
-    <p class="text-gray-600 dark:text-gray-400 mb-3 max-w-xl text-base md:text-lg" data-test-track-header-description>
+    <p class="text-gray-600 dark:text-gray-400 mb-3 max-w-2xl text-base md:text-lg" data-test-track-header-description>
       {{markdown-to-html @language.trackDescriptionMarkdown}}
     </p>
 


### PR DESCRIPTION
Update the max width of the track description paragraph to 
max-w-2xl for better readability. This change enhances the 
visual presentation of the track description on the page.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Adjusted the track description layout to display text in a wider format, enhancing readability on the track page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->