### PR TITLE
Prerender Concept pages with Vercel Prerender Functions

### DIFF
--- a/app/components/concept/index.ts
+++ b/app/components/concept/index.ts
@@ -35,7 +35,7 @@ export default class ConceptComponent extends Component<Signature> {
     super(owner, args);
 
     // Temporary hack to allow for deep linking to a specific block group. (Only for admins)
-    const urlParams = new URLSearchParams(window.location.search);
+    const urlParams = new URLSearchParams(window?.location?.search || '');
     const bgiQueryParam = urlParams.get('bgi');
 
     if (bgiQueryParam) {

--- a/app/routes/concept.ts
+++ b/app/routes/concept.ts
@@ -6,6 +6,7 @@ import ConceptModel from 'codecrafters-frontend/models/concept';
 import ConceptGroupModel from 'codecrafters-frontend/models/concept-group';
 import ConceptEngagementModel from 'codecrafters-frontend/models/concept-engagement';
 import AuthenticatorService from 'codecrafters-frontend/services/authenticator';
+import type MetaDataService from 'codecrafters-frontend/services/meta-data';
 import RouterService from '@ember/routing/router-service';
 import Store from '@ember-data/store';
 import RouteInfoMetadata, { HelpscoutBeaconVisibility } from 'codecrafters-frontend/utils/route-info-metadata';
@@ -22,6 +23,11 @@ export default class ConceptRoute extends BaseRoute {
   @service declare authenticator: AuthenticatorService;
   @service declare router: RouterService;
   @service declare store: Store;
+  @service declare metaData: MetaDataService;
+
+  previousMetaImageUrl: string | undefined;
+  previousMetaTitle: string | undefined;
+  previousMetaDescription: string | undefined;
 
   constructor(...args: object[]) {
     super(...args);
@@ -31,8 +37,31 @@ export default class ConceptRoute extends BaseRoute {
     });
   }
 
+  afterModel({ concept }: ConceptRouteModel): void {
+    // Save previous OG meta tags
+    this.previousMetaImageUrl = this.metaData.imageUrl;
+    this.previousMetaTitle = this.metaData.title;
+    this.previousMetaDescription = this.metaData.description;
+
+    // Override OG meta tags with concept-specific ones
+    this.metaData.imageUrl = `https://og.codecrafters.io/api/concept/${concept.slug}`;
+    this.metaData.title =
+      concept.title ||
+      concept.slug // Fallback to converting the slug to title: network-protocols > Network Protocols
+        .split('-')
+        .map((word) => word.charAt(0).toUpperCase() + word.slice(1).toLowerCase())
+        .join(' ');
+    this.metaData.description = concept.descriptionMarkdown || `View the ${this.metaData.title} concept on CodeCrafters`;
+  }
+
   buildRouteInfoMetadata() {
     return new RouteInfoMetadata({ beaconVisibility: HelpscoutBeaconVisibility.Hidden });
+  }
+
+  deactivate() {
+    this.metaData.imageUrl = this.previousMetaImageUrl;
+    this.metaData.title = this.previousMetaTitle;
+    this.metaData.description = this.previousMetaDescription;
   }
 
   async findOrCreateConceptEngagement(concept: ConceptModel) {

--- a/app/routes/concept.ts
+++ b/app/routes/concept.ts
@@ -21,9 +21,9 @@ export type ConceptRouteModel = {
 export default class ConceptRoute extends BaseRoute {
   allowsAnonymousAccess = true;
   @service declare authenticator: AuthenticatorService;
+  @service declare metaData: MetaDataService;
   @service declare router: RouterService;
   @service declare store: Store;
-  @service declare metaData: MetaDataService;
 
   previousMetaImageUrl: string | undefined;
   previousMetaTitle: string | undefined;

--- a/config/fastboot.js
+++ b/config/fastboot.js
@@ -12,6 +12,7 @@ module.exports = function (/* environment */) {
     buildSandboxGlobals(defaultGlobals) {
       return Object.assign({}, defaultGlobals, {
         AbortController,
+        URLSearchParams,
       });
     },
   };

--- a/vercel-functions/prerender/_prerender-ember-route.func/index.js
+++ b/vercel-functions/prerender/_prerender-ember-route.func/index.js
@@ -12,6 +12,7 @@ export default async function prerenderEmberRoute(request, response) {
     buildSandboxGlobals(defaultGlobals) {
       return Object.assign({}, defaultGlobals, {
         AbortController,
+        URLSearchParams,
       });
     },
 

--- a/vercel-functions/prerender/concepts/[concept].func
+++ b/vercel-functions/prerender/concepts/[concept].func
@@ -1,0 +1,1 @@
+../_prerender-ember-route.func

--- a/vercel-functions/prerender/concepts/[concept].prerender-config.json
+++ b/vercel-functions/prerender/concepts/[concept].prerender-config.json
@@ -1,0 +1,5 @@
+{
+  "expiration": 86400,
+  "allowQuery": ["concept"],
+  "passQuery": true
+}

--- a/vercel.json
+++ b/vercel.json
@@ -14,6 +14,7 @@
     { "source": "/submissions/:match*", "destination": "https://backend.codecrafters.io/submissions/:match*" },
     { "source": "/progress/:match*", "destination": "https://backend.codecrafters.io/progress/:match*" },
     { "source": "/users/:user", "destination": "/prerender/users/[user]" },
+    { "source": "/concepts/:concept", "destination": "/prerender/concepts/[concept]" },
     { "source": "/:path*", "destination": "/_empty.html" }
   ],
   "github": {

--- a/vercel.json
+++ b/vercel.json
@@ -10,11 +10,11 @@
     { "source": "/r/famous-wombat-417894", "destination": "/join?via=gnomezgrave" }
   ],
   "rewrites": [
+    { "source": "/concepts/:concept", "destination": "/prerender/concepts/[concept]" },
+    { "source": "/progress/:match*", "destination": "https://backend.codecrafters.io/progress/:match*" },
     { "source": "/submissions", "destination": "https://backend.codecrafters.io/submissions" },
     { "source": "/submissions/:match*", "destination": "https://backend.codecrafters.io/submissions/:match*" },
-    { "source": "/progress/:match*", "destination": "https://backend.codecrafters.io/progress/:match*" },
     { "source": "/users/:user", "destination": "/prerender/users/[user]" },
-    { "source": "/concepts/:concept", "destination": "/prerender/concepts/[concept]" },
     { "source": "/:path*", "destination": "/_empty.html" }
   ],
   "github": {


### PR DESCRIPTION
Second part of #2607

### Brief

This adds server-side rendering for `/concepts/:concept` route, based on Vercel's [Prerender Functions](https://vercel.com/docs/build-output-api/v3/primitives#prerender-functions).

### Details

- Set proper OG meta tags for `/concepts/concept` route
- Added an alias function `/prerender/concepts/[concept]` which reuses `/prerender/_prerender-ember-route` function
- Made `/prerender/concepts/[concept]` function handle `/concepts/:concept` route instead of the middleware
  - `expiration` time is currently set to `24 hours`
- Removed `/concepts/:concept` route handling from the middleware and cleaned it up
  - The middleware is now handling only _contests_
- Fixed a couple FastBoot related undefined reference errors

### Checklist

- [x] I've thoroughly self-reviewed my changes
- [x] I've added tests for my changes, unless they affect admin-only areas (or are otherwise not worth testing)
- [x] I've verified any visual changes using Percy (add a commit with `[percy]` in the message to trigger)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Concept pages now feature dynamic metadata updates and enhanced prerendering for improved performance and SEO.
  - Contest-related routes have been streamlined for more efficient processing.
  - New configuration for prerendering allows query parameters to be included.

- **Bug Fixes**
  - URL parameter handling has been improved to prevent runtime errors in non-browser environments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->