### PR TITLE
Add keyboard event listeners only for currentBlock

### DIFF
--- a/app/components/blocks/concept-question-block.hbs
+++ b/app/components/blocks/concept-question-block.hbs
@@ -2,6 +2,7 @@
   <div ...attributes>
     {{! @glint-expect-error not ts-ified yet }}
     <ConceptPage::QuestionCard
+      @isCurrentBlock={{@isCurrentBlock}}
       @question={{this.question}}
       @onSubmit={{this.handleSubmit}}
       class="w-full max-w-xl"

--- a/app/components/blocks/concept-question-block.hbs
+++ b/app/components/blocks/concept-question-block.hbs
@@ -1,6 +1,5 @@
 {{#if this.question}}
   <div ...attributes>
-    {{! @glint-expect-error not ts-ified yet }}
     <ConceptPage::QuestionCard
       @isCurrentBlock={{@isCurrentBlock}}
       @question={{this.question}}

--- a/app/components/concept-page/question-card.hbs
+++ b/app/components/concept-page/question-card.hbs
@@ -16,22 +16,24 @@
         />
       {{/each}}
 
-      {{! @glint-expect-error incorrect type - event object is passed to handler}}
-      {{on-key "k" this.handleMoveUp}}
-      {{! @glint-expect-error incorrect type - event object is passed to handler}}
-      {{on-key "j" this.handleMoveDown}}
-      {{! @glint-expect-error incorrect type - event object is passed to handler}}
-      {{on-key "ArrowUp" this.handleMoveUp}}
-      {{! @glint-expect-error incorrect type - event object is passed to handler}}
-      {{on-key "ArrowDown" this.handleMoveDown}}
+      {{#if @isCurrentBlock}}
+        {{! @glint-expect-error incorrect type - event object is passed to handler}}
+        {{on-key "k" this.handleMoveUp}}
+        {{! @glint-expect-error incorrect type - event object is passed to handler}}
+        {{on-key "j" this.handleMoveDown}}
+        {{! @glint-expect-error incorrect type - event object is passed to handler}}
+        {{on-key "ArrowUp" this.handleMoveUp}}
+        {{! @glint-expect-error incorrect type - event object is passed to handler}}
+        {{on-key "ArrowDown" this.handleMoveDown}}
 
-      {{#each this.digitKeys as |digitKey digitKeyIndex|}}
-        {{on-key digitKey (fn this.handleOptionSelected digitKeyIndex)}}
-      {{/each}}
+        {{#each this.digitKeys as |digitKey digitKeyIndex|}}
+          {{on-key digitKey (fn this.handleOptionSelected digitKeyIndex)}}
+        {{/each}}
 
-      {{#each this.letterKeys as |letterKey letterKeyIndex|}}
-        {{on-key letterKey (fn this.handleOptionSelected letterKeyIndex)}}
-      {{/each}}
+        {{#each this.letterKeys as |letterKey letterKeyIndex|}}
+          {{on-key letterKey (fn this.handleOptionSelected letterKeyIndex)}}
+        {{/each}}
+      {{/if}}
     </div>
   </div>
 

--- a/app/components/concept-page/question-card.ts
+++ b/app/components/concept-page/question-card.ts
@@ -11,6 +11,7 @@ interface Signature {
   Element: HTMLDivElement;
 
   Args: {
+    isCurrentBlock: boolean;
     question: ConceptQuestionModel;
     onSubmit: () => void;
   };

--- a/app/components/concept-page/question-card.ts
+++ b/app/components/concept-page/question-card.ts
@@ -159,3 +159,9 @@ export default class QuestionCardComponent extends Component<Signature> {
     this.handleOptionSelected(this.args.question.correctOptionIndex);
   }
 }
+
+declare module '@glint/environment-ember-loose/registry' {
+  export default interface Registry {
+    'ConceptPage::QuestionCard': typeof QuestionCardComponent;
+  }
+}

--- a/tests/acceptance/concepts-test.js
+++ b/tests/acceptance/concepts-test.js
@@ -499,41 +499,6 @@ module('Acceptance | concepts-test', function (hooks) {
 
     await conceptPage.questionCards[0].focusedOption.click(); // Simulate ENTER on focused option
     assert.true(conceptPage.questionCards[0].hasSubmitted, 'the question has been submitted');
-
-    await conceptPage.clickOnContinueButton();
-    await conceptPage.clickOnContinueButton();
-    await conceptPage.clickOnContinueButton();
-    await conceptPage.questionCards[1].clickOnShowExplanationButton();
-    await conceptPage.clickOnContinueButton();
-    await conceptPage.clickOnContinueButton();
-    await conceptPage.clickOnContinueButton();
-
-    assert.strictEqual(conceptPage.questionCards[2].focusedOption.text, 'Ethernet');
-    await conceptPage.questionCards[2].keydown({ keyCode: 74 }); // Send j key
-    assert.strictEqual(conceptPage.questionCards[2].focusedOption.text, 'HTTP');
-    await conceptPage.questionCards[2].keydown({ keyCode: 74 }); // Send j key
-    assert.strictEqual(conceptPage.questionCards[2].focusedOption.text, 'FTP');
-    await conceptPage.questionCards[2].keydown({ keyCode: 74 }); // Send j key
-    assert.strictEqual(conceptPage.questionCards[2].focusedOption.text, 'SMTP');
-
-    await conceptPage.questionCards[2].clickOnShowExplanationButton();
-    await conceptPage.clickOnContinueButton();
-    await conceptPage.clickOnContinueButton();
-    await conceptPage.clickOnContinueButton();
-    await conceptPage.clickOnContinueButton();
-    await conceptPage.clickOnContinueButton();
-    await conceptPage.clickOnContinueButton();
-    await conceptPage.questionCards[3].clickOnShowExplanationButton();
-    await conceptPage.clickOnContinueButton();
-    await conceptPage.clickOnContinueButton();
-    await conceptPage.clickOnContinueButton();
-    await conceptPage.clickOnContinueButton();
-    await conceptPage.clickOnContinueButton();
-
-    await conceptPage.upcomingConcept.card.click();
-    assert.strictEqual(currentURL(), '/concepts/tcp-overview', 'Clicking on the upcoming concept card navigates to the next concept');
-    assert.strictEqual(conceptPage.blocks.length, 1, 'The progress is reset when navigating to a new concept');
-    assert.strictEqual(window.scrollY, 0, 'The page is scrolled to the top when navigating to a new concept');
   });
 
   test('while navigating using keys, options are traversed one at a time', async function (assert) {

--- a/tests/acceptance/concepts-test.js
+++ b/tests/acceptance/concepts-test.js
@@ -500,7 +500,7 @@ module('Acceptance | concepts-test', function (hooks) {
     await conceptPage.questionCards[0].focusedOption.click(); // Simulate ENTER on focused option
     assert.true(conceptPage.questionCards[0].hasSubmitted, 'the question has been submitted');
 
-        await conceptPage.clickOnContinueButton();
+    await conceptPage.clickOnContinueButton();
     await conceptPage.clickOnContinueButton();
     await conceptPage.clickOnContinueButton();
     await conceptPage.questionCards[1].clickOnShowExplanationButton();
@@ -535,7 +535,7 @@ module('Acceptance | concepts-test', function (hooks) {
     assert.strictEqual(conceptPage.blocks.length, 1, 'The progress is reset when navigating to a new concept');
     assert.strictEqual(window.scrollY, 0, 'The page is scrolled to the top when navigating to a new concept');
   });
-    
+
   test('while navigating using keys, options are traversed one at a time', async function (assert) {
     testScenario(this.server);
     createConcepts(this.server);

--- a/tests/acceptance/concepts-test.js
+++ b/tests/acceptance/concepts-test.js
@@ -499,6 +499,96 @@ module('Acceptance | concepts-test', function (hooks) {
 
     await conceptPage.questionCards[0].focusedOption.click(); // Simulate ENTER on focused option
     assert.true(conceptPage.questionCards[0].hasSubmitted, 'the question has been submitted');
+
+        await conceptPage.clickOnContinueButton();
+    await conceptPage.clickOnContinueButton();
+    await conceptPage.clickOnContinueButton();
+    await conceptPage.questionCards[1].clickOnShowExplanationButton();
+    await conceptPage.clickOnContinueButton();
+    await conceptPage.clickOnContinueButton();
+    await conceptPage.clickOnContinueButton();
+
+    assert.strictEqual(conceptPage.questionCards[2].focusedOption.text, 'Ethernet');
+    await conceptPage.questionCards[2].keydown({ keyCode: 74 }); // Send j key
+    assert.strictEqual(conceptPage.questionCards[2].focusedOption.text, 'HTTP');
+    await conceptPage.questionCards[2].keydown({ keyCode: 74 }); // Send j key
+    assert.strictEqual(conceptPage.questionCards[2].focusedOption.text, 'FTP');
+    await conceptPage.questionCards[2].keydown({ keyCode: 74 }); // Send j key
+    assert.strictEqual(conceptPage.questionCards[2].focusedOption.text, 'SMTP');
+
+    await conceptPage.questionCards[2].clickOnShowExplanationButton();
+    await conceptPage.clickOnContinueButton();
+    await conceptPage.clickOnContinueButton();
+    await conceptPage.clickOnContinueButton();
+    await conceptPage.clickOnContinueButton();
+    await conceptPage.clickOnContinueButton();
+    await conceptPage.clickOnContinueButton();
+    await conceptPage.questionCards[3].clickOnShowExplanationButton();
+    await conceptPage.clickOnContinueButton();
+    await conceptPage.clickOnContinueButton();
+    await conceptPage.clickOnContinueButton();
+    await conceptPage.clickOnContinueButton();
+    await conceptPage.clickOnContinueButton();
+
+    await conceptPage.upcomingConcept.card.click();
+    assert.strictEqual(currentURL(), '/concepts/tcp-overview', 'Clicking on the upcoming concept card navigates to the next concept');
+    assert.strictEqual(conceptPage.blocks.length, 1, 'The progress is reset when navigating to a new concept');
+    assert.strictEqual(window.scrollY, 0, 'The page is scrolled to the top when navigating to a new concept');
+  });
+    
+  test('while navigating using keys, options are traversed one at a time', async function (assert) {
+    testScenario(this.server);
+    createConcepts(this.server);
+
+    signInAsStaff(this.owner, this.server);
+
+    this.server.schema.conceptGroups.create({
+      conceptSlugs: ['network-protocols', 'tcp-overview'],
+      descriptionMarkdown: 'This is a group about network concepts',
+      slug: 'network-primer',
+      title: 'Network Primer',
+    });
+
+    await conceptsPage.visit();
+    await conceptsPage.clickOnConceptCard('Network Protocols');
+    await conceptPage.clickOnContinueButton();
+    await conceptPage.clickOnContinueButton();
+    await conceptPage.questionCards[0].selectOption('PDF');
+    await conceptPage.clickOnContinueButton();
+    await conceptPage.clickOnContinueButton();
+    await conceptPage.clickOnContinueButton();
+    await conceptPage.questionCards[1].clickOnShowExplanationButton();
+    await conceptPage.clickOnContinueButton();
+    await conceptPage.clickOnContinueButton();
+    await conceptPage.clickOnContinueButton();
+
+    // Question 3
+    assert.strictEqual(conceptPage.questionCards[2].focusedOption.text, 'Ethernet');
+    await conceptPage.questionCards[2].keydown({ keyCode: 74 }); // Send j key
+    assert.strictEqual(conceptPage.questionCards[2].focusedOption.text, 'HTTP');
+    await conceptPage.questionCards[2].keydown({ keyCode: 74 }); // Send j key
+    assert.strictEqual(conceptPage.questionCards[2].focusedOption.text, 'FTP');
+    await conceptPage.questionCards[2].keydown({ keyCode: 74 }); // Send j key
+    assert.strictEqual(conceptPage.questionCards[2].focusedOption.text, 'SMTP');
+
+    await conceptPage.questionCards[2].clickOnShowExplanationButton();
+    await conceptPage.clickOnContinueButton();
+    await conceptPage.clickOnContinueButton();
+    await conceptPage.clickOnContinueButton();
+    await conceptPage.clickOnContinueButton();
+    await conceptPage.clickOnContinueButton();
+    await conceptPage.clickOnContinueButton();
+    await conceptPage.questionCards[3].clickOnShowExplanationButton();
+    await conceptPage.clickOnContinueButton();
+    await conceptPage.clickOnContinueButton();
+    await conceptPage.clickOnContinueButton();
+    await conceptPage.clickOnContinueButton();
+    await conceptPage.clickOnContinueButton();
+
+    await conceptPage.upcomingConcept.card.click();
+    assert.strictEqual(currentURL(), '/concepts/tcp-overview', 'Clicking on the upcoming concept card navigates to the next concept');
+    assert.strictEqual(conceptPage.blocks.length, 1, 'The progress is reset when navigating to a new concept');
+    assert.strictEqual(window.scrollY, 0, 'The page is scrolled to the top when navigating to a new concept');
   });
 
   test('can navigate using arrow keys and select option using enter', async function (assert) {


### PR DESCRIPTION
Introduce an `isCurrentBlock` property to manage keyboard event listeners conditionally, enhancing user interaction with concept question blocks. Add comprehensive tests to ensure proper navigation and interaction functionality.

**Checklist**:

- [x] I've thoroughly self-reviewed my changes
- [x] I've added tests for my changes, unless they affect admin-only areas (or are otherwise not worth testing)
- [ ] I've verified any visual changes using Percy (add a commit with `[percy]` in the message to trigger)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced question navigation: Keyboard shortcuts now activate only when the question is in focus, ensuring precise and context-aware interactions.
	- Improved selection experience: This update reduces unintended actions during option navigation, offering a smoother and more intuitive process.
	- New property added to the QuestionCard component to enhance its context awareness.
- **Tests**
	- Added a test case to verify keyboard navigation through question options, ensuring sequential traversal and correct focus updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->