### PR TITLE
CC-1627: Show login modal when a logged out user completes a concept, on click login & redirect to parent collections page

### DIFF
--- a/app/components/concept-page/concept-completed-modal.hbs
+++ b/app/components/concept-page/concept-completed-modal.hbs
@@ -22,7 +22,7 @@
         by signing in with GitHub.
       </p>
     </div>
-    <PrimaryButton @size="large" {{on "click" this.handleClicked}} data-test-concept-completed-modal-sign-in-button>
+    <PrimaryButton @size="large" {{on "click" this.handleSignInButtonClick}} data-test-concept-completed-modal-sign-in-button>
       <div class="flex items-center gap-x-2">
         {{svg-jar "github" class="fill-current w-5"}}
 

--- a/app/components/concept-page/concept-completed-modal.hbs
+++ b/app/components/concept-page/concept-completed-modal.hbs
@@ -12,7 +12,7 @@
       <p class="text-teal-700">
         Get
         <span class="font-semibold">free access</span>
-        to the rest of Rust Primer by signing in with GitHub.
+        to {{this.getAccessToMessage}} by signing in with GitHub.
       </p>
     </div>
     <PrimaryButton @size="large">

--- a/app/components/concept-page/concept-completed-modal.hbs
+++ b/app/components/concept-page/concept-completed-modal.hbs
@@ -15,7 +15,7 @@
         to {{this.getAccessToMessage}} by signing in with GitHub.
       </p>
     </div>
-    <PrimaryButton @size="large">
+    <PrimaryButton @size="large" {{on "click" this.handleClicked}}>
       <div class="flex items-center gap-x-2">
         {{svg-jar "github" class="fill-current w-5"}}
 

--- a/app/components/concept-page/concept-completed-modal.hbs
+++ b/app/components/concept-page/concept-completed-modal.hbs
@@ -13,7 +13,12 @@
         Get
         <span class="font-semibold">free access</span>
         to
-        {{this.getAccessToMessage}}
+        {{#if @conceptGroup}}
+          the rest of
+          {{@conceptGroup.title}}
+        {{else}}
+          all CodeCrafters concepts
+        {{/if}}
         by signing in with GitHub.
       </p>
     </div>

--- a/app/components/concept-page/concept-completed-modal.hbs
+++ b/app/components/concept-page/concept-completed-modal.hbs
@@ -12,10 +12,12 @@
       <p class="text-teal-700">
         Get
         <span class="font-semibold">free access</span>
-        to {{this.getAccessToMessage}} by signing in with GitHub.
+        to
+        {{this.getAccessToMessage}}
+        by signing in with GitHub.
       </p>
     </div>
-    <PrimaryButton @size="large" {{on "click" this.handleClicked}}>
+    <PrimaryButton @size="large" {{on "click" this.handleClicked}} data-test-concept-completed-modal-sign-in-button>
       <div class="flex items-center gap-x-2">
         {{svg-jar "github" class="fill-current w-5"}}
 

--- a/app/components/concept-page/concept-completed-modal.hbs
+++ b/app/components/concept-page/concept-completed-modal.hbs
@@ -1,0 +1,28 @@
+<ModalBody class>
+  <div class="flex flex-col items-center justify-center">
+    <div class="text-5xl mb-4">
+      🎉
+    </div>
+    <div class="prose mb-6 text-center">
+      <p>
+        You've completed this concept!
+      </p>
+      <p>
+        Get free access to the rest of Rust Primer by signing in with GitHub:
+      </p>
+    </div>
+    <PrimaryButton @size="large">
+      <div class="flex items-center gap-x-2">
+        {{svg-jar "github" class="fill-current w-4"}}
+
+        <span>
+          Sign in with GitHub
+        </span>
+      </div>
+    </PrimaryButton>
+
+    <div class="text-xs text-gray-400 text-center mt-3 max-w-xs">
+      The only data we request from GitHub is your username, avatar and email address.
+    </div>
+  </div>
+</ModalBody>

--- a/app/components/concept-page/concept-completed-modal.hbs
+++ b/app/components/concept-page/concept-completed-modal.hbs
@@ -1,19 +1,23 @@
-<ModalBody class>
-  <div class="flex flex-col items-center justify-center">
+<div class="flex w-full max-w-sm relative" data-test-concept-completed-modal ...attributes>
+  <div
+    class="flex flex-col items-center justify-center bg-gradient-to-t from-teal-50 via-teal-50 to-teal-100 border border-teal-600 rounded-lg px-6 py-10 md:px-8 md:py-16 shadow-2xl"
+  >
     <div class="text-5xl mb-4">
       🎉
     </div>
-    <div class="prose mb-6 text-center">
-      <p>
+    <div class="prose mb-6 text-center leading-6">
+      <p class="text-teal-700">
         You've completed this concept!
       </p>
-      <p>
-        Get free access to the rest of Rust Primer by signing in with GitHub:
+      <p class="text-teal-700">
+        Get
+        <span class="font-semibold">free access</span>
+        to the rest of Rust Primer by signing in with GitHub.
       </p>
     </div>
     <PrimaryButton @size="large">
       <div class="flex items-center gap-x-2">
-        {{svg-jar "github" class="fill-current w-4"}}
+        {{svg-jar "github" class="fill-current w-5"}}
 
         <span>
           Sign in with GitHub
@@ -21,8 +25,8 @@
       </div>
     </PrimaryButton>
 
-    <div class="text-xs text-gray-400 text-center mt-3 max-w-xs">
-      The only data we request from GitHub is your username, avatar and email address.
+    <div class="text-xs text-gray-400 text-center mt-4 max-w-xs">
+      We use GitHub for authentication. The only data we request is your username, avatar and email address.
     </div>
   </div>
-</ModalBody>
+</div>

--- a/app/components/concept-page/concept-completed-modal.ts
+++ b/app/components/concept-page/concept-completed-modal.ts
@@ -18,14 +18,6 @@ type Signature = {
 export default class ConceptCompletedModal extends Component<Signature> {
   @service declare authenticator: AuthenticatorService;
 
-  get getAccessToMessage() {
-    if (this.args.conceptGroup?.title) {
-      return `the rest of ${this.args.conceptGroup.title}`;
-    }
-
-    return 'all CodeCrafters concepts';
-  }
-
   get redirectPathAfterLogin() {
     if (this.args.conceptGroup?.title) {
       return `/collections/${this.args.conceptGroup.slug}`;

--- a/app/components/concept-page/concept-completed-modal.ts
+++ b/app/components/concept-page/concept-completed-modal.ts
@@ -27,20 +27,12 @@ export default class ConceptCompletedModal extends Component<Signature> {
   }
 
   @action
-  handleClicked() {
-    // We use a backend redirect flow here to handle concept completion after signup.
-    // Flow:
-    // 1. User clicks "Sign up" on concept completed modal
-    // 2. Redirect to backend endpoint that:
-    //    - Marks concept as complete (once user is authenticated)
-    //    - Redirects user to their final destination
-    //
-    // This approach ensures we don't lose the completion state during the auth flow,
-    // and handles edge cases like browser refresh during signup.
+  handleSignInButtonClick() {
+    // We redirect to `<backend_url>/concepts/:id/mark_as_complete` to ensure the user's progress is saved.
     const markAsCompleteUrl = new URL(`${config.x.backendUrl}/concepts/${this.args.concept.id}/mark_as_complete`);
 
-    markAsCompleteUrl.searchParams.set('redirect_url', this.redirectPathAfterLogin);
-
+    markAsCompleteUrl.searchParams.set('redirect_url', `${window.origin}${this.redirectPathAfterLogin}`);
+    
     this.authenticator.initiateLogin(markAsCompleteUrl.toString());
   }
 }

--- a/app/components/concept-page/concept-completed-modal.ts
+++ b/app/components/concept-page/concept-completed-modal.ts
@@ -1,6 +1,9 @@
+import { action } from '@ember/object';
+import { service } from '@ember/service';
 import Component from '@glimmer/component';
 import ConceptModel from 'codecrafters-frontend/models/concept';
 import type ConceptGroupModel from 'codecrafters-frontend/models/concept-group';
+import type AuthenticatorService from 'codecrafters-frontend/services/authenticator';
 
 type Signature = {
   Args: {
@@ -12,12 +15,27 @@ type Signature = {
 };
 
 export default class ConceptCompletedModal extends Component<Signature> {
+  @service declare authenticator: AuthenticatorService;
+
+  @action
+  handleClicked() {
+    this.authenticator.initiateLogin(this.redirectPathAfterLogin);
+  }
+
   get getAccessToMessage() {
     if (this.args.conceptGroup?.title) {
       return `the rest of ${this.args.conceptGroup.title}`;
     }
 
     return 'all CodeCrafters concepts';
+  }
+
+  get redirectPathAfterLogin() {
+    if (this.args.conceptGroup?.title) {
+      return `/collections/${this.args.conceptGroup.slug}`;
+    }
+
+    return '/catalog';
   }
 }
 

--- a/app/components/concept-page/concept-completed-modal.ts
+++ b/app/components/concept-page/concept-completed-modal.ts
@@ -32,7 +32,7 @@ export default class ConceptCompletedModal extends Component<Signature> {
     const markAsCompleteUrl = new URL(`${config.x.backendUrl}/concepts/${this.args.concept.id}/mark_as_complete`);
 
     markAsCompleteUrl.searchParams.set('redirect_url', `${window.origin}${this.redirectPathAfterLogin}`);
-    
+
     this.authenticator.initiateLogin(markAsCompleteUrl.toString());
   }
 }

--- a/app/components/concept-page/concept-completed-modal.ts
+++ b/app/components/concept-page/concept-completed-modal.ts
@@ -1,0 +1,18 @@
+import Component from '@glimmer/component';
+import ConceptModel from 'codecrafters-frontend/models/concept';
+
+type Signature = {
+  Args: {
+    concept: ConceptModel;
+  };
+
+  Element: HTMLDivElement;
+};
+
+export default class ConceptCompletedModal extends Component<Signature> {}
+
+declare module '@glint/environment-ember-loose/registry' {
+  export default interface Registry {
+    'ConceptPage::ConceptCompletedModal': typeof ConceptCompletedModal;
+  }
+}

--- a/app/components/concept-page/concept-completed-modal.ts
+++ b/app/components/concept-page/concept-completed-modal.ts
@@ -1,15 +1,25 @@
 import Component from '@glimmer/component';
 import ConceptModel from 'codecrafters-frontend/models/concept';
+import type ConceptGroupModel from 'codecrafters-frontend/models/concept-group';
 
 type Signature = {
   Args: {
     concept: ConceptModel;
+    conceptGroup: ConceptGroupModel;
   };
 
   Element: HTMLDivElement;
 };
 
-export default class ConceptCompletedModal extends Component<Signature> {}
+export default class ConceptCompletedModal extends Component<Signature> {
+  get getAccessToMessage() {
+    if (this.args.conceptGroup?.title) {
+      return `the rest of ${this.args.conceptGroup.title}`;
+    }
+
+    return 'all CodeCrafters concepts';
+  }
+}
 
 declare module '@glint/environment-ember-loose/registry' {
   export default interface Registry {

--- a/app/components/concept-page/concept-completed-modal.ts
+++ b/app/components/concept-page/concept-completed-modal.ts
@@ -9,7 +9,7 @@ import type AuthenticatorService from 'codecrafters-frontend/services/authentica
 type Signature = {
   Args: {
     concept: ConceptModel;
-    conceptGroup: ConceptGroupModel;
+    conceptGroup: ConceptGroupModel | undefined;
   };
 
   Element: HTMLDivElement;
@@ -17,29 +17,6 @@ type Signature = {
 
 export default class ConceptCompletedModal extends Component<Signature> {
   @service declare authenticator: AuthenticatorService;
-
-  @action
-  handleClicked() {
-    // We use a backend redirect flow here to handle concept completion after signup.
-    // Flow:
-    // 1. User clicks "Sign up" on concept completed modal
-    // 2. Redirect to backend endpoint that:
-    //    - Marks concept as complete (once user is authenticated)
-    //    - Redirects user to their final destination
-    // 
-    // This approach ensures we don't lose the completion state during the auth flow,
-    // and handles edge cases like browser refresh during signup.
-    const markAsCompleteUrl = new URL(
-      `${config.x.backendUrl}/concepts/${this.args.concept.id}/mark_as_complete`
-    );
-    
-    markAsCompleteUrl.searchParams.set(
-      'redirect_url',
-      this.redirectPathAfterLogin
-    );
-
-    this.authenticator.initiateLogin(markAsCompleteUrl.toString());
-  }
 
   get getAccessToMessage() {
     if (this.args.conceptGroup?.title) {
@@ -55,6 +32,24 @@ export default class ConceptCompletedModal extends Component<Signature> {
     }
 
     return '/catalog';
+  }
+
+  @action
+  handleClicked() {
+    // We use a backend redirect flow here to handle concept completion after signup.
+    // Flow:
+    // 1. User clicks "Sign up" on concept completed modal
+    // 2. Redirect to backend endpoint that:
+    //    - Marks concept as complete (once user is authenticated)
+    //    - Redirects user to their final destination
+    //
+    // This approach ensures we don't lose the completion state during the auth flow,
+    // and handles edge cases like browser refresh during signup.
+    const markAsCompleteUrl = new URL(`${config.x.backendUrl}/concepts/${this.args.concept.id}/mark_as_complete`);
+
+    markAsCompleteUrl.searchParams.set('redirect_url', this.redirectPathAfterLogin);
+
+    this.authenticator.initiateLogin(markAsCompleteUrl.toString());
   }
 }
 

--- a/app/components/concept-page/concept-completed-modal.ts
+++ b/app/components/concept-page/concept-completed-modal.ts
@@ -1,4 +1,5 @@
 import { action } from '@ember/object';
+import config from 'codecrafters-frontend/config/environment';
 import { service } from '@ember/service';
 import Component from '@glimmer/component';
 import ConceptModel from 'codecrafters-frontend/models/concept';
@@ -19,7 +20,25 @@ export default class ConceptCompletedModal extends Component<Signature> {
 
   @action
   handleClicked() {
-    this.authenticator.initiateLogin(this.redirectPathAfterLogin);
+    // We use a backend redirect flow here to handle concept completion after signup.
+    // Flow:
+    // 1. User clicks "Sign up" on concept completed modal
+    // 2. Redirect to backend endpoint that:
+    //    - Marks concept as complete (once user is authenticated)
+    //    - Redirects user to their final destination
+    // 
+    // This approach ensures we don't lose the completion state during the auth flow,
+    // and handles edge cases like browser refresh during signup.
+    const markAsCompleteUrl = new URL(
+      `${config.x.backendUrl}/concepts/${this.args.concept.id}/mark_as_complete`
+    );
+    
+    markAsCompleteUrl.searchParams.set(
+      'redirect_url',
+      this.redirectPathAfterLogin
+    );
+
+    this.authenticator.initiateLogin(markAsCompleteUrl.toString());
   }
 
   get getAccessToMessage() {

--- a/app/components/concept-page/content.hbs
+++ b/app/components/concept-page/content.hbs
@@ -24,7 +24,7 @@
 
         {{#if (and this.hasCompletedConcept this.authenticator.isAnonymous)}}
           <ModalBackdrop>
-            <ConceptPage::ConceptCompletedModal @concept={{@concept}} />
+            <ConceptPage::ConceptCompletedModal @concept={{@concept}} @conceptGroup={{@conceptGroup}} />
           </ModalBackdrop>
         {{/if}}
 

--- a/app/components/concept-page/content.hbs
+++ b/app/components/concept-page/content.hbs
@@ -22,6 +22,12 @@
       <div class="md:pr-8 pt-6 md:pt-10 pb-[75vh] min-w-0 flex-grow">
         <Concept @concept={{@concept}} @latestConceptEngagement={{@latestConceptEngagement}} />
 
+        {{#if (and this.hasCompletedConcept this.authenticator.isAnonymous)}}
+          <ModalBackdrop>
+            <ConceptPage::ConceptCompletedModal @concept={{@concept}} />
+          </ModalBackdrop>
+        {{/if}}
+
         {{#animated-if this.hasCompletedConcept}}
           <div class="flex flex-col gap-y-16 border-t pt-12" {{scroll-into-view block="start"}}>
             <div class="flex flex-col items-center justify-center">

--- a/app/services/authenticator.ts
+++ b/app/services/authenticator.ts
@@ -74,6 +74,7 @@ export default class AuthenticatorService extends Service {
 
   initiateLogin(redirectPath: string | null) {
     const isFullUrl = redirectPath?.startsWith(`${config.x.backendUrl}`);
+
     if (isFullUrl) {
       window.location.href = `${config.x.backendUrl}/login?next=` + redirectPath;
     } else if (redirectPath) {

--- a/app/services/authenticator.ts
+++ b/app/services/authenticator.ts
@@ -73,7 +73,10 @@ export default class AuthenticatorService extends Service {
   }
 
   initiateLogin(redirectPath: string | null) {
-    if (redirectPath) {
+    const isFullUrl = redirectPath?.startsWith(`${config.x.backendUrl}`);
+    if (isFullUrl) {
+      window.location.href = `${config.x.backendUrl}/login?next=` + redirectPath;
+    } else if (redirectPath) {
       window.location.href = `${config.x.backendUrl}/login?next=` + encodeURIComponent(`${window.origin}${redirectPath}`);
     } else if (this.router.currentURL) {
       window.location.href = `${config.x.backendUrl}/login?next=` + encodeURIComponent(`${window.origin}${this.router.currentURL}`);

--- a/tests/acceptance/concepts-test.js
+++ b/tests/acceptance/concepts-test.js
@@ -87,7 +87,7 @@ module('Acceptance | concepts-test', function (hooks) {
     await percySnapshot('Concept - Completed');
   });
 
-  test('anonymous users can also view concepts', async function (assert) {
+  test('anonymous users can view concepts linked to a concept group', async function (assert) {
     testScenario(this.server);
     createConcepts(this.server);
 
@@ -135,7 +135,59 @@ module('Acceptance | concepts-test', function (hooks) {
     );
 
     const conceptId = this.server.schema.concepts.findBy({ slug: 'network-protocols' }).id;
-    const expectedRedirectUrl = encodeURIComponent('/collections/network-primer');
+
+    const expectedRedirectUrl = encodeURIComponent(`${window.origin}/collections/network-primer`);
+    const nextUrl = config.x.backendUrl + '/concepts/' + conceptId + '/mark_as_complete?redirect_url=' + expectedRedirectUrl;
+
+    await conceptPage.conceptCompletedModal.clickOnSignInButton();
+
+    assert.strictEqual(
+      windowMock.location.href,
+      `${windowMock.location.origin}/login?next=${nextUrl}`,
+      'should redirect to login URL with correct mark_as_complete endpoint',
+    );
+  });
+
+  test('anonymous users can view concepts not linked to a concept group', async function (assert) {
+    testScenario(this.server);
+    createConcepts(this.server);
+
+    await conceptsPage.visit();
+
+    await conceptsPage.clickOnConceptCard('Network Protocols');
+    await conceptPage.clickOnContinueButton();
+    await conceptPage.clickOnContinueButton();
+    await conceptPage.questionCards[0].selectOption('PDF');
+    await conceptPage.clickOnContinueButton();
+    await conceptPage.clickOnContinueButton();
+    await conceptPage.clickOnContinueButton();
+    await conceptPage.questionCards[1].clickOnShowExplanationButton();
+    await conceptPage.clickOnContinueButton();
+    await conceptPage.clickOnContinueButton();
+    await conceptPage.clickOnContinueButton();
+    await conceptPage.questionCards[2].clickOnShowExplanationButton();
+    await conceptPage.clickOnContinueButton();
+    await conceptPage.clickOnContinueButton();
+    await conceptPage.clickOnContinueButton();
+    await conceptPage.clickOnContinueButton();
+    await conceptPage.clickOnContinueButton();
+    await conceptPage.clickOnContinueButton();
+    await conceptPage.questionCards[3].clickOnShowExplanationButton();
+    await conceptPage.clickOnContinueButton();
+    await conceptPage.clickOnContinueButton();
+    await conceptPage.clickOnContinueButton();
+    await conceptPage.clickOnContinueButton();
+    await conceptPage.clickOnContinueButton();
+
+    assert.true(conceptPage.conceptCompletedModal.isVisible, 'Concept completed modal is shown for anonymous users');
+    assert.true(
+      conceptPage.conceptCompletedModal.text.includes('Get free access to all CodeCrafters concepts'),
+      'Modal shows correct full catalog access message',
+    );
+
+    const conceptId = this.server.schema.concepts.findBy({ slug: 'network-protocols' }).id;
+
+    const expectedRedirectUrl = encodeURIComponent(`${window.origin}/catalog`);
     const nextUrl = config.x.backendUrl + '/concepts/' + conceptId + '/mark_as_complete?redirect_url=' + expectedRedirectUrl;
 
     await conceptPage.conceptCompletedModal.clickOnSignInButton();

--- a/tests/acceptance/concepts-test.js
+++ b/tests/acceptance/concepts-test.js
@@ -27,65 +27,65 @@ module('Acceptance | concepts-test', function (hooks) {
   setupAnimationTest(hooks);
   setupWindowMock(hooks);
 
-  // test('can create concept', async function (assert) {
-  //   testScenario(this.server);
+  test('can create concept', async function (assert) {
+    testScenario(this.server);
 
-  //   signInAsStaff(this.owner, this.server);
+    signInAsStaff(this.owner, this.server);
 
-  //   await conceptsPage.visit();
-  //   await conceptsPage.clickOnCreateConceptButton();
+    await conceptsPage.visit();
+    await conceptsPage.clickOnCreateConceptButton();
 
-  //   assert.strictEqual(currentURL(), '/concepts/new-concept/admin/basic-details');
-  // });
+    assert.strictEqual(currentURL(), '/concepts/new-concept/admin/basic-details');
+  });
 
-  // test('can view concepts', async function (assert) {
-  //   testScenario(this.server);
-  //   createConcepts(this.server);
+  test('can view concepts', async function (assert) {
+    testScenario(this.server);
+    createConcepts(this.server);
 
-  //   signInAsStaff(this.owner, this.server);
+    signInAsStaff(this.owner, this.server);
 
-  //   this.server.schema.conceptGroups.create({
-  //     conceptSlugs: ['network-protocols', 'tcp-overview'],
-  //     descriptionMarkdown: 'This is a group about network concepts',
-  //     slug: 'network-primer',
-  //     title: 'Network Primer',
-  //   });
+    this.server.schema.conceptGroups.create({
+      conceptSlugs: ['network-protocols', 'tcp-overview'],
+      descriptionMarkdown: 'This is a group about network concepts',
+      slug: 'network-primer',
+      title: 'Network Primer',
+    });
 
-  //   await conceptsPage.visit();
+    await conceptsPage.visit();
 
-  //   await percySnapshot('Concept - Start');
+    await percySnapshot('Concept - Start');
 
-  //   await conceptsPage.clickOnConceptCard('Network Protocols');
-  //   await conceptPage.clickOnContinueButton();
-  //   await conceptPage.clickOnContinueButton();
-  //   await conceptPage.questionCards[0].selectOption('PDF');
-  //   await conceptPage.clickOnContinueButton();
-  //   await conceptPage.clickOnContinueButton();
-  //   await conceptPage.clickOnContinueButton();
-  //   await conceptPage.questionCards[1].clickOnShowExplanationButton();
-  //   await conceptPage.clickOnContinueButton();
-  //   await conceptPage.clickOnContinueButton();
-  //   await conceptPage.clickOnContinueButton();
-  //   await conceptPage.questionCards[2].clickOnShowExplanationButton();
-  //   await conceptPage.clickOnContinueButton();
-  //   await conceptPage.clickOnContinueButton();
-  //   await conceptPage.clickOnContinueButton();
-  //   await conceptPage.clickOnContinueButton();
-  //   await conceptPage.clickOnContinueButton();
-  //   await conceptPage.clickOnContinueButton();
-  //   await conceptPage.questionCards[3].clickOnShowExplanationButton();
-  //   await conceptPage.clickOnContinueButton();
-  //   await conceptPage.clickOnContinueButton();
-  //   await conceptPage.clickOnContinueButton();
-  //   await conceptPage.clickOnContinueButton();
-  //   await conceptPage.clickOnContinueButton();
+    await conceptsPage.clickOnConceptCard('Network Protocols');
+    await conceptPage.clickOnContinueButton();
+    await conceptPage.clickOnContinueButton();
+    await conceptPage.questionCards[0].selectOption('PDF');
+    await conceptPage.clickOnContinueButton();
+    await conceptPage.clickOnContinueButton();
+    await conceptPage.clickOnContinueButton();
+    await conceptPage.questionCards[1].clickOnShowExplanationButton();
+    await conceptPage.clickOnContinueButton();
+    await conceptPage.clickOnContinueButton();
+    await conceptPage.clickOnContinueButton();
+    await conceptPage.questionCards[2].clickOnShowExplanationButton();
+    await conceptPage.clickOnContinueButton();
+    await conceptPage.clickOnContinueButton();
+    await conceptPage.clickOnContinueButton();
+    await conceptPage.clickOnContinueButton();
+    await conceptPage.clickOnContinueButton();
+    await conceptPage.clickOnContinueButton();
+    await conceptPage.questionCards[3].clickOnShowExplanationButton();
+    await conceptPage.clickOnContinueButton();
+    await conceptPage.clickOnContinueButton();
+    await conceptPage.clickOnContinueButton();
+    await conceptPage.clickOnContinueButton();
+    await conceptPage.clickOnContinueButton();
 
-  //   assert.true(conceptPage.upcomingConcept.title.text.includes('Network Primer'), 'Concept group title is correct');
-  //   assert.true(conceptPage.upcomingConcept.card.title.text.includes('TCP: An Overview'), 'Next concept title is correct');
-  //   assert.true(conceptPage.shareConceptContainer.text.includes('https://app.codecrafters.io/concepts/network-protocols'));
+    assert.true(conceptPage.upcomingConcept.title.text.includes('Network Primer'), 'Concept group title is correct');
+    assert.true(conceptPage.upcomingConcept.card.title.text.includes('TCP: An Overview'), 'Next concept title is correct');
+    assert.true(conceptPage.shareConceptContainer.text.includes('https://app.codecrafters.io/concepts/network-protocols'));
 
-  //   await percySnapshot('Concept - Completed');
-  // });
+    await percySnapshot('Concept - Completed');
+  });
 
   test('anonymous users can also view concepts', async function (assert) {
     testScenario(this.server);
@@ -123,8 +123,6 @@ module('Acceptance | concepts-test', function (hooks) {
     await conceptPage.clickOnContinueButton();
     await conceptPage.clickOnContinueButton();
     await conceptPage.clickOnContinueButton();
-
-    await animationsSettled();
     await conceptPage.clickOnContinueButton();
 
     assert.true(conceptPage.upcomingConcept.title.text.includes('Network Primer'), 'Concept group title is correct');
@@ -138,11 +136,10 @@ module('Acceptance | concepts-test', function (hooks) {
 
     const expectedRedirectUrl = encodeURIComponent('/collections/network-primer');
 
-    const conceptId = 2;
+    const conceptId = this.server.schema.concepts.findBy({ slug: 'network-protocols' }).id;
     const nextUrl = config.x.backendUrl + '/concepts/' + conceptId + '/mark_as_complete?redirect_url=' + expectedRedirectUrl;
 
     await conceptPage.conceptCompletedModal.clickOnSignInButton();
-    await animationsSettled();
 
     assert.strictEqual(
       windowMock.location.href,
@@ -151,575 +148,575 @@ module('Acceptance | concepts-test', function (hooks) {
     );
   });
 
-  // test('concept question body has prism highlighting', async function (assert) {
-  //   testScenario(this.server);
-  //   createConcepts(this.server);
-
-  //   signInAsStaff(this.owner, this.server);
-
-  //   await conceptsPage.visit();
-
-  //   await conceptsPage.clickOnConceptCard('Dummy Concept');
-  //   await conceptPage.clickOnContinueButton();
-  //   await conceptPage.clickOnContinueButton();
-  //   assert.true(conceptPage.questionCards[0].body.hasPrismHighlighting);
-  //   await conceptPage.questionCards[0].selectOption('Correct');
-  //   await conceptPage.clickOnContinueButton();
-  //   await conceptPage.clickOnContinueButton();
-  // });
-
-  // test('clicking on the upcoming concept cards works properly', async function (assert) {
-  //   testScenario(this.server);
-  //   createConcepts(this.server);
-
-  //   signInAsStaff(this.owner, this.server);
-
-  //   this.server.schema.conceptGroups.create({
-  //     conceptSlugs: ['network-protocols', 'tcp-overview'],
-  //     descriptionMarkdown: 'This is a group about network concepts',
-  //     slug: 'network-primer',
-  //     title: 'Network Primer',
-  //   });
-
-  //   await conceptsPage.visit();
-  //   await conceptsPage.clickOnConceptCard('Network Protocols');
-  //   await conceptPage.clickOnContinueButton();
-  //   await conceptPage.clickOnContinueButton();
-  //   await conceptPage.questionCards[0].selectOption('PDF');
-  //   await conceptPage.clickOnContinueButton();
-  //   await conceptPage.clickOnContinueButton();
-  //   await conceptPage.clickOnContinueButton();
-  //   await conceptPage.questionCards[1].clickOnShowExplanationButton();
-  //   await conceptPage.clickOnContinueButton();
-  //   await conceptPage.clickOnContinueButton();
-  //   await conceptPage.clickOnContinueButton();
-  //   await conceptPage.questionCards[2].clickOnShowExplanationButton();
-  //   await conceptPage.clickOnContinueButton();
-  //   await conceptPage.clickOnContinueButton();
-  //   await conceptPage.clickOnContinueButton();
-  //   await conceptPage.clickOnContinueButton();
-  //   await conceptPage.clickOnContinueButton();
-  //   await conceptPage.clickOnContinueButton();
-  //   await conceptPage.questionCards[3].clickOnShowExplanationButton();
-  //   await conceptPage.clickOnContinueButton();
-  //   await conceptPage.clickOnContinueButton();
-  //   await conceptPage.clickOnContinueButton();
-  //   await conceptPage.clickOnContinueButton();
-  //   await conceptPage.clickOnContinueButton();
-
-  //   await conceptPage.upcomingConcept.card.click();
-  //   assert.strictEqual(currentURL(), '/concepts/tcp-overview', 'Clicking on the upcoming concept card navigates to the next concept');
-  //   assert.strictEqual(conceptPage.blocks.length, 1, 'The progress is reset when navigating to a new concept');
-  //   assert.strictEqual(window.scrollY, 0, 'The page is scrolled to the top when navigating to a new concept');
-  // });
-
-  // test('tracks concepts events', async function (assert) {
-  //   testScenario(this.server);
-  //   createConcepts(this.server);
-
-  //   signInAsStaff(this.owner, this.server);
-
-  //   await conceptsPage.visit();
-
-  //   await conceptsPage.clickOnConceptCard('Network Protocols');
-  //   await conceptPage.clickOnContinueButton();
-  //   await conceptPage.clickOnContinueButton();
-  //   await conceptPage.questionCards[0].clickOnShowExplanationButton();
-  //   await conceptPage.clickOnContinueButton();
-  //   await conceptPage.clickOnContinueButton();
-  //   await conceptPage.clickOnContinueButton();
-
-  //   const analyticsEvents = this.server.schema.analyticsEvents.all().models;
-  //   const filteredAnalyticsEvents = analyticsEvents.filter((event) => event.name !== 'feature_flag_called');
-
-  //   assert.strictEqual(filteredAnalyticsEvents.length, 8, 'Expected 8 analytics events to be tracked');
-
-  //   assert.deepEqual(
-  //     filteredAnalyticsEvents.map((event) => event.name),
-  //     [
-  //       'viewed_page',
-  //       'viewed_page',
-  //       'viewed_concept',
-  //       'progressed_through_concept',
-  //       'progressed_through_concept',
-  //       'progressed_through_concept',
-  //       'progressed_through_concept',
-  //       'progressed_through_concept',
-  //     ],
-  //   );
-  // });
-
-  // test('tracks when share concept button is clicked', async function (assert) {
-  //   testScenario(this.server);
-  //   createConcepts(this.server);
+  test('concept question body has prism highlighting', async function (assert) {
+    testScenario(this.server);
+    createConcepts(this.server);
+
+    signInAsStaff(this.owner, this.server);
+
+    await conceptsPage.visit();
+
+    await conceptsPage.clickOnConceptCard('Dummy Concept');
+    await conceptPage.clickOnContinueButton();
+    await conceptPage.clickOnContinueButton();
+    assert.true(conceptPage.questionCards[0].body.hasPrismHighlighting);
+    await conceptPage.questionCards[0].selectOption('Correct');
+    await conceptPage.clickOnContinueButton();
+    await conceptPage.clickOnContinueButton();
+  });
+
+  test('clicking on the upcoming concept cards works properly', async function (assert) {
+    testScenario(this.server);
+    createConcepts(this.server);
+
+    signInAsStaff(this.owner, this.server);
+
+    this.server.schema.conceptGroups.create({
+      conceptSlugs: ['network-protocols', 'tcp-overview'],
+      descriptionMarkdown: 'This is a group about network concepts',
+      slug: 'network-primer',
+      title: 'Network Primer',
+    });
+
+    await conceptsPage.visit();
+    await conceptsPage.clickOnConceptCard('Network Protocols');
+    await conceptPage.clickOnContinueButton();
+    await conceptPage.clickOnContinueButton();
+    await conceptPage.questionCards[0].selectOption('PDF');
+    await conceptPage.clickOnContinueButton();
+    await conceptPage.clickOnContinueButton();
+    await conceptPage.clickOnContinueButton();
+    await conceptPage.questionCards[1].clickOnShowExplanationButton();
+    await conceptPage.clickOnContinueButton();
+    await conceptPage.clickOnContinueButton();
+    await conceptPage.clickOnContinueButton();
+    await conceptPage.questionCards[2].clickOnShowExplanationButton();
+    await conceptPage.clickOnContinueButton();
+    await conceptPage.clickOnContinueButton();
+    await conceptPage.clickOnContinueButton();
+    await conceptPage.clickOnContinueButton();
+    await conceptPage.clickOnContinueButton();
+    await conceptPage.clickOnContinueButton();
+    await conceptPage.questionCards[3].clickOnShowExplanationButton();
+    await conceptPage.clickOnContinueButton();
+    await conceptPage.clickOnContinueButton();
+    await conceptPage.clickOnContinueButton();
+    await conceptPage.clickOnContinueButton();
+    await conceptPage.clickOnContinueButton();
+
+    await conceptPage.upcomingConcept.card.click();
+    assert.strictEqual(currentURL(), '/concepts/tcp-overview', 'Clicking on the upcoming concept card navigates to the next concept');
+    assert.strictEqual(conceptPage.blocks.length, 1, 'The progress is reset when navigating to a new concept');
+    assert.strictEqual(window.scrollY, 0, 'The page is scrolled to the top when navigating to a new concept');
+  });
+
+  test('tracks concepts events', async function (assert) {
+    testScenario(this.server);
+    createConcepts(this.server);
+
+    signInAsStaff(this.owner, this.server);
+
+    await conceptsPage.visit();
+
+    await conceptsPage.clickOnConceptCard('Network Protocols');
+    await conceptPage.clickOnContinueButton();
+    await conceptPage.clickOnContinueButton();
+    await conceptPage.questionCards[0].clickOnShowExplanationButton();
+    await conceptPage.clickOnContinueButton();
+    await conceptPage.clickOnContinueButton();
+    await conceptPage.clickOnContinueButton();
+
+    const analyticsEvents = this.server.schema.analyticsEvents.all().models;
+    const filteredAnalyticsEvents = analyticsEvents.filter((event) => event.name !== 'feature_flag_called');
+
+    assert.strictEqual(filteredAnalyticsEvents.length, 8, 'Expected 8 analytics events to be tracked');
+
+    assert.deepEqual(
+      filteredAnalyticsEvents.map((event) => event.name),
+      [
+        'viewed_page',
+        'viewed_page',
+        'viewed_concept',
+        'progressed_through_concept',
+        'progressed_through_concept',
+        'progressed_through_concept',
+        'progressed_through_concept',
+        'progressed_through_concept',
+      ],
+    );
+  });
+
+  test('tracks when share concept button is clicked', async function (assert) {
+    testScenario(this.server);
+    createConcepts(this.server);
 
-  //   signInAsStaff(this.owner, this.server);
+    signInAsStaff(this.owner, this.server);
 
-  //   await conceptsPage.visit();
+    await conceptsPage.visit();
 
-  //   await conceptsPage.clickOnConceptCard('Dummy Concept');
-  //   await conceptPage.clickOnContinueButton();
-  //   await conceptPage.clickOnContinueButton();
-  //   await conceptPage.questionCards[0].clickOnShowExplanationButton();
-  //   await conceptPage.clickOnContinueButton();
-  //   await conceptPage.clickOnContinueButton();
+    await conceptsPage.clickOnConceptCard('Dummy Concept');
+    await conceptPage.clickOnContinueButton();
+    await conceptPage.clickOnContinueButton();
+    await conceptPage.questionCards[0].clickOnShowExplanationButton();
+    await conceptPage.clickOnContinueButton();
+    await conceptPage.clickOnContinueButton();
 
-  //   await conceptPage.shareConceptContainer.clickOnCopyButton();
-
-  //   const analyticsEvents = this.server.schema.analyticsEvents.all().models;
-  //   const filteredAnalyticsEvents = analyticsEvents.filter((event) => event.name !== 'feature_flag_called');
-  //   const filteredAnalyticsEventsNames = filteredAnalyticsEvents.map((event) => event.name);
-
-  //   assert.ok(filteredAnalyticsEventsNames.includes('clicked_share_concept_button'), 'clicked_on_share_concept_button event should be tracked');
-  // });
-
-  // test('submit button does not work when no option is selected for question card', async function (assert) {
-  //   testScenario(this.server);
-  //   createConcepts(this.server);
-
-  //   signInAsStaff(this.owner, this.server);
-  //   await conceptsPage.visit();
-  //   await conceptsPage.clickOnConceptCard('Network Protocols');
-  //   await conceptPage.clickOnContinueButton();
-  //   await conceptPage.clickOnContinueButton();
-
-  //   assert.notOk(conceptPage.questionCards[0].hasSubmitted, 'The submission result should not be visible without selecting an option.');
-
-  //   await conceptPage.questionCards[0].selectOption('PDF');
-
-  //   assert.ok(conceptPage.questionCards[0].hasSubmitted, 'After selecting an option, the submission result should be visible.');
-  // });
-
-  // test('progress is tracked', async function (assert) {
-  //   testScenario(this.server);
-  //   createConcepts(this.server);
-
-  //   const user = this.server.schema.users.first();
-  //   signIn(this.owner, this.server, user);
-
-  //   await conceptsPage.visit();
-  //   assert.notOk(conceptsPage.conceptCards[1].hasProgressBar, 'Progress bar should not be present in concept card before starting concept');
-
-  //   await conceptsPage.conceptCards[1].hover();
-  //   assert.strictEqual(conceptsPage.conceptCards[1].actionText, 'View', 'Concept card action text should be view');
-
-  //   await conceptsPage.clickOnConceptCard('Network Protocols');
-  //   assert.notOk(conceptPage.progress.isPresent, 'Progress bar should not be present in concept before starting');
-
-  //   await conceptPage.clickOnContinueButton();
-  //   assert.ok(conceptPage.progress.isPresent, 'Progress bar should be present after starting concept');
-  //   assert.ok(conceptPage.progress.text.includes('5%'), 'Progress text should reflect tracked progress in concept page');
-  //   assert.ok(conceptPage.progress.barStyle.includes('width: 5%'), 'Progress bar should reflect tracked progress in concept page');
-  //   assert.ok(conceptPage.progress.text.includes('39 blocks left'), 'Remaining blocks left should be reflected properly');
+    await conceptPage.shareConceptContainer.clickOnCopyButton();
+
+    const analyticsEvents = this.server.schema.analyticsEvents.all().models;
+    const filteredAnalyticsEvents = analyticsEvents.filter((event) => event.name !== 'feature_flag_called');
+    const filteredAnalyticsEventsNames = filteredAnalyticsEvents.map((event) => event.name);
+
+    assert.ok(filteredAnalyticsEventsNames.includes('clicked_share_concept_button'), 'clicked_on_share_concept_button event should be tracked');
+  });
+
+  test('submit button does not work when no option is selected for question card', async function (assert) {
+    testScenario(this.server);
+    createConcepts(this.server);
+
+    signInAsStaff(this.owner, this.server);
+    await conceptsPage.visit();
+    await conceptsPage.clickOnConceptCard('Network Protocols');
+    await conceptPage.clickOnContinueButton();
+    await conceptPage.clickOnContinueButton();
+
+    assert.notOk(conceptPage.questionCards[0].hasSubmitted, 'The submission result should not be visible without selecting an option.');
+
+    await conceptPage.questionCards[0].selectOption('PDF');
+
+    assert.ok(conceptPage.questionCards[0].hasSubmitted, 'After selecting an option, the submission result should be visible.');
+  });
+
+  test('progress is tracked', async function (assert) {
+    testScenario(this.server);
+    createConcepts(this.server);
+
+    const user = this.server.schema.users.first();
+    signIn(this.owner, this.server, user);
+
+    await conceptsPage.visit();
+    assert.notOk(conceptsPage.conceptCards[1].hasProgressBar, 'Progress bar should not be present in concept card before starting concept');
+
+    await conceptsPage.conceptCards[1].hover();
+    assert.strictEqual(conceptsPage.conceptCards[1].actionText, 'View', 'Concept card action text should be view');
+
+    await conceptsPage.clickOnConceptCard('Network Protocols');
+    assert.notOk(conceptPage.progress.isPresent, 'Progress bar should not be present in concept before starting');
+
+    await conceptPage.clickOnContinueButton();
+    assert.ok(conceptPage.progress.isPresent, 'Progress bar should be present after starting concept');
+    assert.ok(conceptPage.progress.text.includes('5%'), 'Progress text should reflect tracked progress in concept page');
+    assert.ok(conceptPage.progress.barStyle.includes('width: 5%'), 'Progress bar should reflect tracked progress in concept page');
+    assert.ok(conceptPage.progress.text.includes('39 blocks left'), 'Remaining blocks left should be reflected properly');
 
-  //   await conceptPage.clickOnContinueButton();
-  //   await conceptPage.questionCards[0].clickOnShowExplanationButton();
-  //   assert.ok(conceptPage.progress.text.includes('10%'));
-  //   assert.ok(conceptPage.progress.barStyle.includes('width: 10%'));
-
-  //   await conceptPage.clickOnStepBackButton();
-  //   assert.ok(conceptPage.progress.text.includes('5%'));
-  //   assert.ok(conceptPage.progress.barStyle.includes('width: 5%'));
+    await conceptPage.clickOnContinueButton();
+    await conceptPage.questionCards[0].clickOnShowExplanationButton();
+    assert.ok(conceptPage.progress.text.includes('10%'));
+    assert.ok(conceptPage.progress.barStyle.includes('width: 10%'));
+
+    await conceptPage.clickOnStepBackButton();
+    assert.ok(conceptPage.progress.text.includes('5%'));
+    assert.ok(conceptPage.progress.barStyle.includes('width: 5%'));
 
-  //   await conceptsPage.visit();
-  //   assert.ok(conceptsPage.conceptCards[1].progressText.includes('5% complete'), 'Progress text should reflect tracked progress in concept card');
+    await conceptsPage.visit();
+    assert.ok(conceptsPage.conceptCards[1].progressText.includes('5% complete'), 'Progress text should reflect tracked progress in concept card');
 
-  //   await conceptsPage.conceptCards[1].hover();
-  //   assert.strictEqual(
-  //     conceptsPage.conceptCards[1].actionText,
-  //     'Resume',
-  //     'Concept card action text should be resume for concept that is in progress',
-  //   );
-  // });
+    await conceptsPage.conceptCards[1].hover();
+    assert.strictEqual(
+      conceptsPage.conceptCards[1].actionText,
+      'Resume',
+      'Concept card action text should be resume for concept that is in progress',
+    );
+  });
 
-  // test('tracked progress is rendered properly on page visit', async function (assert) {
-  //   testScenario(this.server);
-  //   createConcepts(this.server);
-
-  //   const user = this.server.schema.users.first();
-  //   const networkProtocolsConcept = this.server.schema.concepts.findBy({ slug: 'network-protocols' });
-
-  //   this.server.create('concept-engagement', {
-  //     concept: networkProtocolsConcept,
-  //     user,
-  //     currentProgressPercentage: 5,
-  //     lastActivityAt: new Date(),
-  //     startedAt: new Date(),
-  //   });
-
-  //   signIn(this.owner, this.server, user);
-
-  //   await conceptsPage.visit();
-  //   assert.ok(conceptsPage.conceptCards[0].progressText.includes('5% complete'), 'Progress should be tracked');
-
-  //   await conceptsPage.conceptCards[0].hover();
-  //   assert.strictEqual(
-  //     conceptsPage.conceptCards[0].actionText,
-  //     'Resume',
-  //     'Concept card action text should be resume for concept that is in progress',
-  //   );
-
-  //   await conceptsPage.clickOnConceptCard('Network Protocols');
-  //   assert.strictEqual(conceptPage.blocks.length, 2, 'Completed blocks are automatically shown');
-  //   assert.ok(conceptPage.progress.isPresent, 'Progress bar should be present');
-  //   assert.ok(conceptPage.progress.text.includes('5%'), 'Progress text should reflect tracked progress in concept page');
-  //   assert.ok(conceptPage.progress.barStyle.includes('width: 5%'), 'Progress bar should reflect tracked progress in concept page');
-  //   assert.ok(conceptPage.progress.text.includes('39 blocks left'), 'Remaining blocks left should be reflected properly');
-  // });
-
-  // test('progress for completed concepts is rendered properly', async function (assert) {
-  //   testScenario(this.server);
-  //   createConcepts(this.server);
-
-  //   const user = this.server.schema.users.first();
-  //   const networkProtocolsConcept = this.server.schema.concepts.findBy({ slug: 'network-protocols' });
-
-  //   this.server.create('concept-engagement', {
-  //     concept: networkProtocolsConcept,
-  //     user,
-  //     currentProgressPercentage: 100,
-  //     lastActivityAt: new Date(),
-  //     startedAt: new Date(),
-  //   });
-
-  //   signIn(this.owner, this.server, user);
-
-  //   await conceptsPage.visit();
-  //   assert.notOk(conceptsPage.conceptCards[0].hasProgressBar, 'Concept card should not show progress');
-
-  //   assert.ok(
-  //     conceptsPage.conceptCards[0].text.includes('completed'),
-  //     'Concept card should show completed instead of progress percentage on completion',
-  //   );
-
-  //   await conceptsPage.conceptCards[0].hover();
-  //   assert.strictEqual(conceptsPage.conceptCards[0].actionText, 'View', 'Concept card action text should be view for completed concept');
-  // });
-
-  // test('remaining blocks left is rendered properly', async function (assert) {
-  //   testScenario(this.server);
-  //   createConcepts(this.server);
-
-  //   const user = this.server.schema.users.first();
-  //   signIn(this.owner, this.server, user);
-
-  //   await conceptsPage.visit();
-  //   await conceptsPage.clickOnConceptCard('Network Protocols');
-  //   assert.notOk(conceptPage.progress.isPresent, 'Remaining blocks left should not be shown if no progress is made');
-
-  //   await conceptPage.clickOnContinueButton();
-  //   assert.contains(conceptPage.progress.text, '39 blocks left');
-
-  //   await conceptPage.clickOnContinueButton();
-  //   assert.contains(conceptPage.progress.text, '37 blocks left');
-  // });
-
-  // test('remaining blocks left is not present if user completed concept', async function (assert) {
-  //   testScenario(this.server);
-  //   createConcepts(this.server);
-
-  //   signInAsStaff(this.owner, this.server);
-
-  //   this.server.schema.conceptGroups.create({
-  //     conceptSlugs: ['network-protocols', 'tcp-overview'],
-  //     descriptionMarkdown: 'This is a group about network concepts',
-  //     slug: 'network-primer',
-  //     title: 'Network Primer',
-  //   });
-
-  //   await conceptsPage.visit();
-
-  //   await conceptsPage.clickOnConceptCard('Network Protocols');
-  //   await conceptPage.clickOnContinueButton();
-  //   await conceptPage.clickOnContinueButton();
-  //   await conceptPage.questionCards[0].clickOnShowExplanationButton();
-  //   await conceptPage.clickOnContinueButton();
-  //   await conceptPage.clickOnContinueButton();
-  //   await conceptPage.clickOnContinueButton();
-  //   await conceptPage.questionCards[1].clickOnShowExplanationButton();
-  //   await conceptPage.clickOnContinueButton();
-  //   await conceptPage.clickOnContinueButton();
-  //   await conceptPage.clickOnContinueButton();
-  //   await conceptPage.questionCards[2].clickOnShowExplanationButton();
-  //   await conceptPage.clickOnContinueButton();
-  //   await conceptPage.clickOnContinueButton();
-  //   await conceptPage.clickOnContinueButton();
-  //   await conceptPage.clickOnContinueButton();
-  //   await conceptPage.clickOnContinueButton();
-  //   await conceptPage.clickOnContinueButton();
-  //   await conceptPage.questionCards[3].clickOnShowExplanationButton();
-  //   await conceptPage.clickOnContinueButton();
-  //   await conceptPage.clickOnContinueButton();
-  //   await conceptPage.clickOnContinueButton();
-  //   await conceptPage.clickOnContinueButton();
-  //   await conceptPage.clickOnContinueButton();
-
-  //   assert.notOk(conceptPage.progress.text.includes('blocks left'), 'Remaining blocks left should not be present');
-  // });
-
-  // test('can select an option for a question using 1/2/3/4', async function (assert) {
-  //   testScenario(this.server);
-  //   createConcepts(this.server);
-
-  //   signInAsStaff(this.owner, this.server);
-
-  //   this.server.schema.conceptGroups.create({
-  //     conceptSlugs: ['network-protocols', 'tcp-overview'],
-  //     descriptionMarkdown: 'This is a group about network concepts',
-  //     slug: 'network-primer',
-  //     title: 'Network Primer',
-  //   });
-
-  //   await conceptsPage.visit();
-
-  //   await conceptsPage.clickOnConceptCard('Network Protocols');
-  //   await conceptPage.clickOnContinueButton();
-  //   await conceptPage.clickOnContinueButton();
-
-  //   assert.false(conceptPage.questionCards[0].hasSubmitted, 'the question has not been submitted yet');
-
-  //   await conceptPage.questionCards[0].keydown({ key: '1' });
-
-  //   assert.true(conceptPage.questionCards[0].hasSubmitted, 'the question has been submitted');
-  // });
-
-  // test('can select an option for a question using a/b/c/d', async function (assert) {
-  //   testScenario(this.server);
-  //   createConcepts(this.server);
-
-  //   signInAsStaff(this.owner, this.server);
-
-  //   this.server.schema.conceptGroups.create({
-  //     conceptSlugs: ['network-protocols', 'tcp-overview'],
-  //     descriptionMarkdown: 'This is a group about network concepts',
-  //     slug: 'network-primer',
-  //     title: 'Network Primer',
-  //   });
+  test('tracked progress is rendered properly on page visit', async function (assert) {
+    testScenario(this.server);
+    createConcepts(this.server);
+
+    const user = this.server.schema.users.first();
+    const networkProtocolsConcept = this.server.schema.concepts.findBy({ slug: 'network-protocols' });
+
+    this.server.create('concept-engagement', {
+      concept: networkProtocolsConcept,
+      user,
+      currentProgressPercentage: 5,
+      lastActivityAt: new Date(),
+      startedAt: new Date(),
+    });
+
+    signIn(this.owner, this.server, user);
+
+    await conceptsPage.visit();
+    assert.ok(conceptsPage.conceptCards[0].progressText.includes('5% complete'), 'Progress should be tracked');
+
+    await conceptsPage.conceptCards[0].hover();
+    assert.strictEqual(
+      conceptsPage.conceptCards[0].actionText,
+      'Resume',
+      'Concept card action text should be resume for concept that is in progress',
+    );
+
+    await conceptsPage.clickOnConceptCard('Network Protocols');
+    assert.strictEqual(conceptPage.blocks.length, 2, 'Completed blocks are automatically shown');
+    assert.ok(conceptPage.progress.isPresent, 'Progress bar should be present');
+    assert.ok(conceptPage.progress.text.includes('5%'), 'Progress text should reflect tracked progress in concept page');
+    assert.ok(conceptPage.progress.barStyle.includes('width: 5%'), 'Progress bar should reflect tracked progress in concept page');
+    assert.ok(conceptPage.progress.text.includes('39 blocks left'), 'Remaining blocks left should be reflected properly');
+  });
+
+  test('progress for completed concepts is rendered properly', async function (assert) {
+    testScenario(this.server);
+    createConcepts(this.server);
+
+    const user = this.server.schema.users.first();
+    const networkProtocolsConcept = this.server.schema.concepts.findBy({ slug: 'network-protocols' });
+
+    this.server.create('concept-engagement', {
+      concept: networkProtocolsConcept,
+      user,
+      currentProgressPercentage: 100,
+      lastActivityAt: new Date(),
+      startedAt: new Date(),
+    });
+
+    signIn(this.owner, this.server, user);
+
+    await conceptsPage.visit();
+    assert.notOk(conceptsPage.conceptCards[0].hasProgressBar, 'Concept card should not show progress');
+
+    assert.ok(
+      conceptsPage.conceptCards[0].text.includes('completed'),
+      'Concept card should show completed instead of progress percentage on completion',
+    );
+
+    await conceptsPage.conceptCards[0].hover();
+    assert.strictEqual(conceptsPage.conceptCards[0].actionText, 'View', 'Concept card action text should be view for completed concept');
+  });
+
+  test('remaining blocks left is rendered properly', async function (assert) {
+    testScenario(this.server);
+    createConcepts(this.server);
+
+    const user = this.server.schema.users.first();
+    signIn(this.owner, this.server, user);
+
+    await conceptsPage.visit();
+    await conceptsPage.clickOnConceptCard('Network Protocols');
+    assert.notOk(conceptPage.progress.isPresent, 'Remaining blocks left should not be shown if no progress is made');
+
+    await conceptPage.clickOnContinueButton();
+    assert.contains(conceptPage.progress.text, '39 blocks left');
+
+    await conceptPage.clickOnContinueButton();
+    assert.contains(conceptPage.progress.text, '37 blocks left');
+  });
+
+  test('remaining blocks left is not present if user completed concept', async function (assert) {
+    testScenario(this.server);
+    createConcepts(this.server);
+
+    signInAsStaff(this.owner, this.server);
+
+    this.server.schema.conceptGroups.create({
+      conceptSlugs: ['network-protocols', 'tcp-overview'],
+      descriptionMarkdown: 'This is a group about network concepts',
+      slug: 'network-primer',
+      title: 'Network Primer',
+    });
+
+    await conceptsPage.visit();
+
+    await conceptsPage.clickOnConceptCard('Network Protocols');
+    await conceptPage.clickOnContinueButton();
+    await conceptPage.clickOnContinueButton();
+    await conceptPage.questionCards[0].clickOnShowExplanationButton();
+    await conceptPage.clickOnContinueButton();
+    await conceptPage.clickOnContinueButton();
+    await conceptPage.clickOnContinueButton();
+    await conceptPage.questionCards[1].clickOnShowExplanationButton();
+    await conceptPage.clickOnContinueButton();
+    await conceptPage.clickOnContinueButton();
+    await conceptPage.clickOnContinueButton();
+    await conceptPage.questionCards[2].clickOnShowExplanationButton();
+    await conceptPage.clickOnContinueButton();
+    await conceptPage.clickOnContinueButton();
+    await conceptPage.clickOnContinueButton();
+    await conceptPage.clickOnContinueButton();
+    await conceptPage.clickOnContinueButton();
+    await conceptPage.clickOnContinueButton();
+    await conceptPage.questionCards[3].clickOnShowExplanationButton();
+    await conceptPage.clickOnContinueButton();
+    await conceptPage.clickOnContinueButton();
+    await conceptPage.clickOnContinueButton();
+    await conceptPage.clickOnContinueButton();
+    await conceptPage.clickOnContinueButton();
+
+    assert.notOk(conceptPage.progress.text.includes('blocks left'), 'Remaining blocks left should not be present');
+  });
+
+  test('can select an option for a question using 1/2/3/4', async function (assert) {
+    testScenario(this.server);
+    createConcepts(this.server);
+
+    signInAsStaff(this.owner, this.server);
+
+    this.server.schema.conceptGroups.create({
+      conceptSlugs: ['network-protocols', 'tcp-overview'],
+      descriptionMarkdown: 'This is a group about network concepts',
+      slug: 'network-primer',
+      title: 'Network Primer',
+    });
+
+    await conceptsPage.visit();
+
+    await conceptsPage.clickOnConceptCard('Network Protocols');
+    await conceptPage.clickOnContinueButton();
+    await conceptPage.clickOnContinueButton();
+
+    assert.false(conceptPage.questionCards[0].hasSubmitted, 'the question has not been submitted yet');
+
+    await conceptPage.questionCards[0].keydown({ key: '1' });
+
+    assert.true(conceptPage.questionCards[0].hasSubmitted, 'the question has been submitted');
+  });
+
+  test('can select an option for a question using a/b/c/d', async function (assert) {
+    testScenario(this.server);
+    createConcepts(this.server);
+
+    signInAsStaff(this.owner, this.server);
+
+    this.server.schema.conceptGroups.create({
+      conceptSlugs: ['network-protocols', 'tcp-overview'],
+      descriptionMarkdown: 'This is a group about network concepts',
+      slug: 'network-primer',
+      title: 'Network Primer',
+    });
 
-  //   await conceptsPage.visit();
+    await conceptsPage.visit();
 
-  //   await conceptsPage.clickOnConceptCard('Network Protocols');
-  //   await conceptPage.clickOnContinueButton();
-  //   await conceptPage.clickOnContinueButton();
+    await conceptsPage.clickOnConceptCard('Network Protocols');
+    await conceptPage.clickOnContinueButton();
+    await conceptPage.clickOnContinueButton();
 
-  //   assert.false(conceptPage.questionCards[0].hasSubmitted, 'the question has not been submitted yet');
+    assert.false(conceptPage.questionCards[0].hasSubmitted, 'the question has not been submitted yet');
 
-  //   await conceptPage.questionCards[0].keydown({ keyCode: 65 });
+    await conceptPage.questionCards[0].keydown({ keyCode: 65 });
 
-  //   assert.true(conceptPage.questionCards[0].hasSubmitted, 'the question has been submitted');
-  // });
+    assert.true(conceptPage.questionCards[0].hasSubmitted, 'the question has been submitted');
+  });
 
-  // test('can navigate using j/k and select option using enter', async function (assert) {
-  //   testScenario(this.server);
-  //   createConcepts(this.server);
+  test('can navigate using j/k and select option using enter', async function (assert) {
+    testScenario(this.server);
+    createConcepts(this.server);
 
-  //   signInAsStaff(this.owner, this.server);
+    signInAsStaff(this.owner, this.server);
 
-  //   await conceptsPage.visit();
+    await conceptsPage.visit();
 
-  //   await conceptsPage.clickOnConceptCard('Network Protocols');
-  //   await conceptPage.clickOnContinueButton();
-  //   await conceptPage.clickOnContinueButton();
+    await conceptsPage.clickOnConceptCard('Network Protocols');
+    await conceptPage.clickOnContinueButton();
+    await conceptPage.clickOnContinueButton();
 
-  //   assert.false(conceptPage.questionCards[0].hasSubmitted, 'the question has not been submitted yet');
+    assert.false(conceptPage.questionCards[0].hasSubmitted, 'the question has not been submitted yet');
 
-  //   // Should be able to move back and fort
-  //   assert.strictEqual(conceptPage.questionCards[0].focusedOption.text, 'SMTP');
-  //   await conceptPage.questionCards[0].keydown({ keyCode: 74 }); // Send j key
-  //   assert.strictEqual(conceptPage.questionCards[0].focusedOption.text, 'HTTP');
-  //   await conceptPage.questionCards[0].keydown({ keyCode: 75 }); // Send k key
-  //   assert.strictEqual(conceptPage.questionCards[0].focusedOption.text, 'SMTP');
+    // Should be able to move back and fort
+    assert.strictEqual(conceptPage.questionCards[0].focusedOption.text, 'SMTP');
+    await conceptPage.questionCards[0].keydown({ keyCode: 74 }); // Send j key
+    assert.strictEqual(conceptPage.questionCards[0].focusedOption.text, 'HTTP');
+    await conceptPage.questionCards[0].keydown({ keyCode: 75 }); // Send k key
+    assert.strictEqual(conceptPage.questionCards[0].focusedOption.text, 'SMTP');
 
-  //   // Can move to end of list
-  //   await conceptPage.questionCards[0].keydown({ keyCode: 74 }); // Send j key
-  //   await conceptPage.questionCards[0].keydown({ keyCode: 74 }); // Send j key
-  //   await conceptPage.questionCards[0].keydown({ keyCode: 74 }); // Send j key
-  //   assert.strictEqual(conceptPage.questionCards[0].focusedOption.text, 'PDF');
+    // Can move to end of list
+    await conceptPage.questionCards[0].keydown({ keyCode: 74 }); // Send j key
+    await conceptPage.questionCards[0].keydown({ keyCode: 74 }); // Send j key
+    await conceptPage.questionCards[0].keydown({ keyCode: 74 }); // Send j key
+    assert.strictEqual(conceptPage.questionCards[0].focusedOption.text, 'PDF');
 
-  //   // Can wrap around to start of list
-  //   await conceptPage.questionCards[0].keydown({ keyCode: 74 }); // Send j key
-  //   assert.strictEqual(conceptPage.questionCards[0].focusedOption.text, 'SMTP');
-
-  //   await conceptPage.questionCards[0].focusedOption.click(); // Simulate ENTER on focused option
-  //   assert.true(conceptPage.questionCards[0].hasSubmitted, 'the question has been submitted');
-  // });
-
-  // test('can navigate using arrow keys and select option using enter', async function (assert) {
-  //   testScenario(this.server);
-  //   createConcepts(this.server);
-
-  //   signInAsStaff(this.owner, this.server);
-
-  //   await conceptsPage.visit();
-
-  //   await conceptsPage.clickOnConceptCard('Network Protocols');
-  //   await conceptPage.clickOnContinueButton();
-  //   await conceptPage.clickOnContinueButton();
-
-  //   assert.false(conceptPage.questionCards[0].hasSubmitted, 'the question has not been submitted yet');
-
-  //   // Should be able to move back and fort
-  //   assert.strictEqual(conceptPage.questionCards[0].focusedOption.text, 'SMTP');
-  //   await conceptPage.questionCards[0].keydown({ key: 'ArrowDown' }); // Send down arrow key
-  //   assert.strictEqual(conceptPage.questionCards[0].focusedOption.text, 'HTTP');
-  //   await conceptPage.questionCards[0].keydown({ key: 'ArrowUp' }); // Send up arrow key
-  //   assert.strictEqual(conceptPage.questionCards[0].focusedOption.text, 'SMTP');
-
-  //   // Can move to end of list
-  //   await conceptPage.questionCards[0].keydown({ key: 'ArrowDown' }); // Send down arrow key
-  //   await conceptPage.questionCards[0].keydown({ key: 'ArrowDown' }); // Send down arrow key
-  //   await conceptPage.questionCards[0].keydown({ key: 'ArrowDown' }); // Send down arrow key
-  //   assert.strictEqual(conceptPage.questionCards[0].focusedOption.text, 'PDF');
-
-  //   // Can wrap around to start of list
-  //   await conceptPage.questionCards[0].keydown({ key: 'ArrowDown' }); // Send down arrow key
-  //   assert.strictEqual(conceptPage.questionCards[0].focusedOption.text, 'SMTP');
-
-  //   await conceptPage.questionCards[0].focusedOption.click(); // Simulate ENTER on focused option
-  //   assert.true(conceptPage.questionCards[0].hasSubmitted, 'the question has been submitted');
-  // });
-
-  // test('navigating question options using arrow keys does not trigger scrolling', async function (assert) {
-  //   testScenario(this.server);
-  //   createConcepts(this.server);
-
-  //   signInAsStaff(this.owner, this.server);
-
-  //   await conceptsPage.visit();
-
-  //   await conceptsPage.clickOnConceptCard('Network Protocols');
-  //   await conceptPage.clickOnContinueButton();
-  //   await conceptPage.clickOnContinueButton();
-
-  //   const currentScrollY = window.scrollY;
-
-  //   await conceptPage.questionCards[0].keydown({ key: 'ArrowDown' }); // Send down arrow key
-  //   await conceptPage.questionCards[0].keydown({ key: 'ArrowDown' }); // Send down arrow key
-  //   await conceptPage.questionCards[0].keydown({ key: 'ArrowDown' }); // Send down arrow key
-
-  //   assert.strictEqual(window.scrollY, currentScrollY, 'scrolling should not be triggered');
-  // });
-
-  // test('navigating options wraps around the list for the current question card only', async function (assert) {
-  //   testScenario(this.server);
-  //   createConcepts(this.server);
-
-  //   signInAsStaff(this.owner, this.server);
-
-  //   await conceptsPage.visit();
-
-  //   await conceptsPage.clickOnConceptCard('Network Protocols');
-  //   await conceptPage.clickOnContinueButton();
-  //   await conceptPage.clickOnContinueButton();
-  //   await conceptPage.questionCards[0].clickOnShowExplanationButton();
-  //   await conceptPage.clickOnContinueButton();
-  //   await conceptPage.clickOnContinueButton();
-  //   await conceptPage.clickOnContinueButton();
-
-  //   assert.strictEqual(conceptPage.questionCards[1].focusedOption.text, '1 layer');
-
-  //   await conceptPage.questionCards[0].keydown({ key: 'ArrowDown' }); // Send down arrow key
-  //   await conceptPage.questionCards[0].keydown({ key: 'ArrowDown' }); // Send down arrow key
-  //   await conceptPage.questionCards[0].keydown({ key: 'ArrowDown' }); // Send down arrow key
-  //   await conceptPage.questionCards[0].keydown({ key: 'ArrowDown' }); // Send down arrow key
-
-  //   assert.strictEqual(conceptPage.questionCards[1].focusedOption.text, '1 layer');
-  // });
-
-  // test('only published concepts are visible to users', async function (assert) {
-  //   testScenario(this.server);
-  //   createConcepts(this.server);
-
-  //   this.server.create('concept', {
-  //     slug: 'new-concept',
-  //     title: 'New Concept',
-  //     'description-markdown': 'This is a new concept.',
-  //     blocks: [
-  //       {
-  //         type: 'markdown',
-  //         args: {
-  //           markdown: `This is the first markdown block.`,
-  //         },
-  //       },
-  //     ],
-  //     status: 'draft',
-  //   });
-
-  //   signInAsSubscriber(this.owner, this.server);
-
-  //   await conceptsPage.visit();
-  //   assert.strictEqual(conceptsPage.conceptCards.length, 3, 'Only published concepts are visible to users');
-  //   assert.notOk(conceptsPage.conceptCards.map((card) => card.title).includes('New Concept'), 'Draft concepts are not visible to users');
-  // });
-
-  // test('draft concepts are visible to staff', async function (assert) {
-  //   testScenario(this.server);
-  //   createConcepts(this.server);
-
-  //   this.server.create('concept', {
-  //     slug: 'new-concept',
-  //     title: 'New Concept',
-  //     'description-markdown': 'This is a new concept.',
-  //     blocks: [
-  //       {
-  //         type: 'markdown',
-  //         args: {
-  //           markdown: `This is the first markdown block.`,
-  //         },
-  //       },
-  //     ],
-  //     status: 'draft',
-  //   });
-
-  //   signInAsStaff(this.owner, this.server);
-
-  //   await conceptsPage.visit();
-
-  //   assert.strictEqual(conceptsPage.conceptCards.length, 4, 'Draft concepts are visible to staff');
-  //   assert.strictEqual(conceptsPage.conceptCards[3].title, 'New Concept', 'Draft concepts are visible to staff');
-  //   assert.ok(conceptsPage.conceptCards[3].draftLabel.isVisible, 'Draft label is visible for draft concepts');
-
-  //   await conceptsPage.conceptCards[3].draftLabel.hover();
-
-  //   assertTooltipContent(assert, {
-  //     contentString: 'This concept is only visible to staff',
-  //   });
-  // });
-
-  // test('draft concepts are visible to concept author', async function (assert) {
-  //   testScenario(this.server);
-  //   createConcepts(this.server);
-
-  //   const user = this.server.create('user', {
-  //     id: 'user1',
-  //     avatarUrl: 'https://github.com/Gufran.png',
-  //     createdAt: new Date(),
-  //     githubUsername: 'Gufran',
-  //     username: 'Gufran',
-  //   });
-
-  //   this.server.create('concept', {
-  //     slug: 'new-concept',
-  //     title: 'New Concept',
-  //     'description-markdown': 'This is a new concept.',
-  //     blocks: [
-  //       {
-  //         type: 'markdown',
-  //         args: {
-  //           markdown: `This is the first markdown block.`,
-  //         },
-  //       },
-  //     ],
-  //     status: 'draft',
-  //     author: user,
-  //   });
-
-  //   signIn(this.owner, this.server, user);
-
-  //   await conceptsPage.visit();
-
-  //   assert.strictEqual(conceptsPage.conceptCards.length, 4, 'Draft concepts are visible to concept author');
-  //   assert.strictEqual(conceptsPage.conceptCards[3].title, 'New Concept', 'Draft concepts are visible to concept author');
-  //   assert.ok(conceptsPage.conceptCards[3].draftLabel.isVisible, 'Draft label is visible for draft concepts');
-  // });
+    // Can wrap around to start of list
+    await conceptPage.questionCards[0].keydown({ keyCode: 74 }); // Send j key
+    assert.strictEqual(conceptPage.questionCards[0].focusedOption.text, 'SMTP');
+
+    await conceptPage.questionCards[0].focusedOption.click(); // Simulate ENTER on focused option
+    assert.true(conceptPage.questionCards[0].hasSubmitted, 'the question has been submitted');
+  });
+
+  test('can navigate using arrow keys and select option using enter', async function (assert) {
+    testScenario(this.server);
+    createConcepts(this.server);
+
+    signInAsStaff(this.owner, this.server);
+
+    await conceptsPage.visit();
+
+    await conceptsPage.clickOnConceptCard('Network Protocols');
+    await conceptPage.clickOnContinueButton();
+    await conceptPage.clickOnContinueButton();
+
+    assert.false(conceptPage.questionCards[0].hasSubmitted, 'the question has not been submitted yet');
+
+    // Should be able to move back and fort
+    assert.strictEqual(conceptPage.questionCards[0].focusedOption.text, 'SMTP');
+    await conceptPage.questionCards[0].keydown({ key: 'ArrowDown' }); // Send down arrow key
+    assert.strictEqual(conceptPage.questionCards[0].focusedOption.text, 'HTTP');
+    await conceptPage.questionCards[0].keydown({ key: 'ArrowUp' }); // Send up arrow key
+    assert.strictEqual(conceptPage.questionCards[0].focusedOption.text, 'SMTP');
+
+    // Can move to end of list
+    await conceptPage.questionCards[0].keydown({ key: 'ArrowDown' }); // Send down arrow key
+    await conceptPage.questionCards[0].keydown({ key: 'ArrowDown' }); // Send down arrow key
+    await conceptPage.questionCards[0].keydown({ key: 'ArrowDown' }); // Send down arrow key
+    assert.strictEqual(conceptPage.questionCards[0].focusedOption.text, 'PDF');
+
+    // Can wrap around to start of list
+    await conceptPage.questionCards[0].keydown({ key: 'ArrowDown' }); // Send down arrow key
+    assert.strictEqual(conceptPage.questionCards[0].focusedOption.text, 'SMTP');
+
+    await conceptPage.questionCards[0].focusedOption.click(); // Simulate ENTER on focused option
+    assert.true(conceptPage.questionCards[0].hasSubmitted, 'the question has been submitted');
+  });
+
+  test('navigating question options using arrow keys does not trigger scrolling', async function (assert) {
+    testScenario(this.server);
+    createConcepts(this.server);
+
+    signInAsStaff(this.owner, this.server);
+
+    await conceptsPage.visit();
+
+    await conceptsPage.clickOnConceptCard('Network Protocols');
+    await conceptPage.clickOnContinueButton();
+    await conceptPage.clickOnContinueButton();
+
+    const currentScrollY = window.scrollY;
+
+    await conceptPage.questionCards[0].keydown({ key: 'ArrowDown' }); // Send down arrow key
+    await conceptPage.questionCards[0].keydown({ key: 'ArrowDown' }); // Send down arrow key
+    await conceptPage.questionCards[0].keydown({ key: 'ArrowDown' }); // Send down arrow key
+
+    assert.strictEqual(window.scrollY, currentScrollY, 'scrolling should not be triggered');
+  });
+
+  test('navigating options wraps around the list for the current question card only', async function (assert) {
+    testScenario(this.server);
+    createConcepts(this.server);
+
+    signInAsStaff(this.owner, this.server);
+
+    await conceptsPage.visit();
+
+    await conceptsPage.clickOnConceptCard('Network Protocols');
+    await conceptPage.clickOnContinueButton();
+    await conceptPage.clickOnContinueButton();
+    await conceptPage.questionCards[0].clickOnShowExplanationButton();
+    await conceptPage.clickOnContinueButton();
+    await conceptPage.clickOnContinueButton();
+    await conceptPage.clickOnContinueButton();
+
+    assert.strictEqual(conceptPage.questionCards[1].focusedOption.text, '1 layer');
+
+    await conceptPage.questionCards[0].keydown({ key: 'ArrowDown' }); // Send down arrow key
+    await conceptPage.questionCards[0].keydown({ key: 'ArrowDown' }); // Send down arrow key
+    await conceptPage.questionCards[0].keydown({ key: 'ArrowDown' }); // Send down arrow key
+    await conceptPage.questionCards[0].keydown({ key: 'ArrowDown' }); // Send down arrow key
+
+    assert.strictEqual(conceptPage.questionCards[1].focusedOption.text, '1 layer');
+  });
+
+  test('only published concepts are visible to users', async function (assert) {
+    testScenario(this.server);
+    createConcepts(this.server);
+
+    this.server.create('concept', {
+      slug: 'new-concept',
+      title: 'New Concept',
+      'description-markdown': 'This is a new concept.',
+      blocks: [
+        {
+          type: 'markdown',
+          args: {
+            markdown: `This is the first markdown block.`,
+          },
+        },
+      ],
+      status: 'draft',
+    });
+
+    signInAsSubscriber(this.owner, this.server);
+
+    await conceptsPage.visit();
+    assert.strictEqual(conceptsPage.conceptCards.length, 3, 'Only published concepts are visible to users');
+    assert.notOk(conceptsPage.conceptCards.map((card) => card.title).includes('New Concept'), 'Draft concepts are not visible to users');
+  });
+
+  test('draft concepts are visible to staff', async function (assert) {
+    testScenario(this.server);
+    createConcepts(this.server);
+
+    this.server.create('concept', {
+      slug: 'new-concept',
+      title: 'New Concept',
+      'description-markdown': 'This is a new concept.',
+      blocks: [
+        {
+          type: 'markdown',
+          args: {
+            markdown: `This is the first markdown block.`,
+          },
+        },
+      ],
+      status: 'draft',
+    });
+
+    signInAsStaff(this.owner, this.server);
+
+    await conceptsPage.visit();
+
+    assert.strictEqual(conceptsPage.conceptCards.length, 4, 'Draft concepts are visible to staff');
+    assert.strictEqual(conceptsPage.conceptCards[3].title, 'New Concept', 'Draft concepts are visible to staff');
+    assert.ok(conceptsPage.conceptCards[3].draftLabel.isVisible, 'Draft label is visible for draft concepts');
+
+    await conceptsPage.conceptCards[3].draftLabel.hover();
+
+    assertTooltipContent(assert, {
+      contentString: 'This concept is only visible to staff',
+    });
+  });
+
+  test('draft concepts are visible to concept author', async function (assert) {
+    testScenario(this.server);
+    createConcepts(this.server);
+
+    const user = this.server.create('user', {
+      id: 'user1',
+      avatarUrl: 'https://github.com/Gufran.png',
+      createdAt: new Date(),
+      githubUsername: 'Gufran',
+      username: 'Gufran',
+    });
+
+    this.server.create('concept', {
+      slug: 'new-concept',
+      title: 'New Concept',
+      'description-markdown': 'This is a new concept.',
+      blocks: [
+        {
+          type: 'markdown',
+          args: {
+            markdown: `This is the first markdown block.`,
+          },
+        },
+      ],
+      status: 'draft',
+      author: user,
+    });
+
+    signIn(this.owner, this.server, user);
+
+    await conceptsPage.visit();
+
+    assert.strictEqual(conceptsPage.conceptCards.length, 4, 'Draft concepts are visible to concept author');
+    assert.strictEqual(conceptsPage.conceptCards[3].title, 'New Concept', 'Draft concepts are visible to concept author');
+    assert.ok(conceptsPage.conceptCards[3].draftLabel.isVisible, 'Draft label is visible for draft concepts');
+  });
 });

--- a/tests/acceptance/concepts-test.js
+++ b/tests/acceptance/concepts-test.js
@@ -12,7 +12,9 @@ import { module, test } from 'qunit';
 import { setupApplicationTest } from 'codecrafters-frontend/tests/helpers';
 import { setupWindowMock } from 'ember-window-mock/test-support';
 import { signIn, signInAsStaff, signInAsSubscriber } from 'codecrafters-frontend/tests/support/authentication-helpers';
-import { setupAnimationTest } from 'ember-animated/test-support';
+import { animationsSettled, setupAnimationTest } from 'ember-animated/test-support';
+import windowMock from 'ember-window-mock';
+import config from 'codecrafters-frontend/config/environment';
 
 function createConcepts(server) {
   createConceptFromFixture(server, tcpOverview);
@@ -25,65 +27,65 @@ module('Acceptance | concepts-test', function (hooks) {
   setupAnimationTest(hooks);
   setupWindowMock(hooks);
 
-  test('can create concept', async function (assert) {
-    testScenario(this.server);
+  // test('can create concept', async function (assert) {
+  //   testScenario(this.server);
 
-    signInAsStaff(this.owner, this.server);
+  //   signInAsStaff(this.owner, this.server);
 
-    await conceptsPage.visit();
-    await conceptsPage.clickOnCreateConceptButton();
+  //   await conceptsPage.visit();
+  //   await conceptsPage.clickOnCreateConceptButton();
 
-    assert.strictEqual(currentURL(), '/concepts/new-concept/admin/basic-details');
-  });
+  //   assert.strictEqual(currentURL(), '/concepts/new-concept/admin/basic-details');
+  // });
 
-  test('can view concepts', async function (assert) {
-    testScenario(this.server);
-    createConcepts(this.server);
+  // test('can view concepts', async function (assert) {
+  //   testScenario(this.server);
+  //   createConcepts(this.server);
 
-    signInAsStaff(this.owner, this.server);
+  //   signInAsStaff(this.owner, this.server);
 
-    this.server.schema.conceptGroups.create({
-      conceptSlugs: ['network-protocols', 'tcp-overview'],
-      descriptionMarkdown: 'This is a group about network concepts',
-      slug: 'network-primer',
-      title: 'Network Primer',
-    });
+  //   this.server.schema.conceptGroups.create({
+  //     conceptSlugs: ['network-protocols', 'tcp-overview'],
+  //     descriptionMarkdown: 'This is a group about network concepts',
+  //     slug: 'network-primer',
+  //     title: 'Network Primer',
+  //   });
 
-    await conceptsPage.visit();
+  //   await conceptsPage.visit();
 
-    await percySnapshot('Concept - Start');
+  //   await percySnapshot('Concept - Start');
 
-    await conceptsPage.clickOnConceptCard('Network Protocols');
-    await conceptPage.clickOnContinueButton();
-    await conceptPage.clickOnContinueButton();
-    await conceptPage.questionCards[0].selectOption('PDF');
-    await conceptPage.clickOnContinueButton();
-    await conceptPage.clickOnContinueButton();
-    await conceptPage.clickOnContinueButton();
-    await conceptPage.questionCards[1].clickOnShowExplanationButton();
-    await conceptPage.clickOnContinueButton();
-    await conceptPage.clickOnContinueButton();
-    await conceptPage.clickOnContinueButton();
-    await conceptPage.questionCards[2].clickOnShowExplanationButton();
-    await conceptPage.clickOnContinueButton();
-    await conceptPage.clickOnContinueButton();
-    await conceptPage.clickOnContinueButton();
-    await conceptPage.clickOnContinueButton();
-    await conceptPage.clickOnContinueButton();
-    await conceptPage.clickOnContinueButton();
-    await conceptPage.questionCards[3].clickOnShowExplanationButton();
-    await conceptPage.clickOnContinueButton();
-    await conceptPage.clickOnContinueButton();
-    await conceptPage.clickOnContinueButton();
-    await conceptPage.clickOnContinueButton();
-    await conceptPage.clickOnContinueButton();
+  //   await conceptsPage.clickOnConceptCard('Network Protocols');
+  //   await conceptPage.clickOnContinueButton();
+  //   await conceptPage.clickOnContinueButton();
+  //   await conceptPage.questionCards[0].selectOption('PDF');
+  //   await conceptPage.clickOnContinueButton();
+  //   await conceptPage.clickOnContinueButton();
+  //   await conceptPage.clickOnContinueButton();
+  //   await conceptPage.questionCards[1].clickOnShowExplanationButton();
+  //   await conceptPage.clickOnContinueButton();
+  //   await conceptPage.clickOnContinueButton();
+  //   await conceptPage.clickOnContinueButton();
+  //   await conceptPage.questionCards[2].clickOnShowExplanationButton();
+  //   await conceptPage.clickOnContinueButton();
+  //   await conceptPage.clickOnContinueButton();
+  //   await conceptPage.clickOnContinueButton();
+  //   await conceptPage.clickOnContinueButton();
+  //   await conceptPage.clickOnContinueButton();
+  //   await conceptPage.clickOnContinueButton();
+  //   await conceptPage.questionCards[3].clickOnShowExplanationButton();
+  //   await conceptPage.clickOnContinueButton();
+  //   await conceptPage.clickOnContinueButton();
+  //   await conceptPage.clickOnContinueButton();
+  //   await conceptPage.clickOnContinueButton();
+  //   await conceptPage.clickOnContinueButton();
 
-    assert.true(conceptPage.upcomingConcept.title.text.includes('Network Primer'), 'Concept group title is correct');
-    assert.true(conceptPage.upcomingConcept.card.title.text.includes('TCP: An Overview'), 'Next concept title is correct');
-    assert.true(conceptPage.shareConceptContainer.text.includes('https://app.codecrafters.io/concepts/network-protocols'));
+  //   assert.true(conceptPage.upcomingConcept.title.text.includes('Network Primer'), 'Concept group title is correct');
+  //   assert.true(conceptPage.upcomingConcept.card.title.text.includes('TCP: An Overview'), 'Next concept title is correct');
+  //   assert.true(conceptPage.shareConceptContainer.text.includes('https://app.codecrafters.io/concepts/network-protocols'));
 
-    await percySnapshot('Concept - Completed');
-  });
+  //   await percySnapshot('Concept - Completed');
+  // });
 
   test('anonymous users can also view concepts', async function (assert) {
     testScenario(this.server);
@@ -121,581 +123,603 @@ module('Acceptance | concepts-test', function (hooks) {
     await conceptPage.clickOnContinueButton();
     await conceptPage.clickOnContinueButton();
     await conceptPage.clickOnContinueButton();
+
+    await animationsSettled();
     await conceptPage.clickOnContinueButton();
 
     assert.true(conceptPage.upcomingConcept.title.text.includes('Network Primer'), 'Concept group title is correct');
     assert.true(conceptPage.upcomingConcept.card.title.text.includes('TCP: An Overview'), 'Next concept title is correct');
-  });
 
-  test('concept question body has prism highlighting', async function (assert) {
-    testScenario(this.server);
-    createConcepts(this.server);
-
-    signInAsStaff(this.owner, this.server);
-
-    await conceptsPage.visit();
-
-    await conceptsPage.clickOnConceptCard('Dummy Concept');
-    await conceptPage.clickOnContinueButton();
-    await conceptPage.clickOnContinueButton();
-    assert.true(conceptPage.questionCards[0].body.hasPrismHighlighting);
-    await conceptPage.questionCards[0].selectOption('Correct');
-    await conceptPage.clickOnContinueButton();
-    await conceptPage.clickOnContinueButton();
-  });
-
-  test('clicking on the upcoming concept cards works properly', async function (assert) {
-    testScenario(this.server);
-    createConcepts(this.server);
-
-    signInAsStaff(this.owner, this.server);
-
-    this.server.schema.conceptGroups.create({
-      conceptSlugs: ['network-protocols', 'tcp-overview'],
-      descriptionMarkdown: 'This is a group about network concepts',
-      slug: 'network-primer',
-      title: 'Network Primer',
-    });
-
-    await conceptsPage.visit();
-    await conceptsPage.clickOnConceptCard('Network Protocols');
-    await conceptPage.clickOnContinueButton();
-    await conceptPage.clickOnContinueButton();
-    await conceptPage.questionCards[0].selectOption('PDF');
-    await conceptPage.clickOnContinueButton();
-    await conceptPage.clickOnContinueButton();
-    await conceptPage.clickOnContinueButton();
-    await conceptPage.questionCards[1].clickOnShowExplanationButton();
-    await conceptPage.clickOnContinueButton();
-    await conceptPage.clickOnContinueButton();
-    await conceptPage.clickOnContinueButton();
-    await conceptPage.questionCards[2].clickOnShowExplanationButton();
-    await conceptPage.clickOnContinueButton();
-    await conceptPage.clickOnContinueButton();
-    await conceptPage.clickOnContinueButton();
-    await conceptPage.clickOnContinueButton();
-    await conceptPage.clickOnContinueButton();
-    await conceptPage.clickOnContinueButton();
-    await conceptPage.questionCards[3].clickOnShowExplanationButton();
-    await conceptPage.clickOnContinueButton();
-    await conceptPage.clickOnContinueButton();
-    await conceptPage.clickOnContinueButton();
-    await conceptPage.clickOnContinueButton();
-    await conceptPage.clickOnContinueButton();
-
-    await conceptPage.upcomingConcept.card.click();
-    assert.strictEqual(currentURL(), '/concepts/tcp-overview', 'Clicking on the upcoming concept card navigates to the next concept');
-    assert.strictEqual(conceptPage.blocks.length, 1, 'The progress is reset when navigating to a new concept');
-    assert.strictEqual(window.scrollY, 0, 'The page is scrolled to the top when navigating to a new concept');
-  });
-
-  test('tracks concepts events', async function (assert) {
-    testScenario(this.server);
-    createConcepts(this.server);
-
-    signInAsStaff(this.owner, this.server);
-
-    await conceptsPage.visit();
-
-    await conceptsPage.clickOnConceptCard('Network Protocols');
-    await conceptPage.clickOnContinueButton();
-    await conceptPage.clickOnContinueButton();
-    await conceptPage.questionCards[0].clickOnShowExplanationButton();
-    await conceptPage.clickOnContinueButton();
-    await conceptPage.clickOnContinueButton();
-    await conceptPage.clickOnContinueButton();
-
-    const analyticsEvents = this.server.schema.analyticsEvents.all().models;
-    const filteredAnalyticsEvents = analyticsEvents.filter((event) => event.name !== 'feature_flag_called');
-
-    assert.strictEqual(filteredAnalyticsEvents.length, 8, 'Expected 8 analytics events to be tracked');
-
-    assert.deepEqual(
-      filteredAnalyticsEvents.map((event) => event.name),
-      [
-        'viewed_page',
-        'viewed_page',
-        'viewed_concept',
-        'progressed_through_concept',
-        'progressed_through_concept',
-        'progressed_through_concept',
-        'progressed_through_concept',
-        'progressed_through_concept',
-      ],
+    assert.true(conceptPage.conceptCompletedModal.isVisible, 'Concept completed modal is shown for anonymous users');
+    assert.true(
+      conceptPage.conceptCompletedModal.text.includes('Get free access to the rest of Network Primer'),
+      'Modal shows correct group access message',
     );
-  });
 
-  test('tracks when share concept button is clicked', async function (assert) {
-    testScenario(this.server);
-    createConcepts(this.server);
+    const expectedRedirectUrl = encodeURIComponent('/collections/network-primer');
 
-    signInAsStaff(this.owner, this.server);
+    const conceptId = 2;
+    const nextUrl = config.x.backendUrl + '/concepts/' + conceptId + '/mark_as_complete?redirect_url=' + expectedRedirectUrl;
 
-    await conceptsPage.visit();
+    await conceptPage.conceptCompletedModal.clickOnSignInButton();
+    await animationsSettled();
 
-    await conceptsPage.clickOnConceptCard('Dummy Concept');
-    await conceptPage.clickOnContinueButton();
-    await conceptPage.clickOnContinueButton();
-    await conceptPage.questionCards[0].clickOnShowExplanationButton();
-    await conceptPage.clickOnContinueButton();
-    await conceptPage.clickOnContinueButton();
-
-    await conceptPage.shareConceptContainer.clickOnCopyButton();
-
-    const analyticsEvents = this.server.schema.analyticsEvents.all().models;
-    const filteredAnalyticsEvents = analyticsEvents.filter((event) => event.name !== 'feature_flag_called');
-    const filteredAnalyticsEventsNames = filteredAnalyticsEvents.map((event) => event.name);
-
-    assert.ok(filteredAnalyticsEventsNames.includes('clicked_share_concept_button'), 'clicked_on_share_concept_button event should be tracked');
-  });
-
-  test('submit button does not work when no option is selected for question card', async function (assert) {
-    testScenario(this.server);
-    createConcepts(this.server);
-
-    signInAsStaff(this.owner, this.server);
-    await conceptsPage.visit();
-    await conceptsPage.clickOnConceptCard('Network Protocols');
-    await conceptPage.clickOnContinueButton();
-    await conceptPage.clickOnContinueButton();
-
-    assert.notOk(conceptPage.questionCards[0].hasSubmitted, 'The submission result should not be visible without selecting an option.');
-
-    await conceptPage.questionCards[0].selectOption('PDF');
-
-    assert.ok(conceptPage.questionCards[0].hasSubmitted, 'After selecting an option, the submission result should be visible.');
-  });
-
-  test('progress is tracked', async function (assert) {
-    testScenario(this.server);
-    createConcepts(this.server);
-
-    const user = this.server.schema.users.first();
-    signIn(this.owner, this.server, user);
-
-    await conceptsPage.visit();
-    assert.notOk(conceptsPage.conceptCards[1].hasProgressBar, 'Progress bar should not be present in concept card before starting concept');
-
-    await conceptsPage.conceptCards[1].hover();
-    assert.strictEqual(conceptsPage.conceptCards[1].actionText, 'View', 'Concept card action text should be view');
-
-    await conceptsPage.clickOnConceptCard('Network Protocols');
-    assert.notOk(conceptPage.progress.isPresent, 'Progress bar should not be present in concept before starting');
-
-    await conceptPage.clickOnContinueButton();
-    assert.ok(conceptPage.progress.isPresent, 'Progress bar should be present after starting concept');
-    assert.ok(conceptPage.progress.text.includes('5%'), 'Progress text should reflect tracked progress in concept page');
-    assert.ok(conceptPage.progress.barStyle.includes('width: 5%'), 'Progress bar should reflect tracked progress in concept page');
-    assert.ok(conceptPage.progress.text.includes('39 blocks left'), 'Remaining blocks left should be reflected properly');
-
-    await conceptPage.clickOnContinueButton();
-    await conceptPage.questionCards[0].clickOnShowExplanationButton();
-    assert.ok(conceptPage.progress.text.includes('10%'));
-    assert.ok(conceptPage.progress.barStyle.includes('width: 10%'));
-
-    await conceptPage.clickOnStepBackButton();
-    assert.ok(conceptPage.progress.text.includes('5%'));
-    assert.ok(conceptPage.progress.barStyle.includes('width: 5%'));
-
-    await conceptsPage.visit();
-    assert.ok(conceptsPage.conceptCards[1].progressText.includes('5% complete'), 'Progress text should reflect tracked progress in concept card');
-
-    await conceptsPage.conceptCards[1].hover();
     assert.strictEqual(
-      conceptsPage.conceptCards[1].actionText,
-      'Resume',
-      'Concept card action text should be resume for concept that is in progress',
+      windowMock.location.href,
+      `${windowMock.location.origin}/login?next=${nextUrl}`,
+      'should redirect to login URL with correct mark_as_complete endpoint',
     );
   });
 
-  test('tracked progress is rendered properly on page visit', async function (assert) {
-    testScenario(this.server);
-    createConcepts(this.server);
-
-    const user = this.server.schema.users.first();
-    const networkProtocolsConcept = this.server.schema.concepts.findBy({ slug: 'network-protocols' });
-
-    this.server.create('concept-engagement', {
-      concept: networkProtocolsConcept,
-      user,
-      currentProgressPercentage: 5,
-      lastActivityAt: new Date(),
-      startedAt: new Date(),
-    });
-
-    signIn(this.owner, this.server, user);
-
-    await conceptsPage.visit();
-    assert.ok(conceptsPage.conceptCards[0].progressText.includes('5% complete'), 'Progress should be tracked');
-
-    await conceptsPage.conceptCards[0].hover();
-    assert.strictEqual(
-      conceptsPage.conceptCards[0].actionText,
-      'Resume',
-      'Concept card action text should be resume for concept that is in progress',
-    );
-
-    await conceptsPage.clickOnConceptCard('Network Protocols');
-    assert.strictEqual(conceptPage.blocks.length, 2, 'Completed blocks are automatically shown');
-    assert.ok(conceptPage.progress.isPresent, 'Progress bar should be present');
-    assert.ok(conceptPage.progress.text.includes('5%'), 'Progress text should reflect tracked progress in concept page');
-    assert.ok(conceptPage.progress.barStyle.includes('width: 5%'), 'Progress bar should reflect tracked progress in concept page');
-    assert.ok(conceptPage.progress.text.includes('39 blocks left'), 'Remaining blocks left should be reflected properly');
-  });
-
-  test('progress for completed concepts is rendered properly', async function (assert) {
-    testScenario(this.server);
-    createConcepts(this.server);
-
-    const user = this.server.schema.users.first();
-    const networkProtocolsConcept = this.server.schema.concepts.findBy({ slug: 'network-protocols' });
-
-    this.server.create('concept-engagement', {
-      concept: networkProtocolsConcept,
-      user,
-      currentProgressPercentage: 100,
-      lastActivityAt: new Date(),
-      startedAt: new Date(),
-    });
-
-    signIn(this.owner, this.server, user);
-
-    await conceptsPage.visit();
-    assert.notOk(conceptsPage.conceptCards[0].hasProgressBar, 'Concept card should not show progress');
-
-    assert.ok(
-      conceptsPage.conceptCards[0].text.includes('completed'),
-      'Concept card should show completed instead of progress percentage on completion',
-    );
-
-    await conceptsPage.conceptCards[0].hover();
-    assert.strictEqual(conceptsPage.conceptCards[0].actionText, 'View', 'Concept card action text should be view for completed concept');
-  });
-
-  test('remaining blocks left is rendered properly', async function (assert) {
-    testScenario(this.server);
-    createConcepts(this.server);
-
-    const user = this.server.schema.users.first();
-    signIn(this.owner, this.server, user);
-
-    await conceptsPage.visit();
-    await conceptsPage.clickOnConceptCard('Network Protocols');
-    assert.notOk(conceptPage.progress.isPresent, 'Remaining blocks left should not be shown if no progress is made');
-
-    await conceptPage.clickOnContinueButton();
-    assert.contains(conceptPage.progress.text, '39 blocks left');
-
-    await conceptPage.clickOnContinueButton();
-    assert.contains(conceptPage.progress.text, '37 blocks left');
-  });
-
-  test('remaining blocks left is not present if user completed concept', async function (assert) {
-    testScenario(this.server);
-    createConcepts(this.server);
-
-    signInAsStaff(this.owner, this.server);
-
-    this.server.schema.conceptGroups.create({
-      conceptSlugs: ['network-protocols', 'tcp-overview'],
-      descriptionMarkdown: 'This is a group about network concepts',
-      slug: 'network-primer',
-      title: 'Network Primer',
-    });
-
-    await conceptsPage.visit();
-
-    await conceptsPage.clickOnConceptCard('Network Protocols');
-    await conceptPage.clickOnContinueButton();
-    await conceptPage.clickOnContinueButton();
-    await conceptPage.questionCards[0].clickOnShowExplanationButton();
-    await conceptPage.clickOnContinueButton();
-    await conceptPage.clickOnContinueButton();
-    await conceptPage.clickOnContinueButton();
-    await conceptPage.questionCards[1].clickOnShowExplanationButton();
-    await conceptPage.clickOnContinueButton();
-    await conceptPage.clickOnContinueButton();
-    await conceptPage.clickOnContinueButton();
-    await conceptPage.questionCards[2].clickOnShowExplanationButton();
-    await conceptPage.clickOnContinueButton();
-    await conceptPage.clickOnContinueButton();
-    await conceptPage.clickOnContinueButton();
-    await conceptPage.clickOnContinueButton();
-    await conceptPage.clickOnContinueButton();
-    await conceptPage.clickOnContinueButton();
-    await conceptPage.questionCards[3].clickOnShowExplanationButton();
-    await conceptPage.clickOnContinueButton();
-    await conceptPage.clickOnContinueButton();
-    await conceptPage.clickOnContinueButton();
-    await conceptPage.clickOnContinueButton();
-    await conceptPage.clickOnContinueButton();
-
-    assert.notOk(conceptPage.progress.text.includes('blocks left'), 'Remaining blocks left should not be present');
-  });
+  // test('concept question body has prism highlighting', async function (assert) {
+  //   testScenario(this.server);
+  //   createConcepts(this.server);
+
+  //   signInAsStaff(this.owner, this.server);
+
+  //   await conceptsPage.visit();
+
+  //   await conceptsPage.clickOnConceptCard('Dummy Concept');
+  //   await conceptPage.clickOnContinueButton();
+  //   await conceptPage.clickOnContinueButton();
+  //   assert.true(conceptPage.questionCards[0].body.hasPrismHighlighting);
+  //   await conceptPage.questionCards[0].selectOption('Correct');
+  //   await conceptPage.clickOnContinueButton();
+  //   await conceptPage.clickOnContinueButton();
+  // });
+
+  // test('clicking on the upcoming concept cards works properly', async function (assert) {
+  //   testScenario(this.server);
+  //   createConcepts(this.server);
+
+  //   signInAsStaff(this.owner, this.server);
+
+  //   this.server.schema.conceptGroups.create({
+  //     conceptSlugs: ['network-protocols', 'tcp-overview'],
+  //     descriptionMarkdown: 'This is a group about network concepts',
+  //     slug: 'network-primer',
+  //     title: 'Network Primer',
+  //   });
+
+  //   await conceptsPage.visit();
+  //   await conceptsPage.clickOnConceptCard('Network Protocols');
+  //   await conceptPage.clickOnContinueButton();
+  //   await conceptPage.clickOnContinueButton();
+  //   await conceptPage.questionCards[0].selectOption('PDF');
+  //   await conceptPage.clickOnContinueButton();
+  //   await conceptPage.clickOnContinueButton();
+  //   await conceptPage.clickOnContinueButton();
+  //   await conceptPage.questionCards[1].clickOnShowExplanationButton();
+  //   await conceptPage.clickOnContinueButton();
+  //   await conceptPage.clickOnContinueButton();
+  //   await conceptPage.clickOnContinueButton();
+  //   await conceptPage.questionCards[2].clickOnShowExplanationButton();
+  //   await conceptPage.clickOnContinueButton();
+  //   await conceptPage.clickOnContinueButton();
+  //   await conceptPage.clickOnContinueButton();
+  //   await conceptPage.clickOnContinueButton();
+  //   await conceptPage.clickOnContinueButton();
+  //   await conceptPage.clickOnContinueButton();
+  //   await conceptPage.questionCards[3].clickOnShowExplanationButton();
+  //   await conceptPage.clickOnContinueButton();
+  //   await conceptPage.clickOnContinueButton();
+  //   await conceptPage.clickOnContinueButton();
+  //   await conceptPage.clickOnContinueButton();
+  //   await conceptPage.clickOnContinueButton();
+
+  //   await conceptPage.upcomingConcept.card.click();
+  //   assert.strictEqual(currentURL(), '/concepts/tcp-overview', 'Clicking on the upcoming concept card navigates to the next concept');
+  //   assert.strictEqual(conceptPage.blocks.length, 1, 'The progress is reset when navigating to a new concept');
+  //   assert.strictEqual(window.scrollY, 0, 'The page is scrolled to the top when navigating to a new concept');
+  // });
+
+  // test('tracks concepts events', async function (assert) {
+  //   testScenario(this.server);
+  //   createConcepts(this.server);
+
+  //   signInAsStaff(this.owner, this.server);
+
+  //   await conceptsPage.visit();
+
+  //   await conceptsPage.clickOnConceptCard('Network Protocols');
+  //   await conceptPage.clickOnContinueButton();
+  //   await conceptPage.clickOnContinueButton();
+  //   await conceptPage.questionCards[0].clickOnShowExplanationButton();
+  //   await conceptPage.clickOnContinueButton();
+  //   await conceptPage.clickOnContinueButton();
+  //   await conceptPage.clickOnContinueButton();
+
+  //   const analyticsEvents = this.server.schema.analyticsEvents.all().models;
+  //   const filteredAnalyticsEvents = analyticsEvents.filter((event) => event.name !== 'feature_flag_called');
+
+  //   assert.strictEqual(filteredAnalyticsEvents.length, 8, 'Expected 8 analytics events to be tracked');
+
+  //   assert.deepEqual(
+  //     filteredAnalyticsEvents.map((event) => event.name),
+  //     [
+  //       'viewed_page',
+  //       'viewed_page',
+  //       'viewed_concept',
+  //       'progressed_through_concept',
+  //       'progressed_through_concept',
+  //       'progressed_through_concept',
+  //       'progressed_through_concept',
+  //       'progressed_through_concept',
+  //     ],
+  //   );
+  // });
+
+  // test('tracks when share concept button is clicked', async function (assert) {
+  //   testScenario(this.server);
+  //   createConcepts(this.server);
 
-  test('can select an option for a question using 1/2/3/4', async function (assert) {
-    testScenario(this.server);
-    createConcepts(this.server);
+  //   signInAsStaff(this.owner, this.server);
 
-    signInAsStaff(this.owner, this.server);
-
-    this.server.schema.conceptGroups.create({
-      conceptSlugs: ['network-protocols', 'tcp-overview'],
-      descriptionMarkdown: 'This is a group about network concepts',
-      slug: 'network-primer',
-      title: 'Network Primer',
-    });
-
-    await conceptsPage.visit();
-
-    await conceptsPage.clickOnConceptCard('Network Protocols');
-    await conceptPage.clickOnContinueButton();
-    await conceptPage.clickOnContinueButton();
-
-    assert.false(conceptPage.questionCards[0].hasSubmitted, 'the question has not been submitted yet');
-
-    await conceptPage.questionCards[0].keydown({ key: '1' });
-
-    assert.true(conceptPage.questionCards[0].hasSubmitted, 'the question has been submitted');
-  });
-
-  test('can select an option for a question using a/b/c/d', async function (assert) {
-    testScenario(this.server);
-    createConcepts(this.server);
-
-    signInAsStaff(this.owner, this.server);
+  //   await conceptsPage.visit();
 
-    this.server.schema.conceptGroups.create({
-      conceptSlugs: ['network-protocols', 'tcp-overview'],
-      descriptionMarkdown: 'This is a group about network concepts',
-      slug: 'network-primer',
-      title: 'Network Primer',
-    });
+  //   await conceptsPage.clickOnConceptCard('Dummy Concept');
+  //   await conceptPage.clickOnContinueButton();
+  //   await conceptPage.clickOnContinueButton();
+  //   await conceptPage.questionCards[0].clickOnShowExplanationButton();
+  //   await conceptPage.clickOnContinueButton();
+  //   await conceptPage.clickOnContinueButton();
 
-    await conceptsPage.visit();
+  //   await conceptPage.shareConceptContainer.clickOnCopyButton();
+
+  //   const analyticsEvents = this.server.schema.analyticsEvents.all().models;
+  //   const filteredAnalyticsEvents = analyticsEvents.filter((event) => event.name !== 'feature_flag_called');
+  //   const filteredAnalyticsEventsNames = filteredAnalyticsEvents.map((event) => event.name);
+
+  //   assert.ok(filteredAnalyticsEventsNames.includes('clicked_share_concept_button'), 'clicked_on_share_concept_button event should be tracked');
+  // });
+
+  // test('submit button does not work when no option is selected for question card', async function (assert) {
+  //   testScenario(this.server);
+  //   createConcepts(this.server);
+
+  //   signInAsStaff(this.owner, this.server);
+  //   await conceptsPage.visit();
+  //   await conceptsPage.clickOnConceptCard('Network Protocols');
+  //   await conceptPage.clickOnContinueButton();
+  //   await conceptPage.clickOnContinueButton();
+
+  //   assert.notOk(conceptPage.questionCards[0].hasSubmitted, 'The submission result should not be visible without selecting an option.');
+
+  //   await conceptPage.questionCards[0].selectOption('PDF');
+
+  //   assert.ok(conceptPage.questionCards[0].hasSubmitted, 'After selecting an option, the submission result should be visible.');
+  // });
+
+  // test('progress is tracked', async function (assert) {
+  //   testScenario(this.server);
+  //   createConcepts(this.server);
+
+  //   const user = this.server.schema.users.first();
+  //   signIn(this.owner, this.server, user);
+
+  //   await conceptsPage.visit();
+  //   assert.notOk(conceptsPage.conceptCards[1].hasProgressBar, 'Progress bar should not be present in concept card before starting concept');
+
+  //   await conceptsPage.conceptCards[1].hover();
+  //   assert.strictEqual(conceptsPage.conceptCards[1].actionText, 'View', 'Concept card action text should be view');
+
+  //   await conceptsPage.clickOnConceptCard('Network Protocols');
+  //   assert.notOk(conceptPage.progress.isPresent, 'Progress bar should not be present in concept before starting');
+
+  //   await conceptPage.clickOnContinueButton();
+  //   assert.ok(conceptPage.progress.isPresent, 'Progress bar should be present after starting concept');
+  //   assert.ok(conceptPage.progress.text.includes('5%'), 'Progress text should reflect tracked progress in concept page');
+  //   assert.ok(conceptPage.progress.barStyle.includes('width: 5%'), 'Progress bar should reflect tracked progress in concept page');
+  //   assert.ok(conceptPage.progress.text.includes('39 blocks left'), 'Remaining blocks left should be reflected properly');
 
-    await conceptsPage.clickOnConceptCard('Network Protocols');
-    await conceptPage.clickOnContinueButton();
-    await conceptPage.clickOnContinueButton();
+  //   await conceptPage.clickOnContinueButton();
+  //   await conceptPage.questionCards[0].clickOnShowExplanationButton();
+  //   assert.ok(conceptPage.progress.text.includes('10%'));
+  //   assert.ok(conceptPage.progress.barStyle.includes('width: 10%'));
+
+  //   await conceptPage.clickOnStepBackButton();
+  //   assert.ok(conceptPage.progress.text.includes('5%'));
+  //   assert.ok(conceptPage.progress.barStyle.includes('width: 5%'));
 
-    assert.false(conceptPage.questionCards[0].hasSubmitted, 'the question has not been submitted yet');
+  //   await conceptsPage.visit();
+  //   assert.ok(conceptsPage.conceptCards[1].progressText.includes('5% complete'), 'Progress text should reflect tracked progress in concept card');
 
-    await conceptPage.questionCards[0].keydown({ keyCode: 65 });
+  //   await conceptsPage.conceptCards[1].hover();
+  //   assert.strictEqual(
+  //     conceptsPage.conceptCards[1].actionText,
+  //     'Resume',
+  //     'Concept card action text should be resume for concept that is in progress',
+  //   );
+  // });
 
-    assert.true(conceptPage.questionCards[0].hasSubmitted, 'the question has been submitted');
-  });
+  // test('tracked progress is rendered properly on page visit', async function (assert) {
+  //   testScenario(this.server);
+  //   createConcepts(this.server);
+
+  //   const user = this.server.schema.users.first();
+  //   const networkProtocolsConcept = this.server.schema.concepts.findBy({ slug: 'network-protocols' });
+
+  //   this.server.create('concept-engagement', {
+  //     concept: networkProtocolsConcept,
+  //     user,
+  //     currentProgressPercentage: 5,
+  //     lastActivityAt: new Date(),
+  //     startedAt: new Date(),
+  //   });
+
+  //   signIn(this.owner, this.server, user);
+
+  //   await conceptsPage.visit();
+  //   assert.ok(conceptsPage.conceptCards[0].progressText.includes('5% complete'), 'Progress should be tracked');
+
+  //   await conceptsPage.conceptCards[0].hover();
+  //   assert.strictEqual(
+  //     conceptsPage.conceptCards[0].actionText,
+  //     'Resume',
+  //     'Concept card action text should be resume for concept that is in progress',
+  //   );
+
+  //   await conceptsPage.clickOnConceptCard('Network Protocols');
+  //   assert.strictEqual(conceptPage.blocks.length, 2, 'Completed blocks are automatically shown');
+  //   assert.ok(conceptPage.progress.isPresent, 'Progress bar should be present');
+  //   assert.ok(conceptPage.progress.text.includes('5%'), 'Progress text should reflect tracked progress in concept page');
+  //   assert.ok(conceptPage.progress.barStyle.includes('width: 5%'), 'Progress bar should reflect tracked progress in concept page');
+  //   assert.ok(conceptPage.progress.text.includes('39 blocks left'), 'Remaining blocks left should be reflected properly');
+  // });
+
+  // test('progress for completed concepts is rendered properly', async function (assert) {
+  //   testScenario(this.server);
+  //   createConcepts(this.server);
+
+  //   const user = this.server.schema.users.first();
+  //   const networkProtocolsConcept = this.server.schema.concepts.findBy({ slug: 'network-protocols' });
+
+  //   this.server.create('concept-engagement', {
+  //     concept: networkProtocolsConcept,
+  //     user,
+  //     currentProgressPercentage: 100,
+  //     lastActivityAt: new Date(),
+  //     startedAt: new Date(),
+  //   });
+
+  //   signIn(this.owner, this.server, user);
+
+  //   await conceptsPage.visit();
+  //   assert.notOk(conceptsPage.conceptCards[0].hasProgressBar, 'Concept card should not show progress');
+
+  //   assert.ok(
+  //     conceptsPage.conceptCards[0].text.includes('completed'),
+  //     'Concept card should show completed instead of progress percentage on completion',
+  //   );
+
+  //   await conceptsPage.conceptCards[0].hover();
+  //   assert.strictEqual(conceptsPage.conceptCards[0].actionText, 'View', 'Concept card action text should be view for completed concept');
+  // });
+
+  // test('remaining blocks left is rendered properly', async function (assert) {
+  //   testScenario(this.server);
+  //   createConcepts(this.server);
+
+  //   const user = this.server.schema.users.first();
+  //   signIn(this.owner, this.server, user);
+
+  //   await conceptsPage.visit();
+  //   await conceptsPage.clickOnConceptCard('Network Protocols');
+  //   assert.notOk(conceptPage.progress.isPresent, 'Remaining blocks left should not be shown if no progress is made');
+
+  //   await conceptPage.clickOnContinueButton();
+  //   assert.contains(conceptPage.progress.text, '39 blocks left');
+
+  //   await conceptPage.clickOnContinueButton();
+  //   assert.contains(conceptPage.progress.text, '37 blocks left');
+  // });
+
+  // test('remaining blocks left is not present if user completed concept', async function (assert) {
+  //   testScenario(this.server);
+  //   createConcepts(this.server);
+
+  //   signInAsStaff(this.owner, this.server);
+
+  //   this.server.schema.conceptGroups.create({
+  //     conceptSlugs: ['network-protocols', 'tcp-overview'],
+  //     descriptionMarkdown: 'This is a group about network concepts',
+  //     slug: 'network-primer',
+  //     title: 'Network Primer',
+  //   });
+
+  //   await conceptsPage.visit();
+
+  //   await conceptsPage.clickOnConceptCard('Network Protocols');
+  //   await conceptPage.clickOnContinueButton();
+  //   await conceptPage.clickOnContinueButton();
+  //   await conceptPage.questionCards[0].clickOnShowExplanationButton();
+  //   await conceptPage.clickOnContinueButton();
+  //   await conceptPage.clickOnContinueButton();
+  //   await conceptPage.clickOnContinueButton();
+  //   await conceptPage.questionCards[1].clickOnShowExplanationButton();
+  //   await conceptPage.clickOnContinueButton();
+  //   await conceptPage.clickOnContinueButton();
+  //   await conceptPage.clickOnContinueButton();
+  //   await conceptPage.questionCards[2].clickOnShowExplanationButton();
+  //   await conceptPage.clickOnContinueButton();
+  //   await conceptPage.clickOnContinueButton();
+  //   await conceptPage.clickOnContinueButton();
+  //   await conceptPage.clickOnContinueButton();
+  //   await conceptPage.clickOnContinueButton();
+  //   await conceptPage.clickOnContinueButton();
+  //   await conceptPage.questionCards[3].clickOnShowExplanationButton();
+  //   await conceptPage.clickOnContinueButton();
+  //   await conceptPage.clickOnContinueButton();
+  //   await conceptPage.clickOnContinueButton();
+  //   await conceptPage.clickOnContinueButton();
+  //   await conceptPage.clickOnContinueButton();
+
+  //   assert.notOk(conceptPage.progress.text.includes('blocks left'), 'Remaining blocks left should not be present');
+  // });
+
+  // test('can select an option for a question using 1/2/3/4', async function (assert) {
+  //   testScenario(this.server);
+  //   createConcepts(this.server);
+
+  //   signInAsStaff(this.owner, this.server);
+
+  //   this.server.schema.conceptGroups.create({
+  //     conceptSlugs: ['network-protocols', 'tcp-overview'],
+  //     descriptionMarkdown: 'This is a group about network concepts',
+  //     slug: 'network-primer',
+  //     title: 'Network Primer',
+  //   });
+
+  //   await conceptsPage.visit();
+
+  //   await conceptsPage.clickOnConceptCard('Network Protocols');
+  //   await conceptPage.clickOnContinueButton();
+  //   await conceptPage.clickOnContinueButton();
+
+  //   assert.false(conceptPage.questionCards[0].hasSubmitted, 'the question has not been submitted yet');
+
+  //   await conceptPage.questionCards[0].keydown({ key: '1' });
+
+  //   assert.true(conceptPage.questionCards[0].hasSubmitted, 'the question has been submitted');
+  // });
+
+  // test('can select an option for a question using a/b/c/d', async function (assert) {
+  //   testScenario(this.server);
+  //   createConcepts(this.server);
+
+  //   signInAsStaff(this.owner, this.server);
+
+  //   this.server.schema.conceptGroups.create({
+  //     conceptSlugs: ['network-protocols', 'tcp-overview'],
+  //     descriptionMarkdown: 'This is a group about network concepts',
+  //     slug: 'network-primer',
+  //     title: 'Network Primer',
+  //   });
 
-  test('can navigate using j/k and select option using enter', async function (assert) {
-    testScenario(this.server);
-    createConcepts(this.server);
+  //   await conceptsPage.visit();
 
-    signInAsStaff(this.owner, this.server);
+  //   await conceptsPage.clickOnConceptCard('Network Protocols');
+  //   await conceptPage.clickOnContinueButton();
+  //   await conceptPage.clickOnContinueButton();
 
-    await conceptsPage.visit();
+  //   assert.false(conceptPage.questionCards[0].hasSubmitted, 'the question has not been submitted yet');
 
-    await conceptsPage.clickOnConceptCard('Network Protocols');
-    await conceptPage.clickOnContinueButton();
-    await conceptPage.clickOnContinueButton();
+  //   await conceptPage.questionCards[0].keydown({ keyCode: 65 });
 
-    assert.false(conceptPage.questionCards[0].hasSubmitted, 'the question has not been submitted yet');
+  //   assert.true(conceptPage.questionCards[0].hasSubmitted, 'the question has been submitted');
+  // });
 
-    // Should be able to move back and fort
-    assert.strictEqual(conceptPage.questionCards[0].focusedOption.text, 'SMTP');
-    await conceptPage.questionCards[0].keydown({ keyCode: 74 }); // Send j key
-    assert.strictEqual(conceptPage.questionCards[0].focusedOption.text, 'HTTP');
-    await conceptPage.questionCards[0].keydown({ keyCode: 75 }); // Send k key
-    assert.strictEqual(conceptPage.questionCards[0].focusedOption.text, 'SMTP');
+  // test('can navigate using j/k and select option using enter', async function (assert) {
+  //   testScenario(this.server);
+  //   createConcepts(this.server);
 
-    // Can move to end of list
-    await conceptPage.questionCards[0].keydown({ keyCode: 74 }); // Send j key
-    await conceptPage.questionCards[0].keydown({ keyCode: 74 }); // Send j key
-    await conceptPage.questionCards[0].keydown({ keyCode: 74 }); // Send j key
-    assert.strictEqual(conceptPage.questionCards[0].focusedOption.text, 'PDF');
+  //   signInAsStaff(this.owner, this.server);
 
-    // Can wrap around to start of list
-    await conceptPage.questionCards[0].keydown({ keyCode: 74 }); // Send j key
-    assert.strictEqual(conceptPage.questionCards[0].focusedOption.text, 'SMTP');
-
-    await conceptPage.questionCards[0].focusedOption.click(); // Simulate ENTER on focused option
-    assert.true(conceptPage.questionCards[0].hasSubmitted, 'the question has been submitted');
-  });
-
-  test('can navigate using arrow keys and select option using enter', async function (assert) {
-    testScenario(this.server);
-    createConcepts(this.server);
-
-    signInAsStaff(this.owner, this.server);
-
-    await conceptsPage.visit();
-
-    await conceptsPage.clickOnConceptCard('Network Protocols');
-    await conceptPage.clickOnContinueButton();
-    await conceptPage.clickOnContinueButton();
-
-    assert.false(conceptPage.questionCards[0].hasSubmitted, 'the question has not been submitted yet');
-
-    // Should be able to move back and fort
-    assert.strictEqual(conceptPage.questionCards[0].focusedOption.text, 'SMTP');
-    await conceptPage.questionCards[0].keydown({ key: 'ArrowDown' }); // Send down arrow key
-    assert.strictEqual(conceptPage.questionCards[0].focusedOption.text, 'HTTP');
-    await conceptPage.questionCards[0].keydown({ key: 'ArrowUp' }); // Send up arrow key
-    assert.strictEqual(conceptPage.questionCards[0].focusedOption.text, 'SMTP');
-
-    // Can move to end of list
-    await conceptPage.questionCards[0].keydown({ key: 'ArrowDown' }); // Send down arrow key
-    await conceptPage.questionCards[0].keydown({ key: 'ArrowDown' }); // Send down arrow key
-    await conceptPage.questionCards[0].keydown({ key: 'ArrowDown' }); // Send down arrow key
-    assert.strictEqual(conceptPage.questionCards[0].focusedOption.text, 'PDF');
-
-    // Can wrap around to start of list
-    await conceptPage.questionCards[0].keydown({ key: 'ArrowDown' }); // Send down arrow key
-    assert.strictEqual(conceptPage.questionCards[0].focusedOption.text, 'SMTP');
-
-    await conceptPage.questionCards[0].focusedOption.click(); // Simulate ENTER on focused option
-    assert.true(conceptPage.questionCards[0].hasSubmitted, 'the question has been submitted');
-  });
-
-  test('navigating question options using arrow keys does not trigger scrolling', async function (assert) {
-    testScenario(this.server);
-    createConcepts(this.server);
-
-    signInAsStaff(this.owner, this.server);
-
-    await conceptsPage.visit();
-
-    await conceptsPage.clickOnConceptCard('Network Protocols');
-    await conceptPage.clickOnContinueButton();
-    await conceptPage.clickOnContinueButton();
-
-    const currentScrollY = window.scrollY;
-
-    await conceptPage.questionCards[0].keydown({ key: 'ArrowDown' }); // Send down arrow key
-    await conceptPage.questionCards[0].keydown({ key: 'ArrowDown' }); // Send down arrow key
-    await conceptPage.questionCards[0].keydown({ key: 'ArrowDown' }); // Send down arrow key
-
-    assert.strictEqual(window.scrollY, currentScrollY, 'scrolling should not be triggered');
-  });
-
-  test('navigating options wraps around the list for the current question card only', async function (assert) {
-    testScenario(this.server);
-    createConcepts(this.server);
-
-    signInAsStaff(this.owner, this.server);
-
-    await conceptsPage.visit();
-
-    await conceptsPage.clickOnConceptCard('Network Protocols');
-    await conceptPage.clickOnContinueButton();
-    await conceptPage.clickOnContinueButton();
-    await conceptPage.questionCards[0].clickOnShowExplanationButton();
-    await conceptPage.clickOnContinueButton();
-    await conceptPage.clickOnContinueButton();
-    await conceptPage.clickOnContinueButton();
-
-    assert.strictEqual(conceptPage.questionCards[1].focusedOption.text, '1 layer');
-
-    await conceptPage.questionCards[0].keydown({ key: 'ArrowDown' }); // Send down arrow key
-    await conceptPage.questionCards[0].keydown({ key: 'ArrowDown' }); // Send down arrow key
-    await conceptPage.questionCards[0].keydown({ key: 'ArrowDown' }); // Send down arrow key
-    await conceptPage.questionCards[0].keydown({ key: 'ArrowDown' }); // Send down arrow key
-
-    assert.strictEqual(conceptPage.questionCards[1].focusedOption.text, '1 layer');
-  });
-
-  test('only published concepts are visible to users', async function (assert) {
-    testScenario(this.server);
-    createConcepts(this.server);
-
-    this.server.create('concept', {
-      slug: 'new-concept',
-      title: 'New Concept',
-      'description-markdown': 'This is a new concept.',
-      blocks: [
-        {
-          type: 'markdown',
-          args: {
-            markdown: `This is the first markdown block.`,
-          },
-        },
-      ],
-      status: 'draft',
-    });
-
-    signInAsSubscriber(this.owner, this.server);
-
-    await conceptsPage.visit();
-    assert.strictEqual(conceptsPage.conceptCards.length, 3, 'Only published concepts are visible to users');
-    assert.notOk(conceptsPage.conceptCards.map((card) => card.title).includes('New Concept'), 'Draft concepts are not visible to users');
-  });
-
-  test('draft concepts are visible to staff', async function (assert) {
-    testScenario(this.server);
-    createConcepts(this.server);
-
-    this.server.create('concept', {
-      slug: 'new-concept',
-      title: 'New Concept',
-      'description-markdown': 'This is a new concept.',
-      blocks: [
-        {
-          type: 'markdown',
-          args: {
-            markdown: `This is the first markdown block.`,
-          },
-        },
-      ],
-      status: 'draft',
-    });
-
-    signInAsStaff(this.owner, this.server);
-
-    await conceptsPage.visit();
-
-    assert.strictEqual(conceptsPage.conceptCards.length, 4, 'Draft concepts are visible to staff');
-    assert.strictEqual(conceptsPage.conceptCards[3].title, 'New Concept', 'Draft concepts are visible to staff');
-    assert.ok(conceptsPage.conceptCards[3].draftLabel.isVisible, 'Draft label is visible for draft concepts');
-
-    await conceptsPage.conceptCards[3].draftLabel.hover();
-
-    assertTooltipContent(assert, {
-      contentString: 'This concept is only visible to staff',
-    });
-  });
-
-  test('draft concepts are visible to concept author', async function (assert) {
-    testScenario(this.server);
-    createConcepts(this.server);
-
-    const user = this.server.create('user', {
-      id: 'user1',
-      avatarUrl: 'https://github.com/Gufran.png',
-      createdAt: new Date(),
-      githubUsername: 'Gufran',
-      username: 'Gufran',
-    });
-
-    this.server.create('concept', {
-      slug: 'new-concept',
-      title: 'New Concept',
-      'description-markdown': 'This is a new concept.',
-      blocks: [
-        {
-          type: 'markdown',
-          args: {
-            markdown: `This is the first markdown block.`,
-          },
-        },
-      ],
-      status: 'draft',
-      author: user,
-    });
-
-    signIn(this.owner, this.server, user);
-
-    await conceptsPage.visit();
-
-    assert.strictEqual(conceptsPage.conceptCards.length, 4, 'Draft concepts are visible to concept author');
-    assert.strictEqual(conceptsPage.conceptCards[3].title, 'New Concept', 'Draft concepts are visible to concept author');
-    assert.ok(conceptsPage.conceptCards[3].draftLabel.isVisible, 'Draft label is visible for draft concepts');
-  });
+  //   await conceptsPage.visit();
+
+  //   await conceptsPage.clickOnConceptCard('Network Protocols');
+  //   await conceptPage.clickOnContinueButton();
+  //   await conceptPage.clickOnContinueButton();
+
+  //   assert.false(conceptPage.questionCards[0].hasSubmitted, 'the question has not been submitted yet');
+
+  //   // Should be able to move back and fort
+  //   assert.strictEqual(conceptPage.questionCards[0].focusedOption.text, 'SMTP');
+  //   await conceptPage.questionCards[0].keydown({ keyCode: 74 }); // Send j key
+  //   assert.strictEqual(conceptPage.questionCards[0].focusedOption.text, 'HTTP');
+  //   await conceptPage.questionCards[0].keydown({ keyCode: 75 }); // Send k key
+  //   assert.strictEqual(conceptPage.questionCards[0].focusedOption.text, 'SMTP');
+
+  //   // Can move to end of list
+  //   await conceptPage.questionCards[0].keydown({ keyCode: 74 }); // Send j key
+  //   await conceptPage.questionCards[0].keydown({ keyCode: 74 }); // Send j key
+  //   await conceptPage.questionCards[0].keydown({ keyCode: 74 }); // Send j key
+  //   assert.strictEqual(conceptPage.questionCards[0].focusedOption.text, 'PDF');
+
+  //   // Can wrap around to start of list
+  //   await conceptPage.questionCards[0].keydown({ keyCode: 74 }); // Send j key
+  //   assert.strictEqual(conceptPage.questionCards[0].focusedOption.text, 'SMTP');
+
+  //   await conceptPage.questionCards[0].focusedOption.click(); // Simulate ENTER on focused option
+  //   assert.true(conceptPage.questionCards[0].hasSubmitted, 'the question has been submitted');
+  // });
+
+  // test('can navigate using arrow keys and select option using enter', async function (assert) {
+  //   testScenario(this.server);
+  //   createConcepts(this.server);
+
+  //   signInAsStaff(this.owner, this.server);
+
+  //   await conceptsPage.visit();
+
+  //   await conceptsPage.clickOnConceptCard('Network Protocols');
+  //   await conceptPage.clickOnContinueButton();
+  //   await conceptPage.clickOnContinueButton();
+
+  //   assert.false(conceptPage.questionCards[0].hasSubmitted, 'the question has not been submitted yet');
+
+  //   // Should be able to move back and fort
+  //   assert.strictEqual(conceptPage.questionCards[0].focusedOption.text, 'SMTP');
+  //   await conceptPage.questionCards[0].keydown({ key: 'ArrowDown' }); // Send down arrow key
+  //   assert.strictEqual(conceptPage.questionCards[0].focusedOption.text, 'HTTP');
+  //   await conceptPage.questionCards[0].keydown({ key: 'ArrowUp' }); // Send up arrow key
+  //   assert.strictEqual(conceptPage.questionCards[0].focusedOption.text, 'SMTP');
+
+  //   // Can move to end of list
+  //   await conceptPage.questionCards[0].keydown({ key: 'ArrowDown' }); // Send down arrow key
+  //   await conceptPage.questionCards[0].keydown({ key: 'ArrowDown' }); // Send down arrow key
+  //   await conceptPage.questionCards[0].keydown({ key: 'ArrowDown' }); // Send down arrow key
+  //   assert.strictEqual(conceptPage.questionCards[0].focusedOption.text, 'PDF');
+
+  //   // Can wrap around to start of list
+  //   await conceptPage.questionCards[0].keydown({ key: 'ArrowDown' }); // Send down arrow key
+  //   assert.strictEqual(conceptPage.questionCards[0].focusedOption.text, 'SMTP');
+
+  //   await conceptPage.questionCards[0].focusedOption.click(); // Simulate ENTER on focused option
+  //   assert.true(conceptPage.questionCards[0].hasSubmitted, 'the question has been submitted');
+  // });
+
+  // test('navigating question options using arrow keys does not trigger scrolling', async function (assert) {
+  //   testScenario(this.server);
+  //   createConcepts(this.server);
+
+  //   signInAsStaff(this.owner, this.server);
+
+  //   await conceptsPage.visit();
+
+  //   await conceptsPage.clickOnConceptCard('Network Protocols');
+  //   await conceptPage.clickOnContinueButton();
+  //   await conceptPage.clickOnContinueButton();
+
+  //   const currentScrollY = window.scrollY;
+
+  //   await conceptPage.questionCards[0].keydown({ key: 'ArrowDown' }); // Send down arrow key
+  //   await conceptPage.questionCards[0].keydown({ key: 'ArrowDown' }); // Send down arrow key
+  //   await conceptPage.questionCards[0].keydown({ key: 'ArrowDown' }); // Send down arrow key
+
+  //   assert.strictEqual(window.scrollY, currentScrollY, 'scrolling should not be triggered');
+  // });
+
+  // test('navigating options wraps around the list for the current question card only', async function (assert) {
+  //   testScenario(this.server);
+  //   createConcepts(this.server);
+
+  //   signInAsStaff(this.owner, this.server);
+
+  //   await conceptsPage.visit();
+
+  //   await conceptsPage.clickOnConceptCard('Network Protocols');
+  //   await conceptPage.clickOnContinueButton();
+  //   await conceptPage.clickOnContinueButton();
+  //   await conceptPage.questionCards[0].clickOnShowExplanationButton();
+  //   await conceptPage.clickOnContinueButton();
+  //   await conceptPage.clickOnContinueButton();
+  //   await conceptPage.clickOnContinueButton();
+
+  //   assert.strictEqual(conceptPage.questionCards[1].focusedOption.text, '1 layer');
+
+  //   await conceptPage.questionCards[0].keydown({ key: 'ArrowDown' }); // Send down arrow key
+  //   await conceptPage.questionCards[0].keydown({ key: 'ArrowDown' }); // Send down arrow key
+  //   await conceptPage.questionCards[0].keydown({ key: 'ArrowDown' }); // Send down arrow key
+  //   await conceptPage.questionCards[0].keydown({ key: 'ArrowDown' }); // Send down arrow key
+
+  //   assert.strictEqual(conceptPage.questionCards[1].focusedOption.text, '1 layer');
+  // });
+
+  // test('only published concepts are visible to users', async function (assert) {
+  //   testScenario(this.server);
+  //   createConcepts(this.server);
+
+  //   this.server.create('concept', {
+  //     slug: 'new-concept',
+  //     title: 'New Concept',
+  //     'description-markdown': 'This is a new concept.',
+  //     blocks: [
+  //       {
+  //         type: 'markdown',
+  //         args: {
+  //           markdown: `This is the first markdown block.`,
+  //         },
+  //       },
+  //     ],
+  //     status: 'draft',
+  //   });
+
+  //   signInAsSubscriber(this.owner, this.server);
+
+  //   await conceptsPage.visit();
+  //   assert.strictEqual(conceptsPage.conceptCards.length, 3, 'Only published concepts are visible to users');
+  //   assert.notOk(conceptsPage.conceptCards.map((card) => card.title).includes('New Concept'), 'Draft concepts are not visible to users');
+  // });
+
+  // test('draft concepts are visible to staff', async function (assert) {
+  //   testScenario(this.server);
+  //   createConcepts(this.server);
+
+  //   this.server.create('concept', {
+  //     slug: 'new-concept',
+  //     title: 'New Concept',
+  //     'description-markdown': 'This is a new concept.',
+  //     blocks: [
+  //       {
+  //         type: 'markdown',
+  //         args: {
+  //           markdown: `This is the first markdown block.`,
+  //         },
+  //       },
+  //     ],
+  //     status: 'draft',
+  //   });
+
+  //   signInAsStaff(this.owner, this.server);
+
+  //   await conceptsPage.visit();
+
+  //   assert.strictEqual(conceptsPage.conceptCards.length, 4, 'Draft concepts are visible to staff');
+  //   assert.strictEqual(conceptsPage.conceptCards[3].title, 'New Concept', 'Draft concepts are visible to staff');
+  //   assert.ok(conceptsPage.conceptCards[3].draftLabel.isVisible, 'Draft label is visible for draft concepts');
+
+  //   await conceptsPage.conceptCards[3].draftLabel.hover();
+
+  //   assertTooltipContent(assert, {
+  //     contentString: 'This concept is only visible to staff',
+  //   });
+  // });
+
+  // test('draft concepts are visible to concept author', async function (assert) {
+  //   testScenario(this.server);
+  //   createConcepts(this.server);
+
+  //   const user = this.server.create('user', {
+  //     id: 'user1',
+  //     avatarUrl: 'https://github.com/Gufran.png',
+  //     createdAt: new Date(),
+  //     githubUsername: 'Gufran',
+  //     username: 'Gufran',
+  //   });
+
+  //   this.server.create('concept', {
+  //     slug: 'new-concept',
+  //     title: 'New Concept',
+  //     'description-markdown': 'This is a new concept.',
+  //     blocks: [
+  //       {
+  //         type: 'markdown',
+  //         args: {
+  //           markdown: `This is the first markdown block.`,
+  //         },
+  //       },
+  //     ],
+  //     status: 'draft',
+  //     author: user,
+  //   });
+
+  //   signIn(this.owner, this.server, user);
+
+  //   await conceptsPage.visit();
+
+  //   assert.strictEqual(conceptsPage.conceptCards.length, 4, 'Draft concepts are visible to concept author');
+  //   assert.strictEqual(conceptsPage.conceptCards[3].title, 'New Concept', 'Draft concepts are visible to concept author');
+  //   assert.ok(conceptsPage.conceptCards[3].draftLabel.isVisible, 'Draft label is visible for draft concepts');
+  // });
 });

--- a/tests/acceptance/concepts-test.js
+++ b/tests/acceptance/concepts-test.js
@@ -12,7 +12,7 @@ import { module, test } from 'qunit';
 import { setupApplicationTest } from 'codecrafters-frontend/tests/helpers';
 import { setupWindowMock } from 'ember-window-mock/test-support';
 import { signIn, signInAsStaff, signInAsSubscriber } from 'codecrafters-frontend/tests/support/authentication-helpers';
-import { animationsSettled, setupAnimationTest } from 'ember-animated/test-support';
+import { setupAnimationTest } from 'ember-animated/test-support';
 import windowMock from 'ember-window-mock';
 import config from 'codecrafters-frontend/config/environment';
 

--- a/tests/acceptance/concepts-test.js
+++ b/tests/acceptance/concepts-test.js
@@ -134,9 +134,8 @@ module('Acceptance | concepts-test', function (hooks) {
       'Modal shows correct group access message',
     );
 
-    const expectedRedirectUrl = encodeURIComponent('/collections/network-primer');
-
     const conceptId = this.server.schema.concepts.findBy({ slug: 'network-protocols' }).id;
+    const expectedRedirectUrl = encodeURIComponent('/collections/network-primer');
     const nextUrl = config.x.backendUrl + '/concepts/' + conceptId + '/mark_as_complete?redirect_url=' + expectedRedirectUrl;
 
     await conceptPage.conceptCompletedModal.clickOnSignInButton();

--- a/tests/pages/concept-page.js
+++ b/tests/pages/concept-page.js
@@ -17,6 +17,13 @@ export default createPage({
     await animationsSettled();
   },
 
+  conceptCompletedModal: {
+    clickOnSignInButton: clickable('[data-test-concept-completed-modal-sign-in-button]'),
+    isVisible: isPresent(),
+    scope: '[data-test-concept-completed-modal]',
+    text: text(),
+  },
+
   progress: {
     barStyle: attribute('style', '[data-test-concept-progress-bar]'),
     scope: '[data-test-concept-progress]',
@@ -27,16 +34,19 @@ export default createPage({
       scope: '[data-test-question-card-body]',
       hasPrismHighlighting: hasClass('has-prism-highlighting'),
     },
-    focusedOption: {
-      scope: '[data-test-question-card-option]:focus',
-    },
-    selectOption: clickOnText('[data-test-question-card-option]'),
+
     clickOnSubmitButton: clickable('[data-test-question-card-submit-button]'),
     clickOnContinueButton: clickable('[data-test-question-card-continue-button]'),
     clickOnShowExplanationButton: clickable('[data-test-question-card-show-explanation-button]'),
+
+    focusedOption: {
+      scope: '[data-test-question-card-option]:focus',
+    },
+
     hasSubmitted: isPresent('[data-test-question-submitted]'),
     hasSubmittedText: text('[data-test-question-submitted]'),
     keydown: triggerable('keydown', '.question-card-option-container'),
+    selectOption: clickOnText('[data-test-question-card-option]'),
   }),
 
   shareConceptContainer: {
@@ -58,13 +68,6 @@ export default createPage({
     },
 
     scope: '[data-test-upcoming-concept]',
-  },
-
-  conceptCompletedModal: {
-    scope: '[data-test-concept-completed-modal]',
-    isVisible: isPresent(),
-    text: text(),
-    clickOnSignInButton: clickable('[data-test-concept-completed-modal-sign-in-button]'),
   },
 
   visit: visitable('/concept/:slug'),

--- a/tests/pages/concept-page.js
+++ b/tests/pages/concept-page.js
@@ -60,5 +60,12 @@ export default createPage({
     scope: '[data-test-upcoming-concept]',
   },
 
+  conceptCompletedModal: {
+    scope: '[data-test-concept-completed-modal]',
+    isVisible: isPresent(),
+    text: text(),
+    clickOnSignInButton: clickable('[data-test-concept-completed-modal-sign-in-button]'),
+  },
+
   visit: visitable('/concept/:slug'),
 });


### PR DESCRIPTION
Implement login functionality for the concept completed modal by adding a click handler that initiates GitHub authentication. The handler dynamically determines the redirect path based on the current concept group, ensuring users are returned to the appropriate section after signing in.

**Checklist**:

- [x] I've thoroughly self-reviewed my changes
- [x] I've added tests for my changes, unless they affect admin-only areas (or are otherwise not worth testing)
- [ ] I've verified any visual changes using Percy (add a commit with `[percy]` in the message to trigger)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a modal interface that appears when a concept is completed, displaying a celebratory message, a dynamic title, and a GitHub sign-in prompt with a brief authentication disclaimer.
  - Enhanced the sign-in process by refining the redirection logic to handle different URL formats for a smoother login experience.

- **Tests**
  - Expanded test coverage to verify modal visibility and content for anonymous users, ensuring proper redirection upon sign-in.
  - Added functionality to interact with the concept completed modal in acceptance tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->