### PR TITLE
feat: update page title for concept editing view

### DIFF
--- a/app/templates/concept-admin.hbs
+++ b/app/templates/concept-admin.hbs
@@ -1,4 +1,4 @@
-{{page-title "Concepts Admin"}}
+{{page-title (concat "Edit Concept: " (or @model.concept.title "Unknown"))}}
 
 <ConceptAdmin::Header @concept={{@model.concept}} />
 

--- a/app/templates/course.hbs
+++ b/app/templates/course.hbs
@@ -1,4 +1,4 @@
-{{page-title "Courses"}}
+{{page-title @model.course.name}}
 
 <div
   class="flex h-screen w-full relative"


### PR DESCRIPTION
Change the page title in the concepts admin template to reflect the 
specific concept being edited. The title now concatenates "Edit Concept: " 
with the concept's title or defaults to "Unknown" if no title is present. 
This improves clarity for users by providing context on the current 
action being performed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- The Concepts Admin page now displays a dynamic title reflecting the concept being edited.
	- The Courses page has been updated to show a dynamic course title and improved handling of current step information for better contextual accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->