### PR TITLE
feat: add concept completion modal for anonymous users

### DIFF
--- a/app/components/concept-page/concept-completed-modal.hbs
+++ b/app/components/concept-page/concept-completed-modal.hbs
@@ -1,0 +1,28 @@
+<ModalBody class>
+  <div class="flex flex-col items-center justify-center">
+    <div class="text-5xl mb-4">
+      🎉
+    </div>
+    <div class="prose mb-6 text-center">
+      <p>
+        You've completed this concept!
+      </p>
+      <p>
+        Get free access to the rest of Rust Primer by signing in with GitHub:
+      </p>
+    </div>
+    <PrimaryButton @size="large">
+      <div class="flex items-center gap-x-2">
+        {{svg-jar "github" class="fill-current w-4"}}
+
+        <span>
+          Sign in with GitHub
+        </span>
+      </div>
+    </PrimaryButton>
+
+    <div class="text-xs text-gray-400 text-center mt-3 max-w-xs">
+      The only data we request from GitHub is your username, avatar and email address.
+    </div>
+  </div>
+</ModalBody>

--- a/app/components/concept-page/concept-completed-modal.ts
+++ b/app/components/concept-page/concept-completed-modal.ts
@@ -1,0 +1,18 @@
+import Component from '@glimmer/component';
+import ConceptModel from 'codecrafters-frontend/models/concept';
+
+type Signature = {
+  Args: {
+    concept: ConceptModel;
+  };
+
+  Element: HTMLDivElement;
+};
+
+export default class ConceptCompletedModal extends Component<Signature> {}
+
+declare module '@glint/environment-ember-loose/registry' {
+  export default interface Registry {
+    'ConceptPage::ConceptCompletedModal': typeof ConceptCompletedModal;
+  }
+}

--- a/app/components/concept-page/content.hbs
+++ b/app/components/concept-page/content.hbs
@@ -22,6 +22,12 @@
       <div class="md:pr-8 pt-6 md:pt-10 pb-[75vh] min-w-0 flex-grow">
         <Concept @concept={{@concept}} @latestConceptEngagement={{@latestConceptEngagement}} />
 
+        {{#if (and this.hasCompletedConcept this.authenticator.isAnonymous)}}
+          <ModalBackdrop>
+            <ConceptPage::ConceptCompletedModal @concept={{@concept}} />
+          </ModalBackdrop>
+        {{/if}}
+
         {{#animated-if this.hasCompletedConcept}}
           <div class="flex flex-col gap-y-16 border-t pt-12" {{scroll-into-view block="start"}}>
             <div class="flex flex-col items-center justify-center">


### PR DESCRIPTION
Implement a modal that when a user completes a concept, 
specifically for anonymous users. The modal encourages users to sign 
in with GitHub to access additional content. This enhances user 
engagement and provides a clear call to action for further 
interaction with the platform.