### PR TITLE
Add `replaceAllMetaTags` function to `replace-meta-tag` util

### DIFF
--- a/app/utils/replace-meta-tag.js
+++ b/app/utils/replace-meta-tag.js
@@ -21,3 +21,24 @@ export default function replaceMetaTag(text, idAttrName, idAttrValue, newContent
     `<meta ${idAttrName}=$1$2$1 content=$3${newContent}$3$5`,
   );
 }
+
+/**
+ * Overwrites required meta tags in the input text with newer ones, by sequentially
+ * calling `replaceMetaTag` and passing it meta tags from a predefined list.
+ * @param {string} text Input text to search for meta tags.
+ * @param {string} pageTitle Page title to use
+ * @param {string} pageDescription Page description to use
+ * @param {string} pageImageUrl Page image url to use
+ * @returns {string} Resulting text with meta tags content overwritten.
+ */
+export function replaceAllMetaTags(text, pageTitle, pageDescription, pageImageUrl) {
+  return [
+    ['name', 'description', pageDescription], // <meta name="description" content="...">
+    ['property', 'og:title', pageTitle],
+    ['property', 'og:description', pageDescription],
+    ['property', 'og:image', pageImageUrl],
+    ['name', 'twitter:title', pageTitle],
+    ['name', 'twitter:description', pageDescription],
+    ['name', 'twitter:image', pageImageUrl],
+  ].reduce((text, args) => replaceMetaTag(text, ...args), text);
+}

--- a/middleware.js
+++ b/middleware.js
@@ -16,7 +16,7 @@
  */
 
 import { next } from '@vercel/edge';
-import replaceMetaTag from './app/utils/replace-meta-tag';
+import { replaceAllMetaTags } from './app/utils/replace-meta-tag';
 
 export const config = {
   // Limit the middleware to run only for user profile and concept routes
@@ -130,18 +130,8 @@ export default async function middleware(request) {
   // Read contents of `/dist/_empty.html`
   const indexFileText = await fetch(indexFileURL).then((res) => res.text());
 
-  // Overwrite content of required meta tags with user-profile specific ones,
-  // by sequentially calling `replaceMetaTag` against `indexFileText`,
-  // and passing it arguments from the following list:
-  const responseText = [
-    ['name', 'description', pageDescription], // <meta name="description" content="...">
-    ['property', 'og:title', pageTitle],
-    ['property', 'og:description', pageDescription],
-    ['property', 'og:image', pageImageUrl],
-    ['name', 'twitter:title', pageTitle],
-    ['name', 'twitter:description', pageDescription],
-    ['name', 'twitter:image', pageImageUrl],
-  ].reduce((text, args) => replaceMetaTag(text, ...args), indexFileText);
+  // Overwrite content of required meta tags with newer ones
+  const responseText = replaceAllMetaTags(indexFileText, pageTitle, pageDescription, pageImageUrl);
 
   // Serve the result as HTML
   return new Response(responseText, { headers: { 'Content-Type': 'text/html' } });

--- a/tests/unit/utils/replace-meta-tag-test.ts
+++ b/tests/unit/utils/replace-meta-tag-test.ts
@@ -1,12 +1,7 @@
-import replaceMetaTag from 'codecrafters-frontend/utils/replace-meta-tag';
+import replaceMetaTag, { replaceAllMetaTags } from 'codecrafters-frontend/utils/replace-meta-tag';
 import { module, test } from 'qunit';
 
 module('Unit | Utility | replace-meta-tag', function () {
-  test('it exists and is a function', function (assert) {
-    assert.ok(replaceMetaTag, 'it exists');
-    assert.ok(replaceMetaTag instanceof Function, 'it is an instance of Function');
-  });
-
   test('it overwrites content of specified meta tags in passed text', function (assert) {
     assert.strictEqual(
       replaceMetaTag('<meta property="og:image" content="old image">', 'property', 'og:image', 'new image'),
@@ -54,5 +49,20 @@ module('Unit | Utility | replace-meta-tag', function () {
       '<meta foo="bar" content="top tag"><meta property="og:image" content="new image"><meta bar="baz" content="bottom tag">',
       'content around replaced tags is preserved',
     );
+  });
+
+  module('replaceAllMetaTags', function () {
+    test('it overwrites content of all specified meta tags in passed text', function (assert) {
+      assert.strictEqual(
+        replaceAllMetaTags(
+          '<meta property="og:image" content="old image"><meta property="og:title" content="old title"><meta property="og:description" content="old description"><meta name="twitter:image" content="old twitter image">',
+          'new title',
+          'new description',
+          'new image url',
+        ),
+        '<meta property="og:image" content="new image url"><meta property="og:title" content="new title"><meta property="og:description" content="new description"><meta name="twitter:image" content="new image url">',
+        'all old content is replaced with new content',
+      );
+    });
   });
 });


### PR DESCRIPTION
Related to #2607 

### Brief

In preparation to adding pre-rendering for user & concept pages, this extracts the logic to replace _all_ required OG meta tags from our _vercel middleware_ into `app/utils/replace-meta-tag.js`, so that it can be reused in prerender functions.

### Details

Tests included.

### Checklist

- [x] I've thoroughly self-reviewed my changes
- [x] I've added tests for my changes, unless they affect admin-only areas (or are otherwise not worth testing)
- [x] I've verified any visual changes using Percy (add a commit with `[percy]` in the message to trigger)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Streamlined meta tag management now updates your page title, description, and image in one unified step.
  - Enhanced handling of page metadata ensures that previews on search engines and social platforms display the latest, accurate information.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->