### PR TITLE
feat: add contest details mapping for dynamic OG metadata

### DIFF
--- a/middleware.js
+++ b/middleware.js
@@ -24,9 +24,8 @@ export const config = {
   matcher: ['/users/:path*', '/concepts/:path*', '/contests/:path*'],
 };
 
-// Define a hashmap for slug-to-details mapping
 const contestDetailsMap = {
-  'default': {
+  default: {
     imageUrl: '/assets/images/contest-og-images/og-amazon-contest-1.png',
     title: 'CodeCrafters Contests',
     description: 'Compete in this contest only on CodeCrafters.',
@@ -41,7 +40,6 @@ const contestDetailsMap = {
     title: 'CodeCrafters x Vercel',
     description: 'Compete in the first ever contest exclusively for Vercelians on CodeCrafters.',
   },
-  // Add more contest slugs and their details here
 };
 
 function getContestDetails(slug) {

--- a/middleware.js
+++ b/middleware.js
@@ -24,6 +24,34 @@ export const config = {
   matcher: ['/users/:path*', '/concepts/:path*', '/contests/:path*'],
 };
 
+// Define a hashmap for slug-to-details mapping
+const contestDetailsMap = {
+  'default': {
+    imageUrl: '/assets/images/contest-og-images/og-amazon-contest-1.png',
+    title: 'CodeCrafters Contests',
+    description: 'Compete in this contest only on CodeCrafters.',
+  },
+  'amazon-1': {
+    imageUrl: '/assets/images/contest-og-images/og-amazon-contest-1.png',
+    title: 'CodeCrafters x Amazon',
+    description: 'Compete in the first ever contest exclusively for Amazonians on CodeCrafters.',
+  },
+  'vercel-1': {
+    imageUrl: '/assets/images/contest-og-images/og-amazon-contest-1.png',
+    title: 'CodeCrafters x Vercel',
+    description: 'Compete in the first ever contest exclusively for Vercelians on CodeCrafters.',
+  },
+  // Add more contest slugs and their details here
+};
+
+function getContestDetails(slug) {
+  if (!(slug in contestDetailsMap)) {
+    return contestDetailsMap['default'];
+  }
+
+  return contestDetailsMap[slug];
+}
+
 export default async function middleware(request) {
   // Parse the users or concepts path match result from the request URL
   const usersPathMatchResult = request.url.match(/\/users\/([^/?]+)/);
@@ -85,15 +113,12 @@ export default async function middleware(request) {
   } else if (contestsPathMatchResult) {
     const contestSlug = contestsPathMatchResult[1];
 
-    if (contestSlug === 'amazon-1') {
-      pageImageUrl = `/assets/images/contest-og-images/og-amazon-contest-1.png`;
-      pageTitle = `CodeCrafters x Amazon`;
-      pageDescription = `Compete in the first ever contest exclusively for Amazonians on CodeCrafters.`;
-    } else {
-      pageImageUrl = `/assets/images/contest-og-images/og-amazon-contest-1.png`;
-      pageTitle = `CodeCrafters Contests`;
-      pageDescription = `Compete in this contest only on CodeCrafters.`;
-    }
+    // Fetch contest details from the hashmap
+    const contestDetails = getContestDetails(contestSlug);
+
+    pageImageUrl = contestDetails.imageUrl;
+    pageTitle = contestDetails.title;
+    pageDescription = contestDetails.description;
   }
 
   // Determine URL for reading local `/dist/_empty.html`


### PR DESCRIPTION
Introduce a hashmap-based approach to manage contest-specific Open Graph metadata. This allows for easy addition of new contests with custom image URLs, titles, and descriptions, improving the flexibility of contest page metadata generation.

**Checklist**:

- [x] I've thoroughly self-reviewed my changes
- [ ] I've added tests for my changes, unless they affect admin-only areas (or are otherwise not worth testing)
- [ ] I've verified any visual changes using Percy (add a commit with `[percy]` in the message to trigger)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced contest detail handling now ensures pages consistently display contest images, titles, and descriptions.
  - Contest pages will automatically show default details when a contest identifier is unrecognized, simplifying future contest updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->