### PR TITLE
Add Prism highlighting class to concept question cards

### DIFF
--- a/app/components/concept-page/question-card.hbs
+++ b/app/components/concept-page/question-card.hbs
@@ -1,6 +1,6 @@
 <div class="border rounded shadow-sm scroll-mb-10" data-test-question-card ...attributes>
   <div class="p-3 sm:p-4">
-    <div class="text-gray-800 mr-2 mb-2 border-b pb-2.5 prose has-prism-highlighting">
+    <div class="text-gray-800 mr-2 mb-2 border-b pb-2.5 prose has-prism-highlighting" data-test-question-card-body>
       {{markdown-to-html @question.queryMarkdown}}
     </div>
 

--- a/app/components/concept-page/question-card.hbs
+++ b/app/components/concept-page/question-card.hbs
@@ -1,6 +1,6 @@
 <div class="border rounded shadow-sm scroll-mb-10" data-test-question-card ...attributes>
   <div class="p-3 sm:p-4">
-    <div class="text-gray-800 mr-2 mb-2 border-b pb-2.5 prose">
+    <div class="text-gray-800 mr-2 mb-2 border-b pb-2.5 prose has-prism-highlighting">
       {{markdown-to-html @question.queryMarkdown}}
     </div>
 

--- a/mirage/concept-fixtures/dummy.js
+++ b/mirage/concept-fixtures/dummy.js
@@ -6,7 +6,7 @@ export default {
       blocks: [
         { args: { markdown: 'Hello, world!' }, type: 'markdown' },
         { args: {}, type: 'click_to_continue' },
-        { args: { markdown: 'Hello world 2!' }, type: 'markdown' },
+        { args: { markdown: '### Variable assignment with `if` expressions\n\nYou can also assign the result of an `if` expression.\n\nIn the example below, `weather` is getting assigned by the result of the `if` expression.\n\n```rust\nlet temperature = 15;\n\nlet weather = if temperature <= 10 {\n      "cold"\n} else if temperature <= 20 {\n      "cool"\n} else {\n      "warm"\n};,\n\nprintln!("The weather is {}", weather); // "The weather is cool"\n```' }, type: 'markdown' },
         { args: {}, type: 'click_to_continue' },
         { args: { concept_question_slug: 'dummy-q' }, type: 'concept_question' },
         { args: { markdown: "And that's the end!" }, type: 'markdown' },
@@ -27,7 +27,7 @@ export default {
       id: '4e032a49-34aa-4635-97b8-52b46e66db20',
       type: 'concept-questions',
       attributes: {
-        'query-markdown': "What's the question?",
+        'query-markdown': "What's the question?\n\n```rust\nlet temperature = 15;\n\nlet weather = if temperature <= 10 {\n      \"cold\"\n} else if temperature <= 20 {\n      \"cool\"\n} else {\n      \"warm\"\n};,\n\nprintln!(\"The weather is {}\", weather); // \"The weather is cool\"\n```",
         options: [
           { markdown: 'Wrong answer', is_correct: false, explanation_markdown: null },
           { markdown: 'Correct', is_correct: true, explanation_markdown: null },

--- a/mirage/concept-fixtures/dummy.js
+++ b/mirage/concept-fixtures/dummy.js
@@ -6,7 +6,13 @@ export default {
       blocks: [
         { args: { markdown: 'Hello, world!' }, type: 'markdown' },
         { args: {}, type: 'click_to_continue' },
-        { args: { markdown: '### Variable assignment with `if` expressions\n\nYou can also assign the result of an `if` expression.\n\nIn the example below, `weather` is getting assigned by the result of the `if` expression.\n\n```rust\nlet temperature = 15;\n\nlet weather = if temperature <= 10 {\n      "cold"\n} else if temperature <= 20 {\n      "cool"\n} else {\n      "warm"\n};,\n\nprintln!("The weather is {}", weather); // "The weather is cool"\n```' }, type: 'markdown' },
+        {
+          args: {
+            markdown:
+              '### Variable assignment with `if` expressions\n\nYou can also assign the result of an `if` expression.\n\nIn the example below, `weather` is getting assigned by the result of the `if` expression.\n\n```rust\nlet temperature = 15;\n\nlet weather = if temperature <= 10 {\n      "cold"\n} else if temperature <= 20 {\n      "cool"\n} else {\n      "warm"\n};,\n\nprintln!("The weather is {}", weather); // "The weather is cool"\n```',
+          },
+          type: 'markdown',
+        },
         { args: {}, type: 'click_to_continue' },
         { args: { concept_question_slug: 'dummy-q' }, type: 'concept_question' },
         { args: { markdown: "And that's the end!" }, type: 'markdown' },
@@ -27,7 +33,8 @@ export default {
       id: '4e032a49-34aa-4635-97b8-52b46e66db20',
       type: 'concept-questions',
       attributes: {
-        'query-markdown': "What's the question?\n\n```rust\nlet temperature = 15;\n\nlet weather = if temperature <= 10 {\n      \"cold\"\n} else if temperature <= 20 {\n      \"cool\"\n} else {\n      \"warm\"\n};,\n\nprintln!(\"The weather is {}\", weather); // \"The weather is cool\"\n```",
+        'query-markdown':
+          'What\'s the question?\n\n```rust\nlet temperature = 15;\n\nlet weather = if temperature <= 10 {\n      "cold"\n} else if temperature <= 20 {\n      "cool"\n} else {\n      "warm"\n};,\n\nprintln!("The weather is {}", weather); // "The weather is cool"\n```',
         options: [
           { markdown: 'Wrong answer', is_correct: false, explanation_markdown: null },
           { markdown: 'Correct', is_correct: true, explanation_markdown: null },

--- a/tests/acceptance/concepts-test.js
+++ b/tests/acceptance/concepts-test.js
@@ -127,6 +127,23 @@ module('Acceptance | concepts-test', function (hooks) {
     assert.true(conceptPage.upcomingConcept.card.title.text.includes('TCP: An Overview'), 'Next concept title is correct');
   });
 
+  test('concept question body has prism highlighting', async function (assert) {
+    testScenario(this.server);
+    createConcepts(this.server);
+
+    signInAsStaff(this.owner, this.server);
+
+    await conceptsPage.visit();
+
+    await conceptsPage.clickOnConceptCard('Dummy Concept');
+    await conceptPage.clickOnContinueButton();
+    await conceptPage.clickOnContinueButton();
+    assert.true(conceptPage.questionCards[0].body.hasPrismHighlighting);
+    await conceptPage.questionCards[0].selectOption('Correct');
+    await conceptPage.clickOnContinueButton();
+    await conceptPage.clickOnContinueButton();
+  });
+
   test('clicking on the upcoming concept cards works properly', async function (assert) {
     testScenario(this.server);
     createConcepts(this.server);

--- a/tests/pages/concept-page.js
+++ b/tests/pages/concept-page.js
@@ -1,4 +1,4 @@
-import { attribute, clickOnText, clickable, collection, isPresent, text, triggerable, visitable } from 'ember-cli-page-object';
+import { attribute, clickOnText, clickable, collection, isPresent, text, triggerable, visitable, hasClass } from 'ember-cli-page-object';
 import { animationsSettled } from 'ember-animated/test-support';
 import createPage from 'codecrafters-frontend/tests/support/create-page';
 
@@ -23,6 +23,10 @@ export default createPage({
   },
 
   questionCards: collection('[data-test-question-card]', {
+    body: {
+      scope: '[data-test-question-card-body]',
+      hasPrismHighlighting: hasClass('has-prism-highlighting'),
+    },
     focusedOption: {
       scope: '[data-test-question-card-option]:focus',
     },


### PR DESCRIPTION
**Checklist**:

- [x] I've thoroughly self-reviewed my changes
- [x] I've added tests for my changes, unless they affect admin-only areas (or are otherwise not worth testing)
- [ ] I've verified any visual changes using Percy (add a commit with `[percy]` in the message to trigger)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Style**
	- Enhanced the visual presentation of markdown content by updating the syntax highlighting styles, ensuring a clearer and more user-friendly display of highlighted code sections.
- **New Features**
	- Added detailed markdown explanations and code snippets related to variable assignment in Rust.
- **Tests**
	- Introduced a new acceptance test to verify that the question body of a concept displays prism syntax highlighting.
	- Expanded the question card representation in the test framework with new methods for checking syntax highlighting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->