### PR TITLE
chore(env): update backend URL for staging environment

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,11 +1,11 @@
 # Disable FastBoot completely. Re-enable by overriding with ""
 # FASTBOOT_DISABLED=true
 
-# This should match the URL defined in `core`.
-BACKEND_URL="https://<your-name>-backend.ccdev.dev"
-
 # To work against staging, use this:
-# BACKEND_URL="https://backend-staging.codecrafters.io"
+BACKEND_URL="https://backend-staging.codecrafters.io"
+
+# To work against a local instance, use this (should match the URL defined in `core`):
+# BACKEND_URL="https://<your-name>-backend.ccdev.dev"
 
 # Optional, only needed to test payments flow
 STRIPE_PUBLISHABLE_KEY="<your-stripe-publishable-key>"


### PR DESCRIPTION
Updates the BACKEND_URL in the .env.example file to point 
to the staging environment. This change facilitates easier 
development and testing against the correct backend URL. 
The previous URL is commented out for clarity and future 
reference.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the backend connection configuration to use a dedicated staging endpoint, ensuring consistent connectivity when working against a local instance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->