### PR TITLE
Update how concept progress is rendered when progress is 0%

### DIFF
--- a/app/components/concept-card/progress-bar.hbs
+++ b/app/components/concept-card/progress-bar.hbs
@@ -4,25 +4,23 @@
       class="{{if (eq @latestConceptEngagement.currentProgressPercentage 100) 'bg-teal-100 dark:bg-teal-900' 'bg-blue-100 dark:bg-blue-900'}}
         h-3 w-16 flex items-stretch"
     >
-      {{#if (eq @latestConceptEngagement.currentProgressPercentage 0)}}
-        <div class="bg-blue-500 w-1/12"></div>
-      {{else}}
-        <div
-          class="{{if (eq @latestConceptEngagement.currentProgressPercentage 100) 'bg-teal-500 dark:bg-teal-600' 'bg-blue-500 dark:bg-blue-600'}}"
-          style={{html-safe (concat "width: " @latestConceptEngagement.currentProgressPercentage "%")}}
-          data-test-concept-card-progress-bar
-        ></div>
-      {{/if}}
+      <div
+        class="{{if (eq @latestConceptEngagement.currentProgressPercentage 100) 'bg-teal-500 dark:bg-teal-600' 'bg-blue-500 dark:bg-blue-600'}}"
+        style={{html-safe (concat "width: " @latestConceptEngagement.currentProgressPercentage "%")}}
+        data-test-concept-card-progress-bar
+      ></div>
     </div>
   </div>
 
-  <div
-    class="text-xs
-      {{if (eq @latestConceptEngagement.currentProgressPercentage 100) 'text-teal-500 dark:text-teal-600' 'text-blue-500 dark:text-blue-600'}}
-      mr-3"
-    data-test-concept-card-progress-text
-  >
-    <b class="font-bold">{{@latestConceptEngagement.currentProgressPercentage}}%</b>
-    complete
-  </div>
+  {{#if (gt @latestConceptEngagement.currentProgressPercentage 0)}}
+    <div
+      class="text-xs
+        {{if (eq @latestConceptEngagement.currentProgressPercentage 100) 'text-teal-500 dark:text-teal-600' 'text-blue-500 dark:text-blue-600'}}
+        mr-3"
+      data-test-concept-card-progress-text
+    >
+      <b class="font-bold">{{@latestConceptEngagement.currentProgressPercentage}}%</b>
+      complete
+    </div>
+  {{/if}}
 </div>

--- a/app/components/concept-card/progress-bar.hbs
+++ b/app/components/concept-card/progress-bar.hbs
@@ -12,15 +12,13 @@
     </div>
   </div>
 
-  {{#if (gt @latestConceptEngagement.currentProgressPercentage 0)}}
-    <div
-      class="text-xs
-        {{if (eq @latestConceptEngagement.currentProgressPercentage 100) 'text-teal-500 dark:text-teal-600' 'text-blue-500 dark:text-blue-600'}}
-        mr-3"
-      data-test-concept-card-progress-text
-    >
-      <b class="font-bold">{{@latestConceptEngagement.currentProgressPercentage}}%</b>
-      complete
-    </div>
-  {{/if}}
+  <div
+    class="text-xs
+      {{if (eq @latestConceptEngagement.currentProgressPercentage 100) 'text-teal-500 dark:text-teal-600' 'text-blue-500 dark:text-blue-600'}}
+      mr-3"
+    data-test-concept-card-progress-text
+  >
+    <b class="font-bold">{{@latestConceptEngagement.currentProgressPercentage}}%</b>
+    complete
+  </div>
 </div>

--- a/app/components/concepts-page/concept-card.hbs
+++ b/app/components/concepts-page/concept-card.hbs
@@ -38,6 +38,7 @@
             completed
           </span>
         {{else}}
+          {{! @glint-expect-error: incorrectly assumes @latestConceptEngagement is nullable }}
           <ConceptCard::ProgressBar @latestConceptEngagement={{this.latestConceptEngagement}} class="flex shrink-0" />
         {{/if}}
       {{else}}

--- a/app/components/concepts-page/concept-card.hbs
+++ b/app/components/concepts-page/concept-card.hbs
@@ -30,7 +30,7 @@
   {{! Footer }}
   <div class="flex items-center justify-between">
     <div class="flex items-center">
-      {{#if this.latestConceptEngagement}}
+      {{#if (and this.latestConceptEngagement (gt this.latestConceptEngagement.currentProgressPercentage 0))}}
         {{#if (eq this.latestConceptEngagement.currentProgressPercentage 100)}}
           {{svg-jar "check-circle" class="w-4 mr-1 fill-current text-teal-500"}}
 

--- a/app/components/concepts-page/concept-card.hbs
+++ b/app/components/concepts-page/concept-card.hbs
@@ -44,7 +44,7 @@
       {{else}}
         {{svg-jar "clock" class="w-4 mr-1 fill-current text-gray-300 dark:text-gray-700"}}
 
-        <span class="text-xs text-gray-400 dark:text-gray-600">
+        <span class="text-xs text-gray-400 dark:text-gray-600" data-test-concept-card-reading-time>
           {{@concept.estimatedReadingTimeInMinutes}}
           mins
         </span>

--- a/app/routes/concept-group.ts
+++ b/app/routes/concept-group.ts
@@ -28,10 +28,7 @@ export default class ConceptGroupRoute extends BaseRoute {
   }
 
   async model(params: { concept_group_slug: string }) {
-    // const conceptGroup = await this.store.queryRecord('concept-group', { slug: params.concept_group_slug, include: 'author' });
-
-    const allConceptGroups = await this.store.findAll('concept-group', { include: 'author' });
-    const conceptGroup = allConceptGroups.find((group) => group.slug === params.concept_group_slug);
+    const conceptGroup = await this.store.queryRecord('concept-group', { slug: params.concept_group_slug, include: 'author' });
 
     if (!conceptGroup) {
       this.router.transitionTo('/');

--- a/app/routes/concept-group.ts
+++ b/app/routes/concept-group.ts
@@ -28,7 +28,10 @@ export default class ConceptGroupRoute extends BaseRoute {
   }
 
   async model(params: { concept_group_slug: string }) {
-    const conceptGroup = await this.store.queryRecord('concept-group', { slug: params.concept_group_slug, include: 'author' });
+    // const conceptGroup = await this.store.queryRecord('concept-group', { slug: params.concept_group_slug, include: 'author' });
+
+    const allConceptGroups = await this.store.findAll('concept-group', { include: 'author' });
+    const conceptGroup = allConceptGroups.find((group) => group.slug === params.concept_group_slug);
 
     if (!conceptGroup) {
       this.router.transitionTo('/');

--- a/app/routes/concept.ts
+++ b/app/routes/concept.ts
@@ -45,6 +45,7 @@ export default class ConceptRoute extends BaseRoute {
       return await this.store.createRecord('concept-engagement', {
         concept,
         user: this.authenticator.currentUser,
+        currentProgressPercentage: 0,
       });
     }
 

--- a/mirage/handlers/concept-groups.js
+++ b/mirage/handlers/concept-groups.js
@@ -1,10 +1,17 @@
 export default function (server) {
-  server.get('/concept-groups', function (schema) {
+  server.get('/concept-groups', function (schema, request) {
+    if (request.queryParams.slug) {
+      return schema.conceptGroups.where({ slug: request.queryParams.slug });
+    }
     return schema.conceptGroups.all();
   });
 
   server.get('/concept-groups/:concept_group_slug', function (schema, request) {
     let result = schema.conceptGroups.where({ slug: request.params.concept_group_slug });
+
+    if (result.models.length === 0) {
+      return new Response(404, {}, { errors: ['Concept group not found'] });
+    }
 
     return result.models[0];
   });

--- a/mirage/handlers/concept-groups.js
+++ b/mirage/handlers/concept-groups.js
@@ -3,6 +3,7 @@ export default function (server) {
     if (request.queryParams.slug) {
       return schema.conceptGroups.where({ slug: request.queryParams.slug });
     }
+
     return schema.conceptGroups.all();
   });
 

--- a/tests/acceptance/concept-groups-test.js
+++ b/tests/acceptance/concept-groups-test.js
@@ -59,4 +59,15 @@ module('Acceptance | concept-groups-test', function (hooks) {
     assert.strictEqual(conceptGroupsPage.conceptCards[0].title, 'TCP: An Overview');
     assert.strictEqual(conceptGroupsPage.conceptCards[1].title, 'Network Protocols');
   });
+
+  test('displays no progress bar if progress percentage is 0', async function (assert) {
+    await conceptGroupsPage.visit({ concept_group_slug: this.conceptGroup.slug });
+
+    await conceptGroupsPage.clickOnConceptCard('TCP: An Overview');
+    
+    await conceptGroupsPage.visit({ concept_group_slug: this.conceptGroup.slug });
+    
+    assert.false(conceptGroupsPage.conceptCards[0].hasProgressBar, 'Progress bar should not be visible after returning from concept');
+    assert.strictEqual(conceptGroupsPage.conceptCards[0].readingTime, '8 mins', 'Reading time should be visible after returning from concept');
+  });
 });

--- a/tests/acceptance/concept-groups-test.js
+++ b/tests/acceptance/concept-groups-test.js
@@ -16,49 +16,34 @@ function createConcepts(server) {
 module('Acceptance | concept-groups-test', function (hooks) {
   setupApplicationTest(hooks);
 
-  test('displays concept-group page when visiting a valid concept-group', async function (assert) {
+  hooks.beforeEach(function () {
     testScenario(this.server);
     createConcepts(this.server);
 
     const user = this.server.schema.users.first();
-
-    const conceptGroup = this.server.create('concept-group', {
+    this.conceptGroup = this.server.create('concept-group', {
       author: user,
       description_markdown: 'Dummy description',
       concept_slugs: ['tcp-overview', 'network-protocols'],
       slug: 'test-concept-group',
       title: 'Test Concept Group',
     });
+  });
 
-    await conceptGroupsPage.visit({ concept_group_slug: conceptGroup.slug });
+  test('displays concept-group page when visiting a valid concept-group', async function (assert) {
+    await conceptGroupsPage.visit({ concept_group_slug: this.conceptGroup.slug });
 
     assert.strictEqual(currentURL(), '/collections/test-concept-group');
   });
 
   test('redirects to / when visiting a non-existing concept-group', async function (assert) {
-    testScenario(this.server);
-    createConcepts(this.server);
-
-    await conceptGroupsPage.visit({ concept_group_slug: 'non-existent-concept-group' });
+    await conceptGroupsPage.visit({ concept_group_slug: 'nonexistent-concept-group' });
 
     assert.strictEqual(currentURL(), '/catalog');
   });
 
   test('displays the correct concept group details for the header', async function (assert) {
-    testScenario(this.server);
-    createConcepts(this.server);
-
-    const user = this.server.schema.users.first();
-
-    const conceptGroup = this.server.create('concept-group', {
-      author: user,
-      description_markdown: 'Dummy description',
-      concept_slugs: ['tcp-overview', 'network-protocols'],
-      slug: 'test-concept-group',
-      title: 'Test Concept Group',
-    });
-
-    await conceptGroupsPage.visit({ concept_group_slug: conceptGroup.slug });
+    await conceptGroupsPage.visit({ concept_group_slug: this.conceptGroup.slug });
     await percySnapshot('Concept Group');
 
     assert.strictEqual(conceptGroupsPage.header.title, 'Test Concept Group');
@@ -68,20 +53,7 @@ module('Acceptance | concept-groups-test', function (hooks) {
   });
 
   test('displays the correct concept cards', async function (assert) {
-    testScenario(this.server);
-    createConcepts(this.server);
-
-    const user = this.server.schema.users.first();
-
-    const conceptGroup = this.server.create('concept-group', {
-      author: user,
-      description_markdown: 'Dummy description',
-      concept_slugs: ['tcp-overview', 'network-protocols'],
-      slug: 'test-concept-group',
-      title: 'Test Concept Group',
-    });
-
-    await conceptGroupsPage.visit({ concept_group_slug: conceptGroup.slug });
+    await conceptGroupsPage.visit({ concept_group_slug: this.conceptGroup.slug });
 
     assert.strictEqual(conceptGroupsPage.conceptCards.length, 2);
     assert.strictEqual(conceptGroupsPage.conceptCards[0].title, 'TCP: An Overview');

--- a/tests/acceptance/concept-groups-test.js
+++ b/tests/acceptance/concept-groups-test.js
@@ -64,9 +64,9 @@ module('Acceptance | concept-groups-test', function (hooks) {
     await conceptGroupsPage.visit({ concept_group_slug: this.conceptGroup.slug });
 
     await conceptGroupsPage.clickOnConceptCard('TCP: An Overview');
-    
+
     await conceptGroupsPage.visit({ concept_group_slug: this.conceptGroup.slug });
-    
+
     assert.false(conceptGroupsPage.conceptCards[0].hasProgressBar, 'Progress bar should not be visible after returning from concept');
     assert.strictEqual(conceptGroupsPage.conceptCards[0].readingTime, '8 mins', 'Reading time should be visible after returning from concept');
   });

--- a/tests/pages/concept-groups-page.ts
+++ b/tests/pages/concept-groups-page.ts
@@ -10,10 +10,10 @@ export default createPage({
   },
 
   conceptCards: collection('[data-test-concept-card]', {
-    title: text('[data-test-concept-title]'),
     hasProgressBar: isPresent('[data-test-concept-card-progress]'),
     progressBarText: text('[data-test-concept-card-progress-bar]'),
     readingTime: text('[data-test-concept-card-reading-time]'),
+    title: text('[data-test-concept-title]'),
   }),
 
   header: {

--- a/tests/pages/concept-groups-page.ts
+++ b/tests/pages/concept-groups-page.ts
@@ -1,4 +1,4 @@
-import { collection, text, visitable } from 'ember-cli-page-object';
+import { collection, isPresent, text, visitable } from 'ember-cli-page-object';
 import createPage from 'codecrafters-frontend/tests/support/create-page';
 
 export default createPage({
@@ -11,6 +11,9 @@ export default createPage({
 
   conceptCards: collection('[data-test-concept-card]', {
     title: text('[data-test-concept-title]'),
+    hasProgressBar: isPresent('[data-test-concept-card-progress]'),
+    progressBarText: text('[data-test-concept-card-progress-bar]'),
+    readingTime: text('[data-test-concept-card-reading-time]'),
   }),
 
   header: {


### PR DESCRIPTION
**Checklist**:

- [x] I've thoroughly self-reviewed my changes
- [x] I've added tests for my changes, unless they affect admin-only areas (or are otherwise not worth testing)
- [ ] I've verified any visual changes using Percy (add a commit with `[percy]` in the message to trigger)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Streamlined progress indicator display on concept cards so that the progress bar consistently appears while the completion percentage text is shown only when actual progress exists.

- **New Features**
  - Enhanced concept group handling by enabling query-based filtering and providing clearer error messaging when a requested concept group isn’t found.
  - Introduced new properties for concept cards, including indicators for progress bar presence and reading time.

- **Tests**
  - Improved test structure for concept groups, adding checks for progress bar visibility based on progress percentage.
  - Enhanced test cases for concept groups to utilize shared setup and verify progress bar display conditions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->