### PR TITLE
fix: improve focus and hover states for question card options

### DIFF
--- a/app/components/concept-page/question-card-option.hbs
+++ b/app/components/concept-page/question-card-option.hbs
@@ -2,7 +2,7 @@
   type="button"
   tabindex={{if @isSubmitted "-1" "0"}}
   class="flex items-start text-left gap-2 py-2
-    {{if this.isUnselected 'hover:bg-gray-100 focus:bg-gray-100'}}
+    {{if this.isUnselected 'hover:bg-gray-100 focus-visible:bg-gray-100'}}
     {{if this.isUnselectedAndCorrect 'bg-green-200'}}
     {{if this.isSelectedAndUnsubmitted 'bg-gray-100'}}
     {{if this.isSelectedAndCorrect 'bg-green-200'}}

--- a/app/components/concept-page/question-card.ts
+++ b/app/components/concept-page/question-card.ts
@@ -75,14 +75,14 @@ export default class QuestionCardComponent extends Component<Signature> {
 
   @action
   handleDidInsertOptionsList(element: HTMLElement) {
-    // const firstOptionElement = element.children[0];
+    const firstOptionElement = element.children[0];
 
-    // if (firstOptionElement instanceof HTMLElement) {
-    //   // focus() doesn't seem to work unless it's called after the current runloop
-    //   next(() => {
-    //     firstOptionElement?.focus({ preventScroll: true });
-    //   });
-    // }
+    if (firstOptionElement instanceof HTMLElement) {
+      // focus() doesn't seem to work unless it's called after the current runloop
+      next(() => {
+        firstOptionElement?.focus({ preventScroll: true });
+      });
+    }
   }
 
   @action

--- a/app/components/concept-page/question-card.ts
+++ b/app/components/concept-page/question-card.ts
@@ -75,14 +75,14 @@ export default class QuestionCardComponent extends Component<Signature> {
 
   @action
   handleDidInsertOptionsList(element: HTMLElement) {
-    const firstOptionElement = element.children[0];
+    // const firstOptionElement = element.children[0];
 
-    if (firstOptionElement instanceof HTMLElement) {
-      // focus() doesn't seem to work unless it's called after the current runloop
-      next(() => {
-        firstOptionElement?.focus({ preventScroll: true });
-      });
-    }
+    // if (firstOptionElement instanceof HTMLElement) {
+    //   // focus() doesn't seem to work unless it's called after the current runloop
+    //   next(() => {
+    //     firstOptionElement?.focus({ preventScroll: true });
+    //   });
+    // }
   }
 
   @action


### PR DESCRIPTION
**Checklist**:

- [x] I've thoroughly self-reviewed my changes
- [ ] I've added tests for my changes, unless they affect admin-only areas (or are otherwise not worth testing)
- [ ] I've verified any visual changes using Percy (add a commit with `[percy]` in the message to trigger)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Updated the option button's focus visuals to activate only when clearly intended, enhancing accessibility and visual feedback.
- **Refactor**
  - Removed the automatic focus on the first option when options appear, giving users more control over their selection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->