### PR TITLE
fix: handle empty markdown block gracefully

### DIFF
--- a/app/components/blocks/markdown-block.hbs
+++ b/app/components/blocks/markdown-block.hbs
@@ -4,5 +4,5 @@
   {{did-update this.handleDidUpdateHTML @model.markdown}}
   ...attributes
 >
-  {{markdown-to-html @model.markdown}}
+  {{markdown-to-html (or @model.markdown "**_(!! empty markdown block !!)_**")}}
 </div>


### PR DESCRIPTION
Update the markdown block component to display a placeholder text 
when the markdown content is empty. This change ensures that users 
see a clear indication of an empty block instead of a blank space, 
improving the overall user experience.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Markdown sections now display a default placeholder when no content is provided, ensuring clearer and more informative displays for users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->