### PR TITLE
Handle non-existent contest routes with fallback and tests

### DIFF
--- a/tests/acceptance/contests-test.js
+++ b/tests/acceptance/contests-test.js
@@ -102,6 +102,13 @@ module('Acceptance | contests-test', function (hooks) {
     await percySnapshot('Active Contest');
   });
 
+  test('it should redirect to not-found if the contest does not exist', async function (assert) {
+    testScenario(this.server);
+
+    await contestsPage.visit({ contest_slug: 'nonexistent' });
+    assert.strictEqual(currentURL(), '/404');
+  });
+
   test('time remaining status pill shows correct copy', async function (assert) {
     testScenario(this.server);
     createContests(this.owner, this.server);


### PR DESCRIPTION
Implement a fallback to a not-found page for non-existent contest routes and add a corresponding test to ensure the functionality works as intended.

**Checklist**:

- [x] I've thoroughly self-reviewed my changes
- [x] I've added tests for my changes, unless they affect admin-only areas (or are otherwise not worth testing)
- [ ] I've verified any visual changes using Percy (add a commit with `[percy]` in the message to trigger)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved contest handling by redirecting users to a not-found page when an invalid contest is accessed.
- **Tests**
	- Added acceptance tests to verify proper redirection for non-existent contests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->