### PR TITLE
fix: correct spelling of "frontend" in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # codecrafters-frontend
 
-The front-end app that powers [app.codecrafters.io](https://app.codecrafters.io).
+The frontend app that powers [app.codecrafters.io](https://app.codecrafters.io).
 
 ## Prerequisites
 


### PR DESCRIPTION
Update the README.md file to change "front-end" to "frontend" for 
consistency and accuracy. This improves clarity and aligns with 
common terminology in web development.