### PR TITLE
Refactor concept engagement block counting and progress display

### DIFF
--- a/app/components/concept-progress.hbs
+++ b/app/components/concept-progress.hbs
@@ -6,9 +6,9 @@
 
     <div class="flex-shrink-0 ml-3 text-gray-600 text-sm font-medium">
       <AnimatedContainer>
-        {{#animated-value @latestConceptEngagement.currentProgressPercentage rules=this.rules duration=200 as |v|}}
+        {{#animated-value @latestConceptEngagement.completedBlocksCount rules=this.rules duration=200 as |c|}}
           <div>
-            {{v}}%
+            {{c}}/{{@latestConceptEngagement.totalBlocksCount}}
           </div>
         {{/animated-value}}
       </AnimatedContainer>

--- a/app/components/concept-progress.hbs
+++ b/app/components/concept-progress.hbs
@@ -6,9 +6,9 @@
 
     <div class="flex-shrink-0 ml-3 text-gray-600 text-sm font-medium">
       <AnimatedContainer>
-        {{#animated-value @latestConceptEngagement.completedBlocksCount rules=this.rules duration=200 as |c|}}
+        {{#animated-value @latestConceptEngagement.completedBlockGroupsCount rules=this.rules duration=200 as |c|}}
           <div>
-            {{c}}/{{@latestConceptEngagement.totalBlocksCount}}
+            {{c}}/{{@latestConceptEngagement.totalBlockGroupsCount}}
           </div>
         {{/animated-value}}
       </AnimatedContainer>

--- a/app/components/concept-progress.hbs
+++ b/app/components/concept-progress.hbs
@@ -14,17 +14,4 @@
       </AnimatedContainer>
     </div>
   </div>
-
-  {{#if (lt @latestConceptEngagement.currentProgressPercentage 100)}}
-    <div class="flex-shrink-0 mt-2 text-gray-600 text-xs">
-      <AnimatedContainer>
-        {{#animated-value @latestConceptEngagement.remainingBlocksCount rules=this.rules duration=200 as |v|}}
-          <div>
-            <span class="font-medium">{{v}}</span>
-            blocks left
-          </div>
-        {{/animated-value}}
-      </AnimatedContainer>
-    </div>
-  {{/if}}
 </div>

--- a/app/components/concept/index.ts
+++ b/app/components/concept/index.ts
@@ -118,11 +118,10 @@ export default class ConceptComponent extends Component<Signature> {
 
   @action
   async handleContinueButtonClick() {
-    if (this.currentBlockGroupIndex === this.allBlockGroups.length - 1) {
+    this.updateLastRevealedBlockGroupIndex(this.currentBlockGroupIndex + 1);
+    this.enqueueConceptEngagementUpdate.perform();
+    if (this.currentBlockGroupIndex === this.allBlockGroups.length) {
       this.hasFinished = true;
-    } else {
-      this.updateLastRevealedBlockGroupIndex(this.currentBlockGroupIndex + 1);
-      this.enqueueConceptEngagementUpdate.perform();
     }
 
     this.analyticsEventTracker.track('progressed_through_concept', {

--- a/app/components/concept/index.ts
+++ b/app/components/concept/index.ts
@@ -8,7 +8,7 @@ import type { BlockGroup } from 'codecrafters-frontend/models/concept';
 import { ConceptQuestionBlock } from 'codecrafters-frontend/utils/blocks';
 import { TrackedSet } from 'tracked-built-ins';
 import { action } from '@ember/object';
-import { cached, tracked } from '@glimmer/tracking';
+import { tracked } from '@glimmer/tracking';
 import { inject as service } from '@ember/service';
 import { next } from '@ember/runloop';
 import { task } from 'ember-concurrency';

--- a/app/components/concept/index.ts
+++ b/app/components/concept/index.ts
@@ -49,8 +49,8 @@ export default class ConceptComponent extends Component<Signature> {
   }
 
   @cached
-  get allBlockGroups(): BlockGroup[] {
-    return this.args.concept.allBlockGroups;
+  get blockGroups(): BlockGroup[] {
+    return this.args.concept.blockGroups;
   }
 
   @cached
@@ -59,7 +59,7 @@ export default class ConceptComponent extends Component<Signature> {
   }
 
   get completedBlocksCount() {
-    return this.allBlockGroups.reduce((count, blockGroup) => {
+    return this.blockGroups.reduce((count, blockGroup) => {
       if (blockGroup.index < this.currentBlockGroupIndex) {
         count += blockGroup.blocks.length;
       }
@@ -85,15 +85,15 @@ export default class ConceptComponent extends Component<Signature> {
   }
 
   get visibleBlockGroups() {
-    return this.allBlockGroups.slice(0, (this.lastRevealedBlockGroupIndex || 0) + 1);
+    return this.blockGroups.slice(0, (this.lastRevealedBlockGroupIndex || 0) + 1);
   }
 
   findCurrentBlockGroupIndex(completedBlocksCount: number) {
     let traversedBlocksCount = 0;
     let currentBlockGroupIndex = 0;
 
-    for (let i = 0; i < this.allBlockGroups.length; i++) {
-      const blockGroup = this.allBlockGroups[i];
+    for (let i = 0; i < this.blockGroups.length; i++) {
+      const blockGroup = this.blockGroups[i];
       traversedBlocksCount = traversedBlocksCount + blockGroup!.blocks.length;
 
       if (traversedBlocksCount > completedBlocksCount) {
@@ -121,7 +121,7 @@ export default class ConceptComponent extends Component<Signature> {
     this.updateLastRevealedBlockGroupIndex(this.currentBlockGroupIndex + 1);
     this.enqueueConceptEngagementUpdate.perform();
 
-    if (this.currentBlockGroupIndex === this.allBlockGroups.length) {
+    if (this.currentBlockGroupIndex === this.blockGroups.length) {
       this.hasFinished = true;
     }
 
@@ -147,7 +147,7 @@ export default class ConceptComponent extends Component<Signature> {
     if (this.currentBlockGroupIndex === 0) {
       return;
     } else {
-      (this.allBlockGroups[this.currentBlockGroupIndex] as BlockGroup).blocks.forEach((block) => {
+      (this.blockGroups[this.currentBlockGroupIndex] as BlockGroup).blocks.forEach((block) => {
         if (block.type === 'concept_question') {
           this.submittedQuestionSlugs.delete((block as ConceptQuestionBlock).conceptQuestionSlug);
         }

--- a/app/components/concept/index.ts
+++ b/app/components/concept/index.ts
@@ -120,6 +120,7 @@ export default class ConceptComponent extends Component<Signature> {
   async handleContinueButtonClick() {
     this.updateLastRevealedBlockGroupIndex(this.currentBlockGroupIndex + 1);
     this.enqueueConceptEngagementUpdate.perform();
+
     if (this.currentBlockGroupIndex === this.allBlockGroups.length) {
       this.hasFinished = true;
     }

--- a/app/components/concept/index.ts
+++ b/app/components/concept/index.ts
@@ -50,19 +50,7 @@ export default class ConceptComponent extends Component<Signature> {
 
   @cached
   get allBlockGroups(): BlockGroup[] {
-    return this.allBlocks.reduce((groups, block) => {
-      if (groups.length <= 0) {
-        groups.push({ index: 0, blocks: [] });
-      }
-
-      (groups[groups.length - 1] as BlockGroup).blocks.push(block);
-
-      if (block.isInteractable || groups.length === 0) {
-        groups.push({ index: groups.length, blocks: [] });
-      }
-
-      return groups;
-    }, [] as BlockGroup[]);
+    return this.args.concept.allBlockGroups;
   }
 
   @cached

--- a/app/components/concept/index.ts
+++ b/app/components/concept/index.ts
@@ -22,7 +22,7 @@ interface Signature {
   Element: HTMLDivElement;
 }
 
-interface BlockGroup {
+export interface BlockGroup {
   index: number;
   blocks: Block[];
 }

--- a/app/components/concept/index.ts
+++ b/app/components/concept/index.ts
@@ -4,7 +4,7 @@ import Component from '@glimmer/component';
 import ConceptEngagementModel from 'codecrafters-frontend/models/concept-engagement';
 import ConceptModel from 'codecrafters-frontend/models/concept';
 import config from 'codecrafters-frontend/config/environment';
-import type { Block } from 'codecrafters-frontend/models/concept';
+import type { BlockGroup } from 'codecrafters-frontend/models/concept';
 import { ConceptQuestionBlock } from 'codecrafters-frontend/utils/blocks';
 import { TrackedSet } from 'tracked-built-ins';
 import { action } from '@ember/object';
@@ -20,11 +20,6 @@ interface Signature {
   };
 
   Element: HTMLDivElement;
-}
-
-export interface BlockGroup {
-  index: number;
-  blocks: Block[];
 }
 
 export default class ConceptComponent extends Component<Signature> {

--- a/app/components/concept/index.ts
+++ b/app/components/concept/index.ts
@@ -52,12 +52,12 @@ export default class ConceptComponent extends Component<Signature> {
     return this.args.concept.parsedBlocks;
   }
 
-  get blockGroups(): BlockGroup[] {
+  get allBlockGroups(): BlockGroup[] {
     return this.args.concept.blockGroups;
   }
 
   get completedBlocksCount() {
-    return this.blockGroups.reduce((count, blockGroup) => {
+    return this.allBlockGroups.reduce((count, blockGroup) => {
       if (blockGroup.index < this.currentBlockGroupIndex) {
         count += blockGroup.blocks.length;
       }
@@ -83,15 +83,15 @@ export default class ConceptComponent extends Component<Signature> {
   }
 
   get visibleBlockGroups() {
-    return this.blockGroups.slice(0, (this.lastRevealedBlockGroupIndex || 0) + 1);
+    return this.allBlockGroups.slice(0, (this.lastRevealedBlockGroupIndex || 0) + 1);
   }
 
   findCurrentBlockGroupIndex(completedBlocksCount: number) {
     let traversedBlocksCount = 0;
     let currentBlockGroupIndex = 0;
 
-    for (let i = 0; i < this.blockGroups.length; i++) {
-      const blockGroup = this.blockGroups[i];
+    for (let i = 0; i < this.allBlockGroups.length; i++) {
+      const blockGroup = this.allBlockGroups[i];
       traversedBlocksCount = traversedBlocksCount + blockGroup!.blocks.length;
 
       if (traversedBlocksCount > completedBlocksCount) {
@@ -116,7 +116,7 @@ export default class ConceptComponent extends Component<Signature> {
 
   @action
   async handleContinueButtonClick() {
-    if (this.currentBlockGroupIndex === this.blockGroups.length - 1) {
+    if (this.currentBlockGroupIndex === this.allBlockGroups.length - 1) {
       this.hasFinished = true;
     } else {
       this.updateLastRevealedBlockGroupIndex(this.currentBlockGroupIndex + 1);
@@ -146,7 +146,7 @@ export default class ConceptComponent extends Component<Signature> {
     if (this.currentBlockGroupIndex === 0) {
       return;
     } else {
-      (this.blockGroups[this.currentBlockGroupIndex] as BlockGroup).blocks.forEach((block) => {
+      (this.allBlockGroups[this.currentBlockGroupIndex] as BlockGroup).blocks.forEach((block) => {
         if (block.type === 'concept_question') {
           this.submittedQuestionSlugs.delete((block as ConceptQuestionBlock).conceptQuestionSlug);
         }

--- a/app/components/concept/index.ts
+++ b/app/components/concept/index.ts
@@ -48,22 +48,20 @@ export default class ConceptComponent extends Component<Signature> {
     }
   }
 
-  get allBlocks() {
-    return this.args.concept.parsedBlocks;
-  }
-
   get allBlockGroups(): BlockGroup[] {
     return this.args.concept.blockGroups;
   }
 
-  get completedBlocksCount() {
-    return this.allBlockGroups.reduce((count, blockGroup) => {
-      if (blockGroup.index < this.currentBlockGroupIndex) {
-        count += blockGroup.blocks.length;
-      }
+  get allBlocks() {
+    return this.args.concept.parsedBlocks;
+  }
 
-      return count;
-    }, 0);
+  get completedBlockGroups() {
+    return this.allBlockGroups.slice(0, this.currentBlockGroupIndex);
+  }
+
+  get completedBlocksCount() {
+    return this.completedBlockGroups.map((blockGroup) => blockGroup.blocks.length).reduce((a, b) => a + b, 0);
   }
 
   get computedProgressPercentage() {

--- a/app/components/concept/index.ts
+++ b/app/components/concept/index.ts
@@ -48,12 +48,10 @@ export default class ConceptComponent extends Component<Signature> {
     }
   }
 
-  @cached
   get allBlocks() {
     return this.args.concept.parsedBlocks;
   }
 
-  @cached
   get blockGroups(): BlockGroup[] {
     return this.args.concept.blockGroups;
   }

--- a/app/components/concept/index.ts
+++ b/app/components/concept/index.ts
@@ -49,13 +49,13 @@ export default class ConceptComponent extends Component<Signature> {
   }
 
   @cached
-  get blockGroups(): BlockGroup[] {
-    return this.args.concept.blockGroups;
+  get allBlocks() {
+    return this.args.concept.parsedBlocks;
   }
 
   @cached
-  get allBlocks() {
-    return this.args.concept.parsedBlocks;
+  get blockGroups(): BlockGroup[] {
+    return this.args.concept.blockGroups;
   }
 
   get completedBlocksCount() {
@@ -124,7 +124,7 @@ export default class ConceptComponent extends Component<Signature> {
       this.updateLastRevealedBlockGroupIndex(this.currentBlockGroupIndex + 1);
     }
 
-    this.enqueueConceptEngagementUpdate.perform();  
+    this.enqueueConceptEngagementUpdate.perform();
 
     this.analyticsEventTracker.track('progressed_through_concept', {
       concept_id: this.args.concept.id,

--- a/app/components/concept/index.ts
+++ b/app/components/concept/index.ts
@@ -118,12 +118,13 @@ export default class ConceptComponent extends Component<Signature> {
 
   @action
   async handleContinueButtonClick() {
-    this.updateLastRevealedBlockGroupIndex(this.currentBlockGroupIndex + 1);
-    this.enqueueConceptEngagementUpdate.perform();
-
-    if (this.currentBlockGroupIndex === this.blockGroups.length) {
+    if (this.currentBlockGroupIndex === this.blockGroups.length - 1) {
       this.hasFinished = true;
+    } else {
+      this.updateLastRevealedBlockGroupIndex(this.currentBlockGroupIndex + 1);
     }
+
+    this.enqueueConceptEngagementUpdate.perform();  
 
     this.analyticsEventTracker.track('progressed_through_concept', {
       concept_id: this.args.concept.id,

--- a/app/models/concept-engagement.ts
+++ b/app/models/concept-engagement.ts
@@ -1,12 +1,8 @@
-import ConceptModel, { type Block } from 'codecrafters-frontend/models/concept';
+import ConceptModel from 'codecrafters-frontend/models/concept';
 import UserModel from 'codecrafters-frontend/models/user';
 import Model, { attr, belongsTo } from '@ember-data/model';
-import { cached, tracked } from '@glimmer/tracking';
-
-export interface BlockGroup {
-  index: number;
-  blocks: Block[];
-}
+import { cached } from '@glimmer/tracking';
+import type { BlockGroup } from 'codecrafters-frontend/components/concept';
 
 export default class ConceptEngagementModel extends Model {
   @belongsTo('concept', { async: false, inverse: 'engagements' }) declare concept: ConceptModel;
@@ -16,31 +12,13 @@ export default class ConceptEngagementModel extends Model {
   @attr('date') declare lastActivityAt: Date;
   @attr('date') declare startedAt: Date;
 
-  // This needs to be updated on button clicks
-  @tracked lastRevealedBlockGroupIndex: number | null = null;
-
-  get currentBlockGroupIndex() {
-    return this.lastRevealedBlockGroupIndex || 0;
-  }
-
   get completedBlocksCount() {
-    return this.allBlockGroups.reduce((count, blockGroup) => {
-      if (blockGroup.index < this.currentBlockGroupIndex) {
-        count += blockGroup.blocks.length;
-      }
-
-      return count;
-    }, 0);
-  }
-
-  @cached
-  get allBlocks() {
-    return this.concept.parsedBlocks;
+    return Math.round((this.currentProgressPercentage / 100) * this.totalBlocksCount);
   }
 
   @cached
   get allBlockGroups(): BlockGroup[] {
-    return this.allBlocks.reduce((groups, block) => {
+    return this.concept.parsedBlocks.reduce((groups, block) => {
       if (groups.length <= 0) {
         groups.push({ index: 0, blocks: [] });
       }
@@ -56,8 +34,6 @@ export default class ConceptEngagementModel extends Model {
   }
 
   get totalBlocksCount() {
-    const allBlocks = this.allBlockGroups;
-
-    return allBlocks.length;
+    return this.allBlockGroups.length;
   }
 }

--- a/app/models/concept-engagement.ts
+++ b/app/models/concept-engagement.ts
@@ -1,4 +1,4 @@
-import ConceptModel from 'codecrafters-frontend/models/concept';
+import ConceptModel, { type Block } from 'codecrafters-frontend/models/concept';
 import UserModel from 'codecrafters-frontend/models/user';
 import Model, { attr, belongsTo } from '@ember-data/model';
 import { cached } from '@glimmer/tracking';
@@ -12,9 +12,8 @@ export default class ConceptEngagementModel extends Model {
   @attr('date') declare lastActivityAt: Date;
   @attr('date') declare startedAt: Date;
 
-  @cached
-  get allBlockGroups(): BlockGroup[] {
-    return this.concept.parsedBlocks.reduce((groups, block) => {
+  getAllBlockGroups(blocks: Block[]): BlockGroup[] {
+    return blocks.reduce((groups, block) => {
       if (groups.length <= 0) {
         groups.push({ index: 0, blocks: [] });
       }
@@ -30,10 +29,16 @@ export default class ConceptEngagementModel extends Model {
   }
 
   get completedBlocksCount() {
-    return Math.round((this.currentProgressPercentage / 100) * this.totalBlocksCount);
+    let index = Math.round((this.currentProgressPercentage / 100) * this.rawTotalBlocksCount());
+
+    return this.getAllBlockGroups(this.concept.parsedBlocks.slice(0, index)).length;
   }
 
   get totalBlocksCount() {
-    return this.allBlockGroups?.length ?? 0;
+    return this.getAllBlockGroups(this.concept.parsedBlocks).length;
+  }
+
+  rawTotalBlocksCount() {
+    return this.concept.parsedBlocks.length;
   }
 }

--- a/app/models/concept-engagement.ts
+++ b/app/models/concept-engagement.ts
@@ -12,10 +12,6 @@ export default class ConceptEngagementModel extends Model {
   @attr('date') declare lastActivityAt: Date;
   @attr('date') declare startedAt: Date;
 
-  get completedBlocksCount() {
-    return Math.round((this.currentProgressPercentage / 100) * this.totalBlocksCount);
-  }
-
   @cached
   get allBlockGroups(): BlockGroup[] {
     return this.concept.parsedBlocks.reduce((groups, block) => {
@@ -33,6 +29,10 @@ export default class ConceptEngagementModel extends Model {
     }, [] as BlockGroup[]);
   }
 
+  get completedBlocksCount() {
+    return Math.round((this.currentProgressPercentage / 100) * this.totalBlocksCount);
+  }
+ 
   get totalBlocksCount() {
     return this.allBlockGroups.length;
   }

--- a/app/models/concept-engagement.ts
+++ b/app/models/concept-engagement.ts
@@ -13,21 +13,21 @@ export default class ConceptEngagementModel extends Model {
   get completedBlockGroupsCount() {
     const completedBlocksCount = Math.round((this.currentProgressPercentage / 100) * this.totalBlocksCount);
 
-    return this.convertBlockProgressIntoBlockGroupProgress(this.concept.allBlockGroups, completedBlocksCount);
+    return this.convertBlockProgressIntoBlockGroupProgress(this.concept.blockGroups, completedBlocksCount);
   }
 
   get totalBlockGroupsCount() {
-    return this.concept.allBlockGroups.length;
+    return this.concept.blockGroups.length;
   }
 
   get totalBlocksCount() {
     return this.concept.parsedBlocks.length;
   }
 
-  convertBlockProgressIntoBlockGroupProgress(allBlockGroups: BlockGroup[], completedBlocksCount: number) {
+  convertBlockProgressIntoBlockGroupProgress(blockGroups: BlockGroup[], completedBlocksCount: number) {
     let completedBlockGroups = 0;
 
-    for (const blockGroup of allBlockGroups) {
+    for (const blockGroup of blockGroups) {
       completedBlockGroups += blockGroup.blocks.length;
 
       if (completedBlocksCount <= completedBlockGroups) {
@@ -35,6 +35,6 @@ export default class ConceptEngagementModel extends Model {
       }
     }
 
-    return allBlockGroups.length;
+    return blockGroups.length;
   }
 }

--- a/app/models/concept-engagement.ts
+++ b/app/models/concept-engagement.ts
@@ -32,7 +32,7 @@ export default class ConceptEngagementModel extends Model {
   get completedBlocksCount() {
     return Math.round((this.currentProgressPercentage / 100) * this.totalBlocksCount);
   }
- 
+
   get totalBlocksCount() {
     return this.allBlockGroups.length;
   }

--- a/app/models/concept-engagement.ts
+++ b/app/models/concept-engagement.ts
@@ -16,6 +16,7 @@ export default class ConceptEngagementModel extends Model {
 
   get totalBlocksCount() {
     const allBlocks = this.concept.parsedBlocks;
+
     return allBlocks.length;
   }
 }

--- a/app/models/concept-engagement.ts
+++ b/app/models/concept-engagement.ts
@@ -16,23 +16,25 @@ export default class ConceptEngagementModel extends Model {
     return this.convertBlockProgressIntoBlockGroupProgress(this.concept.allBlockGroups, completedBlocksCount);
   }
 
-  convertBlockProgressIntoBlockGroupProgress(allBlockGroups: BlockGroup[], completedBlocksCount: number) {
-    let completedBlockGroups = 0;
-    for (const blockGroup of allBlockGroups) {
-      completedBlockGroups += blockGroup.blocks.length;
-      if (completedBlocksCount <= completedBlockGroups) {
-        return blockGroup.index + 2;
-      }
-    }
-
-    return allBlockGroups.length;
-  }
-
   get totalBlockGroupsCount() {
     return this.concept.allBlockGroups.length;
   }
 
   get totalBlocksCount() {
     return this.concept.parsedBlocks.length;
+  }
+
+  convertBlockProgressIntoBlockGroupProgress(allBlockGroups: BlockGroup[], completedBlocksCount: number) {
+    let completedBlockGroups = 0;
+
+    for (const blockGroup of allBlockGroups) {
+      completedBlockGroups += blockGroup.blocks.length;
+
+      if (completedBlocksCount <= completedBlockGroups) {
+        return blockGroup.index + 2;
+      }
+    }
+
+    return allBlockGroups.length;
   }
 }

--- a/app/models/concept-engagement.ts
+++ b/app/models/concept-engagement.ts
@@ -1,4 +1,4 @@
-import ConceptModel, { type BlockGroup } from 'codecrafters-frontend/models/concept';
+import ConceptModel from 'codecrafters-frontend/models/concept';
 import UserModel from 'codecrafters-frontend/models/user';
 import Model, { attr, belongsTo } from '@ember-data/model';
 
@@ -10,12 +10,22 @@ export default class ConceptEngagementModel extends Model {
   @attr('date') declare lastActivityAt: Date;
   @attr('date') declare startedAt: Date;
 
-  get completedBlocksCount() {
-    return Math.round((this.currentProgressPercentage / 100) * this.totalBlocksCount);
+  get completedBlockGroupsCount() {
+    let completedBlockGroups = 0;
+
+    for (const blockGroup of this.concept.blockGroups) {
+      completedBlockGroups += blockGroup.blocks.length;
+
+      if (this.completedBlocksCount <= completedBlockGroups) {
+        return blockGroup.index + 1;
+      }
+    }
+
+    return this.concept.blockGroups.length;
   }
 
-  get completedBlockGroupsCount() {
-    return this.convertBlockProgressIntoBlockGroupProgress(this.concept.blockGroups, this.completedBlocksCount);
+  get completedBlocksCount() {
+    return Math.round((this.currentProgressPercentage / 100) * this.totalBlocksCount);
   }
 
   get totalBlockGroupsCount() {
@@ -24,19 +34,5 @@ export default class ConceptEngagementModel extends Model {
 
   get totalBlocksCount() {
     return this.concept.parsedBlocks.length;
-  }
-
-  convertBlockProgressIntoBlockGroupProgress(blockGroups: BlockGroup[], completedBlocksCount: number) {
-    let completedBlockGroups = 0;
-
-    for (const blockGroup of blockGroups) {
-      completedBlockGroups += blockGroup.blocks.length;
-
-      if (completedBlocksCount <= completedBlockGroups) {
-        return blockGroup.index + 1;
-      }
-    }
-
-    return blockGroups.length;
   }
 }

--- a/app/models/concept-engagement.ts
+++ b/app/models/concept-engagement.ts
@@ -1,6 +1,12 @@
-import ConceptModel from 'codecrafters-frontend/models/concept';
+import ConceptModel, { type Block } from 'codecrafters-frontend/models/concept';
 import UserModel from 'codecrafters-frontend/models/user';
 import Model, { attr, belongsTo } from '@ember-data/model';
+import { cached, tracked } from '@glimmer/tracking';
+
+export interface BlockGroup {
+  index: number;
+  blocks: Block[];
+}
 
 export default class ConceptEngagementModel extends Model {
   @belongsTo('concept', { async: false, inverse: 'engagements' }) declare concept: ConceptModel;
@@ -10,12 +16,47 @@ export default class ConceptEngagementModel extends Model {
   @attr('date') declare lastActivityAt: Date;
   @attr('date') declare startedAt: Date;
 
+  // This needs to be updated on button clicks
+  @tracked lastRevealedBlockGroupIndex: number | null = null;
+
+  get currentBlockGroupIndex() {
+    return this.lastRevealedBlockGroupIndex || 0;
+  }
+
   get completedBlocksCount() {
-    return Math.round((this.currentProgressPercentage / 100) * this.totalBlocksCount);
+    return this.allBlockGroups.reduce((count, blockGroup) => {
+      if (blockGroup.index < this.currentBlockGroupIndex) {
+        count += blockGroup.blocks.length;
+      }
+
+      return count;
+    }, 0);
+  }
+
+  @cached
+  get allBlocks() {
+    return this.concept.parsedBlocks;
+  }
+
+  @cached
+  get allBlockGroups(): BlockGroup[] {
+    return this.allBlocks.reduce((groups, block) => {
+      if (groups.length <= 0) {
+        groups.push({ index: 0, blocks: [] });
+      }
+
+      (groups[groups.length - 1] as BlockGroup).blocks.push(block);
+
+      if (block.isInteractable || groups.length === 0) {
+        groups.push({ index: groups.length, blocks: [] });
+      }
+
+      return groups;
+    }, [] as BlockGroup[]);
   }
 
   get totalBlocksCount() {
-    const allBlocks = this.concept.parsedBlocks;
+    const allBlocks = this.allBlockGroups;
 
     return allBlocks.length;
   }

--- a/app/models/concept-engagement.ts
+++ b/app/models/concept-engagement.ts
@@ -1,7 +1,6 @@
 import ConceptModel, { type Block } from 'codecrafters-frontend/models/concept';
 import UserModel from 'codecrafters-frontend/models/user';
 import Model, { attr, belongsTo } from '@ember-data/model';
-import { cached } from '@glimmer/tracking';
 import type { BlockGroup } from 'codecrafters-frontend/components/concept';
 
 export default class ConceptEngagementModel extends Model {
@@ -12,7 +11,7 @@ export default class ConceptEngagementModel extends Model {
   @attr('date') declare lastActivityAt: Date;
   @attr('date') declare startedAt: Date;
 
-  getAllBlockGroups(blocks: Block[]): BlockGroup[] {
+  parseIntoBlockGroups(blocks: Block[]): BlockGroup[] {
     return blocks.reduce((groups, block) => {
       if (groups.length <= 0) {
         groups.push({ index: 0, blocks: [] });
@@ -28,17 +27,17 @@ export default class ConceptEngagementModel extends Model {
     }, [] as BlockGroup[]);
   }
 
-  get completedBlocksCount() {
-    let index = Math.round((this.currentProgressPercentage / 100) * this.rawTotalBlocksCount());
+  get completedBlockGroupsCount() {
+    let index = Math.round((this.currentProgressPercentage / 100) * this.totalBlocksCount());
 
-    return this.getAllBlockGroups(this.concept.parsedBlocks.slice(0, index)).length;
+    return this.parseIntoBlockGroups(this.concept.parsedBlocks.slice(0, index)).length;
   }
 
-  get totalBlocksCount() {
-    return this.getAllBlockGroups(this.concept.parsedBlocks).length;
+  get totalBlockGroupsCount() {
+    return this.parseIntoBlockGroups(this.concept.parsedBlocks).length;
   }
 
-  rawTotalBlocksCount() {
+  totalBlocksCount() {
     return this.concept.parsedBlocks.length;
   }
 }

--- a/app/models/concept-engagement.ts
+++ b/app/models/concept-engagement.ts
@@ -11,6 +11,20 @@ export default class ConceptEngagementModel extends Model {
   @attr('date') declare lastActivityAt: Date;
   @attr('date') declare startedAt: Date;
 
+  get completedBlockGroupsCount() {
+    const index = Math.round((this.currentProgressPercentage / 100) * this.totalBlocksCount);
+
+    return this.parseIntoBlockGroups(this.concept.parsedBlocks.slice(0, index)).length;
+  }
+
+  get totalBlockGroupsCount() {
+    return this.parseIntoBlockGroups(this.concept.parsedBlocks).length;
+  }
+
+  get totalBlocksCount() {
+    return this.concept.parsedBlocks.length;
+  }
+
   parseIntoBlockGroups(blocks: Block[]): BlockGroup[] {
     return blocks.reduce((groups, block) => {
       if (groups.length <= 0) {
@@ -25,19 +39,5 @@ export default class ConceptEngagementModel extends Model {
 
       return groups;
     }, [] as BlockGroup[]);
-  }
-
-  get completedBlockGroupsCount() {
-    let index = Math.round((this.currentProgressPercentage / 100) * this.totalBlocksCount());
-
-    return this.parseIntoBlockGroups(this.concept.parsedBlocks.slice(0, index)).length;
-  }
-
-  get totalBlockGroupsCount() {
-    return this.parseIntoBlockGroups(this.concept.parsedBlocks).length;
-  }
-
-  totalBlocksCount() {
-    return this.concept.parsedBlocks.length;
   }
 }

--- a/app/models/concept-engagement.ts
+++ b/app/models/concept-engagement.ts
@@ -10,10 +10,12 @@ export default class ConceptEngagementModel extends Model {
   @attr('date') declare lastActivityAt: Date;
   @attr('date') declare startedAt: Date;
 
-  get completedBlockGroupsCount() {
-    const completedBlocksCount = Math.round((this.currentProgressPercentage / 100) * this.totalBlocksCount);
+  get completedBlocksCount() {
+    return Math.round((this.currentProgressPercentage / 100) * this.totalBlocksCount);
+  }
 
-    return this.convertBlockProgressIntoBlockGroupProgress(this.concept.blockGroups, completedBlocksCount);
+  get completedBlockGroupsCount() {
+    return this.convertBlockProgressIntoBlockGroupProgress(this.concept.blockGroups, this.completedBlocksCount);
   }
 
   get totalBlockGroupsCount() {

--- a/app/models/concept-engagement.ts
+++ b/app/models/concept-engagement.ts
@@ -11,17 +11,19 @@ export default class ConceptEngagementModel extends Model {
   @attr('date') declare startedAt: Date;
 
   get completedBlockGroupsCount() {
-    let completedBlockGroups = 0;
+    let blocksInPreviousGroupsCount = 0;
+    let result = 0;
 
     for (const blockGroup of this.concept.blockGroups) {
-      completedBlockGroups += blockGroup.blocks.length;
-
-      if (this.completedBlocksCount <= completedBlockGroups) {
-        return blockGroup.index + 1;
+      if (blocksInPreviousGroupsCount >= this.completedBlocksCount) {
+        return result;
       }
+
+      blocksInPreviousGroupsCount += blockGroup.blocks.length;
+      result += 1;
     }
 
-    return this.concept.blockGroups.length;
+    return result;
   }
 
   get completedBlocksCount() {

--- a/app/models/concept-engagement.ts
+++ b/app/models/concept-engagement.ts
@@ -11,9 +11,9 @@ export default class ConceptEngagementModel extends Model {
   @attr('date') declare startedAt: Date;
 
   get completedBlockGroupsCount() {
-    const index = Math.round((this.currentProgressPercentage / 100) * this.totalBlocksCount);
+    const completedBlocksIndex = Math.round((this.currentProgressPercentage / 100) * this.totalBlocksCount);
 
-    return this.parseIntoBlockGroups(this.concept.parsedBlocks.slice(0, index)).length;
+    return this.parseIntoBlockGroups(this.concept.parsedBlocks.slice(0, completedBlocksIndex)).length;
   }
 
   get totalBlockGroupsCount() {

--- a/app/models/concept-engagement.ts
+++ b/app/models/concept-engagement.ts
@@ -34,6 +34,6 @@ export default class ConceptEngagementModel extends Model {
   }
 
   get totalBlocksCount() {
-    return this.allBlockGroups.length;
+    return this.allBlockGroups?.length ?? 0;
   }
 }

--- a/app/models/concept-engagement.ts
+++ b/app/models/concept-engagement.ts
@@ -10,10 +10,12 @@ export default class ConceptEngagementModel extends Model {
   @attr('date') declare lastActivityAt: Date;
   @attr('date') declare startedAt: Date;
 
-  get remainingBlocksCount() {
-    const allBlocks = this.concept.parsedBlocks;
-    const completedBlocksCount = Math.round((this.currentProgressPercentage / 100) * allBlocks.length);
+  get completedBlocksCount() {
+    return Math.round((this.currentProgressPercentage / 100) * this.totalBlocksCount);
+  }
 
-    return allBlocks.length - completedBlocksCount;
+  get totalBlocksCount() {
+    const allBlocks = this.concept.parsedBlocks;
+    return allBlocks.length;
   }
 }

--- a/app/models/concept-engagement.ts
+++ b/app/models/concept-engagement.ts
@@ -1,7 +1,7 @@
 import ConceptModel, { type Block } from 'codecrafters-frontend/models/concept';
 import UserModel from 'codecrafters-frontend/models/user';
 import Model, { attr, belongsTo } from '@ember-data/model';
-import type { BlockGroup } from 'codecrafters-frontend/components/concept';
+import type { BlockGroup } from 'codecrafters-frontend/models/concept';
 
 export default class ConceptEngagementModel extends Model {
   @belongsTo('concept', { async: false, inverse: 'engagements' }) declare concept: ConceptModel;

--- a/app/models/concept-engagement.ts
+++ b/app/models/concept-engagement.ts
@@ -1,7 +1,6 @@
-import ConceptModel, { type Block } from 'codecrafters-frontend/models/concept';
+import ConceptModel, { type Block, type BlockGroup } from 'codecrafters-frontend/models/concept';
 import UserModel from 'codecrafters-frontend/models/user';
 import Model, { attr, belongsTo } from '@ember-data/model';
-import type { BlockGroup } from 'codecrafters-frontend/models/concept';
 
 export default class ConceptEngagementModel extends Model {
   @belongsTo('concept', { async: false, inverse: 'engagements' }) declare concept: ConceptModel;

--- a/app/models/concept-engagement.ts
+++ b/app/models/concept-engagement.ts
@@ -1,4 +1,4 @@
-import ConceptModel, { type Block, type BlockGroup } from 'codecrafters-frontend/models/concept';
+import ConceptModel, { type BlockGroup } from 'codecrafters-frontend/models/concept';
 import UserModel from 'codecrafters-frontend/models/user';
 import Model, { attr, belongsTo } from '@ember-data/model';
 
@@ -11,32 +11,28 @@ export default class ConceptEngagementModel extends Model {
   @attr('date') declare startedAt: Date;
 
   get completedBlockGroupsCount() {
-    const completedBlocksIndex = Math.round((this.currentProgressPercentage / 100) * this.totalBlocksCount);
+    const completedBlocksCount = Math.round((this.currentProgressPercentage / 100) * this.totalBlocksCount);
 
-    return this.parseIntoBlockGroups(this.concept.parsedBlocks.slice(0, completedBlocksIndex)).length;
+    return this.convertBlockProgressIntoBlockGroupProgress(this.concept.allBlockGroups, completedBlocksCount);
+  }
+
+  convertBlockProgressIntoBlockGroupProgress(allBlockGroups: BlockGroup[], completedBlocksCount: number) {
+    let completedBlockGroups = 0;
+    for (const blockGroup of allBlockGroups) {
+      completedBlockGroups += blockGroup.blocks.length;
+      if (completedBlocksCount <= completedBlockGroups) {
+        return blockGroup.index + 2;
+      }
+    }
+
+    return allBlockGroups.length;
   }
 
   get totalBlockGroupsCount() {
-    return this.parseIntoBlockGroups(this.concept.parsedBlocks).length;
+    return this.concept.allBlockGroups.length;
   }
 
   get totalBlocksCount() {
     return this.concept.parsedBlocks.length;
-  }
-
-  parseIntoBlockGroups(blocks: Block[]): BlockGroup[] {
-    return blocks.reduce((groups, block) => {
-      if (groups.length <= 0) {
-        groups.push({ index: 0, blocks: [] });
-      }
-
-      (groups[groups.length - 1] as BlockGroup).blocks.push(block);
-
-      if (block.isInteractable || groups.length === 0) {
-        groups.push({ index: groups.length, blocks: [] });
-      }
-
-      return groups;
-    }, [] as BlockGroup[]);
   }
 }

--- a/app/models/concept-engagement.ts
+++ b/app/models/concept-engagement.ts
@@ -31,7 +31,7 @@ export default class ConceptEngagementModel extends Model {
       completedBlockGroups += blockGroup.blocks.length;
 
       if (completedBlocksCount <= completedBlockGroups) {
-        return blockGroup.index + 2;
+        return blockGroup.index + 1;
       }
     }
 

--- a/app/models/concept.ts
+++ b/app/models/concept.ts
@@ -36,7 +36,6 @@ export default class ConceptModel extends Model {
   @equal('status', 'draft') declare statusIsDraft: boolean;
   @equal('status', 'published') declare statusIsPublished: boolean;
 
-  @cached
   get blockGroups(): BlockGroup[] {
     return this.parsedBlocks.reduce((groups, block, index) => {
       if (groups.length <= 0) {

--- a/app/models/concept.ts
+++ b/app/models/concept.ts
@@ -37,7 +37,7 @@ export default class ConceptModel extends Model {
   @equal('status', 'published') declare statusIsPublished: boolean;
 
   @cached
-  get allBlockGroups(): BlockGroup[] {
+  get blockGroups(): BlockGroup[] {
     return this.parsedBlocks.reduce((groups, block, index) => {
       if (groups.length <= 0) {
         groups.push({ index: 0, blocks: [] });

--- a/app/models/concept.ts
+++ b/app/models/concept.ts
@@ -57,6 +57,7 @@ export default class ConceptModel extends Model {
     // This means that there would be a last blockGroup that is empty.
     // We remove it here.
     const lastGroup = blockGroups[blockGroups.length - 1];
+
     if (lastGroup && lastGroup.blocks.length <= 0 && blockGroups.length > 1) {
       blockGroups.pop();
     }

--- a/app/models/concept.ts
+++ b/app/models/concept.ts
@@ -14,6 +14,12 @@ export type BlockJSON = {
   args: Record<string, unknown>;
 };
 
+
+export interface BlockGroup {
+  index: number;
+  blocks: Block[];
+}
+
 export default class ConceptModel extends Model {
   @belongsTo('user', { async: false, inverse: null }) declare author: UserModel;
 

--- a/app/models/concept.ts
+++ b/app/models/concept.ts
@@ -38,7 +38,7 @@ export default class ConceptModel extends Model {
 
   @cached
   get allBlockGroups(): BlockGroup[] {
-    let blockGroups = this.parsedBlocks.reduce((groups, block) => {
+    const blockGroups = this.parsedBlocks.reduce((groups, block) => {
       if (groups.length <= 0) {
         groups.push({ index: 0, blocks: [] });
       }

--- a/app/models/concept.ts
+++ b/app/models/concept.ts
@@ -14,7 +14,6 @@ export type BlockJSON = {
   args: Record<string, unknown>;
 };
 
-
 export interface BlockGroup {
   index: number;
   blocks: Block[];

--- a/app/models/concept.ts
+++ b/app/models/concept.ts
@@ -6,7 +6,6 @@ import { ClickToContinueBlock, ConceptAnimationBlock, ConceptQuestionBlock, Mark
 import { type SyncHasMany, attr, hasMany } from '@ember-data/model';
 import { equal } from '@ember/object/computed'; // eslint-disable-line ember/no-computed-properties-in-native-classes
 import { memberAction } from 'ember-api-actions';
-import { cached } from '@glimmer/tracking';
 
 export type Block = MarkdownBlock | ConceptAnimationBlock | ClickToContinueBlock | ConceptQuestionBlock;
 

--- a/app/models/concept.ts
+++ b/app/models/concept.ts
@@ -38,31 +38,21 @@ export default class ConceptModel extends Model {
 
   @cached
   get allBlockGroups(): BlockGroup[] {
-    const blockGroups = this.parsedBlocks.reduce((groups, block) => {
+    return this.parsedBlocks.reduce((groups, block, index) => {
       if (groups.length <= 0) {
         groups.push({ index: 0, blocks: [] });
       }
 
       (groups[groups.length - 1] as BlockGroup).blocks.push(block);
 
-      if (block.isInteractable) {
+      const isLastBlock = index === this.parsedBlocks.length - 1;
+
+      if (block.isInteractable && !isLastBlock) {
         groups.push({ index: groups.length, blocks: [] });
       }
 
       return groups;
     }, [] as BlockGroup[]);
-
-    // While parsing into block groups, we push a new blockGroup
-    // when we encounter an interactable block.
-    // This means that there would be a last blockGroup that is empty.
-    // We remove it here.
-    const lastGroup = blockGroups[blockGroups.length - 1];
-
-    if (lastGroup && lastGroup.blocks.length <= 0 && blockGroups.length > 1) {
-      blockGroups.pop();
-    }
-
-    return blockGroups;
   }
 
   get estimatedReadingTimeInMinutes(): number {

--- a/app/models/concept.ts
+++ b/app/models/concept.ts
@@ -56,7 +56,8 @@ export default class ConceptModel extends Model {
     // when we encounter an interactable block.
     // This means that there would be a last blockGroup that is empty.
     // We remove it here.
-    if (blockGroups[blockGroups.length - 1]!.blocks.length <= 0) {
+    const lastGroup = blockGroups[blockGroups.length - 1];
+    if (lastGroup && lastGroup.blocks.length <= 0 && blockGroups.length > 1) {
       blockGroups.pop();
     }
 

--- a/app/models/concept.ts
+++ b/app/models/concept.ts
@@ -38,19 +38,29 @@ export default class ConceptModel extends Model {
 
   @cached
   get allBlockGroups(): BlockGroup[] {
-    return this.parsedBlocks.reduce((groups, block) => {
+    let blockGroups = this.parsedBlocks.reduce((groups, block) => {
       if (groups.length <= 0) {
         groups.push({ index: 0, blocks: [] });
       }
 
       (groups[groups.length - 1] as BlockGroup).blocks.push(block);
 
-      if (block.isInteractable || groups.length === 0) {
+      if (block.isInteractable) {
         groups.push({ index: groups.length, blocks: [] });
       }
 
       return groups;
     }, [] as BlockGroup[]);
+
+    // While parsing into block groups, we push a new blockGroup
+    // when we encounter an interactable block.
+    // This means that there would be a last blockGroup that is empty.
+    // We remove it here.
+    if (blockGroups[blockGroups.length - 1]!.blocks.length <= 0) {
+      blockGroups.pop();
+    }
+
+    return blockGroups;
   }
 
   get estimatedReadingTimeInMinutes(): number {

--- a/tests/acceptance/concepts-test.js
+++ b/tests/acceptance/concepts-test.js
@@ -285,16 +285,16 @@ module('Acceptance | concepts-test', function (hooks) {
     await conceptPage.clickOnContinueButton();
     assert.ok(conceptPage.progress.isPresent, 'Progress bar should be present after starting concept');
 
-    assert.ok(conceptPage.progress.text.includes('2/20'), 'Progress text should reflect tracked progress in concept page');
+    assert.ok(conceptPage.progress.text.includes('1/19'), 'Progress text should reflect tracked progress in concept page');
     assert.ok(conceptPage.progress.barStyle.includes('width: 5%'), 'Progress bar should reflect tracked progress in concept page');
 
     await conceptPage.clickOnContinueButton();
     await conceptPage.questionCards[0].clickOnShowExplanationButton();
-    assert.ok(conceptPage.progress.text.includes('3/20'), 'Progress text should reflect tracked progress in concept page');
+    assert.ok(conceptPage.progress.text.includes('2/19'), 'Progress text should reflect tracked progress in concept page');
     assert.ok(conceptPage.progress.barStyle.includes('width: 10%'));
 
     await conceptPage.clickOnStepBackButton();
-    assert.ok(conceptPage.progress.text.includes('2/20'), 'Progress text should reflect tracked progress in concept page');
+    assert.ok(conceptPage.progress.text.includes('1/19'), 'Progress text should reflect tracked progress in concept page');
     assert.ok(conceptPage.progress.barStyle.includes('width: 5%'));
 
     await conceptsPage.visit();
@@ -338,7 +338,7 @@ module('Acceptance | concepts-test', function (hooks) {
     await conceptsPage.clickOnConceptCard('Network Protocols');
     assert.strictEqual(conceptPage.blocks.length, 2, 'Completed blocks are automatically shown');
     assert.ok(conceptPage.progress.isPresent, 'Progress bar should be present');
-    assert.ok(conceptPage.progress.text.includes('2/20'), 'Progress text should reflect tracked progress in concept page');
+    assert.ok(conceptPage.progress.text.includes('1/19'), 'Progress text should reflect tracked progress in concept page');
     assert.ok(conceptPage.progress.barStyle.includes('width: 5%'), 'Progress bar should reflect tracked progress in concept page');
   });
 

--- a/tests/acceptance/concepts-test.js
+++ b/tests/acceptance/concepts-test.js
@@ -282,19 +282,20 @@ module('Acceptance | concepts-test', function (hooks) {
     await conceptsPage.clickOnConceptCard('Network Protocols');
     assert.notOk(conceptPage.progress.isPresent, 'Progress bar should not be present in concept before starting');
 
+    // await this.pauseTest();
     await conceptPage.clickOnContinueButton();
     assert.ok(conceptPage.progress.isPresent, 'Progress bar should be present after starting concept');
-    assert.ok(conceptPage.progress.text.includes('5%'), 'Progress text should reflect tracked progress in concept page');
+    assert.ok(conceptPage.progress.text.includes('1/20'), 'Progress text should reflect tracked progress in concept page');
     assert.ok(conceptPage.progress.barStyle.includes('width: 5%'), 'Progress bar should reflect tracked progress in concept page');
-    assert.ok(conceptPage.progress.text.includes('39 blocks left'), 'Remaining blocks left should be reflected properly');
+    // await this.pauseTest();
 
     await conceptPage.clickOnContinueButton();
     await conceptPage.questionCards[0].clickOnShowExplanationButton();
-    assert.ok(conceptPage.progress.text.includes('10%'));
+    assert.ok(conceptPage.progress.text.includes('2/20'), 'Progress text should reflect tracked progress in concept page');
     assert.ok(conceptPage.progress.barStyle.includes('width: 10%'));
 
     await conceptPage.clickOnStepBackButton();
-    assert.ok(conceptPage.progress.text.includes('5%'));
+    assert.ok(conceptPage.progress.text.includes('1/20'), 'Progress text should reflect tracked progress in concept page');
     assert.ok(conceptPage.progress.barStyle.includes('width: 5%'));
 
     await conceptsPage.visit();
@@ -338,9 +339,8 @@ module('Acceptance | concepts-test', function (hooks) {
     await conceptsPage.clickOnConceptCard('Network Protocols');
     assert.strictEqual(conceptPage.blocks.length, 2, 'Completed blocks are automatically shown');
     assert.ok(conceptPage.progress.isPresent, 'Progress bar should be present');
-    assert.ok(conceptPage.progress.text.includes('5%'), 'Progress text should reflect tracked progress in concept page');
+    assert.ok(conceptPage.progress.text.includes('1/20'), 'Progress text should reflect tracked progress in concept page');
     assert.ok(conceptPage.progress.barStyle.includes('width: 5%'), 'Progress bar should reflect tracked progress in concept page');
-    assert.ok(conceptPage.progress.text.includes('39 blocks left'), 'Remaining blocks left should be reflected properly');
   });
 
   test('progress for completed concepts is rendered properly', async function (assert) {
@@ -370,24 +370,6 @@ module('Acceptance | concepts-test', function (hooks) {
 
     await conceptsPage.conceptCards[0].hover();
     assert.strictEqual(conceptsPage.conceptCards[0].actionText, 'View', 'Concept card action text should be view for completed concept');
-  });
-
-  test('remaining blocks left is rendered properly', async function (assert) {
-    testScenario(this.server);
-    createConcepts(this.server);
-
-    const user = this.server.schema.users.first();
-    signIn(this.owner, this.server, user);
-
-    await conceptsPage.visit();
-    await conceptsPage.clickOnConceptCard('Network Protocols');
-    assert.notOk(conceptPage.progress.isPresent, 'Remaining blocks left should not be shown if no progress is made');
-
-    await conceptPage.clickOnContinueButton();
-    assert.contains(conceptPage.progress.text, '39 blocks left');
-
-    await conceptPage.clickOnContinueButton();
-    assert.contains(conceptPage.progress.text, '37 blocks left');
   });
 
   test('remaining blocks left is not present if user completed concept', async function (assert) {

--- a/tests/acceptance/concepts-test.js
+++ b/tests/acceptance/concepts-test.js
@@ -282,20 +282,19 @@ module('Acceptance | concepts-test', function (hooks) {
     await conceptsPage.clickOnConceptCard('Network Protocols');
     assert.notOk(conceptPage.progress.isPresent, 'Progress bar should not be present in concept before starting');
 
-    // await this.pauseTest();
     await conceptPage.clickOnContinueButton();
     assert.ok(conceptPage.progress.isPresent, 'Progress bar should be present after starting concept');
-    assert.ok(conceptPage.progress.text.includes('1/20'), 'Progress text should reflect tracked progress in concept page');
+
+    assert.ok(conceptPage.progress.text.includes('2/20'), 'Progress text should reflect tracked progress in concept page');
     assert.ok(conceptPage.progress.barStyle.includes('width: 5%'), 'Progress bar should reflect tracked progress in concept page');
-    // await this.pauseTest();
 
     await conceptPage.clickOnContinueButton();
     await conceptPage.questionCards[0].clickOnShowExplanationButton();
-    assert.ok(conceptPage.progress.text.includes('2/20'), 'Progress text should reflect tracked progress in concept page');
+    assert.ok(conceptPage.progress.text.includes('3/20'), 'Progress text should reflect tracked progress in concept page');
     assert.ok(conceptPage.progress.barStyle.includes('width: 10%'));
 
     await conceptPage.clickOnStepBackButton();
-    assert.ok(conceptPage.progress.text.includes('1/20'), 'Progress text should reflect tracked progress in concept page');
+    assert.ok(conceptPage.progress.text.includes('2/20'), 'Progress text should reflect tracked progress in concept page');
     assert.ok(conceptPage.progress.barStyle.includes('width: 5%'));
 
     await conceptsPage.visit();
@@ -339,7 +338,7 @@ module('Acceptance | concepts-test', function (hooks) {
     await conceptsPage.clickOnConceptCard('Network Protocols');
     assert.strictEqual(conceptPage.blocks.length, 2, 'Completed blocks are automatically shown');
     assert.ok(conceptPage.progress.isPresent, 'Progress bar should be present');
-    assert.ok(conceptPage.progress.text.includes('1/20'), 'Progress text should reflect tracked progress in concept page');
+    assert.ok(conceptPage.progress.text.includes('2/20'), 'Progress text should reflect tracked progress in concept page');
     assert.ok(conceptPage.progress.barStyle.includes('width: 5%'), 'Progress bar should reflect tracked progress in concept page');
   });
 


### PR DESCRIPTION
Improve the logic for counting total and completed blocks in the `ConceptEngagementModel`. Update the concept progress component to display counts instead of percentages, enhancing clarity and conciseness.

**Checklist**:

- [x] I've thoroughly self-reviewed may changes
- [x] I've added tests for my changes, unless they affect admin-only areas (or are otherwise not worth testing)
- [ ] I've verified any visual changes using Percy (add a commit with `[percy]` in the message to trigger)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - The progress indicator now displays completed blocks out of the total blocks, providing a clearer overview of engagement.
  - Introduced a new `BlockGroup` interface to enhance block processing.

- **Refactor**
  - Streamlined the progress display by removing the percentage and remaining blocks indicators for a simplified view.
  - Centralized block group management within the `ConceptModel`.

- **Tests**
  - Updated test cases to reflect the new progress display format, focusing on completed blocks instead of percentages or remaining blocks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->