### PR TITLE
Don't use `@tracked` for `previousMetaImageUrl` property in routes

### DIFF
--- a/app/routes/concept-group.ts
+++ b/app/routes/concept-group.ts
@@ -7,7 +7,6 @@ import HeadDataService from 'codecrafters-frontend/services/meta-data';
 import Store from '@ember-data/store';
 import RouterService from '@ember/routing/router-service';
 import { inject as service } from '@ember/service';
-import { tracked } from '@glimmer/tracking';
 
 export default class ConceptGroupRoute extends BaseRoute {
   allowsAnonymousAccess = true;
@@ -16,11 +15,11 @@ export default class ConceptGroupRoute extends BaseRoute {
   @service declare metaData: HeadDataService;
   @service declare store: Store;
   @service declare router: RouterService;
-  @tracked previousMetaImageUrl: string | undefined = undefined;
+
+  previousMetaImageUrl: string | undefined = undefined;
 
   afterModel(model: { conceptGroup: ConceptGroupModel }) {
     this.previousMetaImageUrl = this.metaData.imageUrl;
-    // @ts-ignore
     this.metaData.imageUrl = `${config.x.metaTagImagesBaseURL}collection-${model.conceptGroup.slug}.png`;
   }
 

--- a/app/routes/course-overview.ts
+++ b/app/routes/course-overview.ts
@@ -1,7 +1,6 @@
 import { inject as service } from '@ember/service';
 import BaseRoute from 'codecrafters-frontend/utils/base-route';
 import RepositoryPoller from 'codecrafters-frontend/utils/repository-poller';
-import { tracked } from '@glimmer/tracking';
 import config from 'codecrafters-frontend/config/environment';
 import type AuthenticatorService from 'codecrafters-frontend/services/authenticator';
 import type Store from '@ember-data/store';
@@ -20,7 +19,7 @@ export default class CourseOverviewRoute extends BaseRoute {
   @service declare store: Store;
   @service declare metaData: MetaDataService;
 
-  @tracked previousMetaImageUrl: string | undefined;
+  previousMetaImageUrl: string | undefined;
 
   afterModel(model: ModelType) {
     this.previousMetaImageUrl = this.metaData.imageUrl;

--- a/app/routes/join-course.ts
+++ b/app/routes/join-course.ts
@@ -1,7 +1,6 @@
 import { inject as service } from '@ember/service';
 import BaseRoute from 'codecrafters-frontend/utils/base-route';
 import RepositoryPoller from 'codecrafters-frontend/utils/repository-poller';
-import { tracked } from '@glimmer/tracking';
 import config from 'codecrafters-frontend/config/environment';
 import type AuthenticatorService from 'codecrafters-frontend/services/authenticator';
 import type Store from '@ember-data/store';
@@ -24,7 +23,7 @@ export default class JoinCourseRoute extends BaseRoute {
   @service declare router: RouterService;
   @service declare store: Store;
 
-  @tracked previousMetaImageUrl: string | undefined;
+  previousMetaImageUrl: string | undefined;
 
   afterModel(model: ModelType) {
     if (!model.affiliateLink || !model.course) {

--- a/app/routes/track.ts
+++ b/app/routes/track.ts
@@ -2,7 +2,6 @@ import { inject as service } from '@ember/service';
 import BaseRoute from 'codecrafters-frontend/utils/base-route';
 import RepositoryPoller from 'codecrafters-frontend/utils/repository-poller';
 import scrollToTop from 'codecrafters-frontend/utils/scroll-to-top';
-import { tracked } from '@glimmer/tracking';
 import config from 'codecrafters-frontend/config/environment';
 import type AuthenticatorService from 'codecrafters-frontend/services/authenticator';
 import type Store from '@ember-data/store';
@@ -18,11 +17,12 @@ export type ModelType = {
 
 export default class TrackRoute extends BaseRoute {
   allowsAnonymousAccess = true;
+
   @service declare authenticator: AuthenticatorService;
   @service declare store: Store;
   @service declare metaData: MetaDataService;
 
-  @tracked previousMetaImageUrl: string | undefined;
+  previousMetaImageUrl: string | undefined;
 
   activate(): void {
     scrollToTop();


### PR DESCRIPTION
Related to #2607 

### Brief

In preparation to adding pre-rendering for user & concept pages, this cleans up the meta tags usage, removing `@tracked` from `previousMetaImageUrl` property of all routes that have it.

### Details

This property is only used in `activate` and `deactivate` hooks of the route, and doesn't need to be `@tracked`

### Checklist

- [x] I've thoroughly self-reviewed my changes
- [x] I've added tests for my changes, unless they affect admin-only areas (or are otherwise not worth testing)
- [x] I've verified any visual changes using Percy (add a commit with `[percy]` in the message to trigger)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Improved the handling of metadata images across several user interaction areas for more consistent behavior.
- **New Features**
	- Enhanced integration with core services to support streamlined course engagement and tracking functionalities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->