### PR TITLE
feat(course-overview): add scroll to top on activation

### DIFF
--- a/app/routes/course-overview.ts
+++ b/app/routes/course-overview.ts
@@ -1,12 +1,13 @@
-import { inject as service } from '@ember/service';
 import BaseRoute from 'codecrafters-frontend/utils/base-route';
 import RepositoryPoller from 'codecrafters-frontend/utils/repository-poller';
-import config from 'codecrafters-frontend/config/environment';
-import type AuthenticatorService from 'codecrafters-frontend/services/authenticator';
-import type Store from '@ember-data/store';
-import type MetaDataService from 'codecrafters-frontend/services/meta-data';
-import type CourseModel from 'codecrafters-frontend/models/course';
 import RouteInfoMetadata, { RouteColorScheme } from 'codecrafters-frontend/utils/route-info-metadata';
+import config from 'codecrafters-frontend/config/environment';
+import scrollToTop from 'codecrafters-frontend/utils/scroll-to-top';
+import type AuthenticatorService from 'codecrafters-frontend/services/authenticator';
+import type CourseModel from 'codecrafters-frontend/models/course';
+import type MetaDataService from 'codecrafters-frontend/services/meta-data';
+import type Store from '@ember-data/store';
+import { inject as service } from '@ember/service';
 
 export interface ModelType {
   course: CourseModel;
@@ -20,6 +21,10 @@ export default class CourseOverviewRoute extends BaseRoute {
   @service declare metaData: MetaDataService;
 
   previousMetaImageUrl: string | undefined;
+
+  activate(): void {
+    scrollToTop();
+  }
 
   afterModel(model: ModelType) {
     this.previousMetaImageUrl = this.metaData.imageUrl;


### PR DESCRIPTION
Implements the `activate` method to scroll to the top of the page 
when the CourseOverviewRoute is activated. This enhances user 
experience by ensuring that users start at the top of the page 
when navigating to the course overview. Additionally, it 
reorganizes imports for better clarity and consistency.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - The course overview page now resets the view to the top automatically upon navigation, providing a smoother browsing experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->