### PR TITLE
Refactor and enhance question card option with confetti animation

### DIFF
--- a/app/components/concept-page/question-card-option.hbs
+++ b/app/components/concept-page/question-card-option.hbs
@@ -7,6 +7,7 @@
     {{if this.isSelectedAndUnsubmitted 'bg-gray-100'}}
     {{if this.isSelectedAndCorrect 'bg-green-200'}}
     "
+  {{did-update this.fireCorrectAnswerConfetti @isSubmitted}}
   ...attributes
 >
   <div

--- a/app/components/concept-page/question-card-option.hbs
+++ b/app/components/concept-page/question-card-option.hbs
@@ -5,9 +5,8 @@
     {{if this.isUnselected 'hover:bg-gray-100 focus:bg-gray-100'}}
     {{if this.isUnselectedAndCorrect 'bg-green-200'}}
     {{if this.isSelectedAndUnsubmitted 'bg-gray-100'}}
-    {{if this.isSelectedAndCorrect 'bg-green-200'}}
-    "
-  {{did-update this.fireCorrectAnswerConfetti @isSubmitted}}
+    {{if this.isSelectedAndCorrect 'bg-green-200'}}"
+  {{did-insert this.fireCorrectAnswerConfetti}}
   ...attributes
 >
   <div

--- a/app/components/concept-page/question-card-option.ts
+++ b/app/components/concept-page/question-card-option.ts
@@ -1,6 +1,19 @@
 import Component from '@glimmer/component';
 
-export default class QuestionCardOptionComponent extends Component {
+interface QuestionOption {
+  is_correct: boolean;
+  isSelected: boolean;
+}
+
+interface QuestionCardOptionArgs {
+  option: QuestionOption;
+  isSubmitted: boolean;
+}
+
+export default class QuestionCardOptionComponent extends Component<QuestionCardOptionArgs> {
+  @service declare confetti: ConfettiService;
+  @tracked hasShownConfetti = false;
+
   get isCorrect() {
     return this.args.option.is_correct;
   }
@@ -28,4 +41,3 @@ export default class QuestionCardOptionComponent extends Component {
   get isUnselectedAndCorrect() {
     return this.args.isSubmitted && !this.args.option.isSelected && this.args.option.is_correct;
   }
-}

--- a/app/components/concept-page/question-card-option.ts
+++ b/app/components/concept-page/question-card-option.ts
@@ -1,4 +1,8 @@
 import Component from '@glimmer/component';
+import { inject as service } from '@ember/service';
+import { action } from '@ember/object';
+import { tracked } from '@glimmer/tracking';
+import type ConfettiService from 'codecrafters-frontend/services/confetti';
 
 interface QuestionOption {
   is_correct: boolean;
@@ -41,3 +45,20 @@ export default class QuestionCardOptionComponent extends Component<QuestionCardO
   get isUnselectedAndCorrect() {
     return this.args.isSubmitted && !this.args.option.isSelected && this.args.option.is_correct;
   }
+
+  @action
+  async fireCorrectAnswerConfetti(element: HTMLElement) {
+    if (this.hasShownConfetti || !this.args.isSubmitted || !this.isCorrect) {
+      return;
+    }
+
+    this.hasShownConfetti = true;
+    await this.confetti.fireFromElement(element, {
+      particleCount: 50,
+      spread: 60,
+      startVelocity: 20,
+      colors: ['#22c55e', '#16a34a', '#15803d'], // green colors
+      disableForReducedMotion: true
+    });
+  }
+}

--- a/app/components/concept-page/question-card-option.ts
+++ b/app/components/concept-page/question-card-option.ts
@@ -4,17 +4,22 @@ import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
 import type ConfettiService from 'codecrafters-frontend/services/confetti';
 
-interface QuestionOption {
-  is_correct: boolean;
-  isSelected: boolean;
+export interface Signature {
+  Element: HTMLButtonElement;
+
+  Args: {
+    option: {
+      is_correct: boolean;
+      isSelected: boolean;
+      markdown: string;
+      explanation_markdown: string;
+    };
+    isSubmitted: boolean;
+    questionSlug: string;
+  };
 }
 
-interface QuestionCardOptionArgs {
-  option: QuestionOption;
-  isSubmitted: boolean;
-}
-
-export default class QuestionCardOptionComponent extends Component<QuestionCardOptionArgs> {
+export default class QuestionCardOptionComponent extends Component<Signature> {
   @service declare confetti: ConfettiService;
   @tracked hasShownConfetti = false;
 
@@ -60,5 +65,11 @@ export default class QuestionCardOptionComponent extends Component<QuestionCardO
       colors: ['#22c55e', '#16a34a', '#15803d'], // green colors
       disableForReducedMotion: true
     });
+  }
+}
+
+declare module '@glint/environment-ember-loose/registry' {
+  export default interface Registry {
+    'ConceptPage::QuestionCardOption': typeof QuestionCardOptionComponent;
   }
 }

--- a/app/components/concept-page/question-card-option.ts
+++ b/app/components/concept-page/question-card-option.ts
@@ -23,6 +23,11 @@ export default class QuestionCardOptionComponent extends Component<Signature> {
   @service declare confetti: ConfettiService;
   @tracked hasShownConfetti = false;
 
+  constructor(owner: unknown, args: Signature['Args']) {
+    super(owner, args);
+    this.hasShownConfetti = localStorage.getItem(this.storageKey) === 'true';
+  }
+
   get isCorrect() {
     return this.args.option.is_correct;
   }
@@ -51,19 +56,24 @@ export default class QuestionCardOptionComponent extends Component<Signature> {
     return this.args.isSubmitted && !this.args.option.isSelected && this.args.option.is_correct;
   }
 
+  get storageKey() {
+    return `confetti-shown-question-${this.args.questionSlug}`;
+  }
+
   @action
   async fireCorrectAnswerConfetti(element: HTMLElement) {
-    if (this.hasShownConfetti || !this.args.isSubmitted || !this.isCorrect) {
+    if (this.hasShownConfetti || !this.isSelectedAndCorrect) {
       return;
     }
 
     this.hasShownConfetti = true;
+    localStorage.setItem(this.storageKey, 'true');
     await this.confetti.fireFromElement(element, {
       particleCount: 50,
       spread: 60,
       startVelocity: 20,
       colors: ['#22c55e', '#16a34a', '#15803d'], // green colors
-      disableForReducedMotion: true
+      disableForReducedMotion: true,
     });
   }
 }

--- a/app/components/concept-page/question-card-option.ts
+++ b/app/components/concept-page/question-card-option.ts
@@ -3,6 +3,7 @@ import { inject as service } from '@ember/service';
 import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
 import type ConfettiService from 'codecrafters-frontend/services/confetti';
+import type LocalStorageService from 'codecrafters-frontend/services/local-storage';
 
 export interface Signature {
   Element: HTMLButtonElement;
@@ -21,11 +22,12 @@ export interface Signature {
 
 export default class QuestionCardOptionComponent extends Component<Signature> {
   @service declare confetti: ConfettiService;
+  @service declare localStorage: LocalStorageService;
   @tracked hasShownConfetti = false;
 
   constructor(owner: unknown, args: Signature['Args']) {
     super(owner, args);
-    this.hasShownConfetti = localStorage.getItem(this.storageKey) === 'true';
+    this.hasShownConfetti = this.localStorage.getItem(this.storageKey) === 'true';
   }
 
   get isCorrect() {
@@ -67,7 +69,7 @@ export default class QuestionCardOptionComponent extends Component<Signature> {
     }
 
     this.hasShownConfetti = true;
-    localStorage.setItem(this.storageKey, 'true');
+    this.localStorage.setItem(this.storageKey, 'true');
     await this.confetti.fireFromMousePositionOrElement(element, {
       particleCount: 50,
       spread: 60,

--- a/app/components/concept-page/question-card-option.ts
+++ b/app/components/concept-page/question-card-option.ts
@@ -68,7 +68,7 @@ export default class QuestionCardOptionComponent extends Component<Signature> {
 
     this.hasShownConfetti = true;
     localStorage.setItem(this.storageKey, 'true');
-    await this.confetti.fireFromElement(element, {
+    await this.confetti.fireFromMousePositionOrElement(element, {
       particleCount: 50,
       spread: 60,
       startVelocity: 20,

--- a/app/components/concept-page/question-card.hbs
+++ b/app/components/concept-page/question-card.hbs
@@ -7,11 +7,11 @@
     {{! template-lint-disable no-invalid-interactive }}
     <div class="question-card-option-container flex flex-col -mx-3 sm:-mx-4 gap-px" {{did-insert this.handleDidInsertOptionsList}}>
       {{#each this.options as |option optionIndex|}}
-        {{! @glint-expect-error: not ts-ified yet }}
         <ConceptPage::QuestionCardOption
           class="px-4"
           @option={{option}}
           @isSubmitted={{this.hasSubmitted}}
+          @questionSlug={{@question.slug}}
           {{on "click" (fn this.handleOptionSelected optionIndex)}}
           data-test-question-card-option
         />

--- a/app/services/confetti.ts
+++ b/app/services/confetti.ts
@@ -27,6 +27,31 @@ export default class ConfettiService extends Service {
     return { x: originX, y: originY };
   }
 
+  #calculateConfettiOriginBasedOnMousePositionOrElementCenter(element: HTMLElement) {
+    // Get viewport dimensions
+    const viewportWidth = window.innerWidth;
+    const viewportHeight = window.innerHeight;
+
+    // Get the element's bounding rectangle
+    const rect = element.getBoundingClientRect();
+
+    // if mouseEvent is inside the rect, return the mouseEvent's position
+    const mouseEvent = window.event as MouseEvent;
+    if (mouseEvent) {
+      const x = mouseEvent.clientX;
+      const y = mouseEvent.clientY;
+      if (x > rect.left && x < rect.right && y > rect.top && y < rect.bottom) {
+        return {
+          x: x / viewportWidth,
+          y: y / viewportHeight,
+        };
+      }
+    }
+
+    // otherwise, return the rect's center position
+    return this.#calculateConfettiOrigin(element);
+  }
+
   async fire(options: confetti.Options = {}) {
     // canvas-confetti makes use of the document, doesn't make sense to run it in fastboot
     if (this.fastboot.isFastBoot) {
@@ -43,6 +68,17 @@ export default class ConfettiService extends Service {
     }
 
     options.origin = this.#calculateConfettiOrigin(element);
+
+    return confetti(options);
+  }
+
+  async fireFromMousePositionOrElement(element: HTMLElement, options: confetti.Options = {}) {
+    // canvas-confetti makes use of the document, doesn't make sense to run it in fastboot
+    if (this.fastboot.isFastBoot) {
+      return;
+    }
+
+    options.origin = this.#calculateConfettiOriginBasedOnMousePositionOrElementCenter(element);
 
     return confetti(options);
   }


### PR DESCRIPTION
Convert the question card option component to TypeScript, add a confetti animation for correct answers, and improve the component's functionality by persisting the confetti state and calculating the confetti origin based on mouse position or element center.

**Checklist**:

- [x] I've thoroughly self-reviewed my changes
- [ ] I've added tests for my changes, unless they affect admin-only areas (or are otherwise not worth testing)
- [ ] I've verified any visual changes using Percy (add a commit with `[percy]` in the message to trigger)
