### PR TITLE
Add GitHub contest details to OG metadata mapping

### DIFF
--- a/middleware.js
+++ b/middleware.js
@@ -35,6 +35,11 @@ const contestDetailsMap = {
     title: 'CodeCrafters x Amazon',
     description: 'Compete in the first ever contest exclusively for Amazonians on CodeCrafters.',
   },
+  'github-1': {
+    imageUrl: '/assets/images/contest-og-images/og-amazon-contest-1.png',
+    title: 'CodeCrafters x GitHub',
+    description: 'Compete in the first ever contest exclusively for Hubbers on CodeCrafters.',
+  },
   'vercel-1': {
     imageUrl: '/assets/images/contest-og-images/og-amazon-contest-1.png',
     title: 'CodeCrafters x Vercel',


### PR DESCRIPTION
**Checklist**:

- [X] I've thoroughly self-reviewed my changes
- [ ] I've added tests for my changes, unless they affect admin-only areas (or are otherwise not worth testing)
- [ ] I've verified any visual changes using Percy (add a commit with `[percy]` in the message to trigger)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- A new contest, "CodeCrafters x GitHub," has been introduced with a dedicated image, title, and description for enhanced contest visibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->