### PR TITLE
Refactor `authenticator.initiateLogin`

### DIFF
--- a/app/components/affiliate-link-page/accept-referral-button.ts
+++ b/app/components/affiliate-link-page/accept-referral-button.ts
@@ -64,7 +64,7 @@ export default class AcceptReferralButtonComponent extends Component<Signature> 
   @waitFor
   async handleAcceptOfferButtonClick() {
     if (this.currentUserIsAnonymous) {
-      this.authenticator.initiateLogin(null);
+      this.authenticator.initiateLogin();
     } else if (this.acceptOfferButtonIsEnabled) {
       this.isCreatingAffiliateReferral = true;
 

--- a/app/components/concept-page/concept-completed-modal.ts
+++ b/app/components/concept-page/concept-completed-modal.ts
@@ -33,7 +33,7 @@ export default class ConceptCompletedModal extends Component<Signature> {
 
     markAsCompleteUrl.searchParams.set('redirect_url', `${window.origin}${this.redirectPathAfterLogin}`);
 
-    this.authenticator.initiateLogin(markAsCompleteUrl.toString());
+    this.authenticator.initiateLoginAndRedirectTo(markAsCompleteUrl.toString());
   }
 }
 

--- a/app/components/referral-link-page/accept-referral-container.ts
+++ b/app/components/referral-link-page/accept-referral-container.ts
@@ -68,7 +68,7 @@ export default class AcceptReferralContainerComponent extends Component<Signatur
   @action
   async handleAcceptOfferButtonClick() {
     if (this.currentUserIsAnonymous) {
-      this.authenticator.initiateLogin(null);
+      this.authenticator.initiateLogin();
     } else if (this.acceptOfferButtonIsEnabled) {
       this.isCreatingReferralActivation = true;
 

--- a/app/components/track-page/course-card/signup-to-preview-button.ts
+++ b/app/components/track-page/course-card/signup-to-preview-button.ts
@@ -8,7 +8,7 @@ export default class SignupToPreviewButtonComponent extends Component {
 
   @action
   handleClicked() {
-    this.authenticator.initiateLogin(null);
+    this.authenticator.initiateLogin();
   }
 }
 

--- a/app/components/track-page/start-track-button.ts
+++ b/app/components/track-page/start-track-button.ts
@@ -28,7 +28,7 @@ export default class CourseOverviewStartTrackButtonComponent extends Component<S
   @action
   handleClicked() {
     if (this.currentUserIsAnonymous) {
-      this.authenticator.initiateLogin(null);
+      this.authenticator.initiateLogin();
     } else {
       this.router.transitionTo('course', this.args.courses[0]!.slug, { queryParams: { repo: null, track: this.args.language.slug } });
     }

--- a/app/components/vote-page/course-extension-idea-card.ts
+++ b/app/components/vote-page/course-extension-idea-card.ts
@@ -42,7 +42,7 @@ export default class CourseIdeaCardComponent extends Component<Signature> {
   @action
   async handleVoteButtonClick() {
     if (this.authenticator.isAnonymous) {
-      this.authenticator.initiateLogin(null);
+      this.authenticator.initiateLogin();
 
       return;
     }

--- a/app/components/vote-page/course-idea-card.gts
+++ b/app/components/vote-page/course-idea-card.gts
@@ -52,7 +52,7 @@ export default class CourseIdeaCardComponent extends Component<Signature> {
   @action
   async handleVoteButtonClick() {
     if (this.authenticator.isAnonymous) {
-      this.authenticator.initiateLogin(null);
+      this.authenticator.initiateLogin();
 
       return;
     }

--- a/app/controllers/pay.ts
+++ b/app/controllers/pay.ts
@@ -58,7 +58,7 @@ export default class PayController extends Controller {
       this.configureCheckoutSessionModalIsOpen = true;
       this.selectedPricingFrequency = pricingFrequency;
     } else {
-      this.authenticator.initiateLogin(null);
+      this.authenticator.initiateLogin();
     }
   }
 

--- a/app/routes/login.js
+++ b/app/routes/login.js
@@ -6,7 +6,7 @@ export default class LoginRoute extends BaseRoute {
 
   beforeModel(transition) {
     if (transition.to.queryParams.next) {
-      this.authenticator.initiateLogin(transition.to.queryParams.next);
+      this.authenticator.initiateLoginAndRedirectTo(transition.to.queryParams.next);
     } else {
       this.authenticator.initiateLogin();
     }

--- a/app/services/authenticator.ts
+++ b/app/services/authenticator.ts
@@ -81,12 +81,14 @@ export default class AuthenticatorService extends Service {
   }
 
   initiateLoginAndRedirectTo(redirectPathOrUrl: string) {
-    if (redirectPathOrUrl.startsWith(`${config.x.backendUrl}`)) {
-      window.location.href = `${config.x.backendUrl}/login?next=` + redirectPathOrUrl;
-    } else if (redirectPathOrUrl.startsWith('/')) {
-      window.location.href = `${config.x.backendUrl}/login?next=` + encodeURIComponent(`${window.origin}${redirectPathOrUrl}`);
+    const loginBaseUrl = `${config.x.backendUrl}/login?next=`;
+
+    if (redirectPathOrUrl.startsWith(config.x.backendUrl)) {
+      window.location.href = loginBaseUrl + redirectPathOrUrl;
     } else {
-      window.location.href = `${config.x.backendUrl}/login?next=` + encodeURIComponent(redirectPathOrUrl);
+      const fullRedirectUrl = redirectPathOrUrl.startsWith('/') ? `${window.origin}${redirectPathOrUrl}` : redirectPathOrUrl;
+
+      window.location.href = loginBaseUrl + encodeURIComponent(fullRedirectUrl);
     }
   }
 

--- a/app/services/authenticator.ts
+++ b/app/services/authenticator.ts
@@ -72,13 +72,7 @@ export default class AuthenticatorService extends Service {
     await this.syncCurrentUser();
   }
 
-  initiateLogin(redirectPathOrUrl: string | null = null) {
-    if (redirectPathOrUrl) {
-      this.initiateLoginAndRedirect(redirectPathOrUrl);
-
-      return;
-    }
-
+  initiateLogin() {
     if (this.router.currentURL) {
       window.location.href = `${config.x.backendUrl}/login?next=` + encodeURIComponent(`${window.origin}${this.router.currentURL}`);
     } else {
@@ -86,7 +80,7 @@ export default class AuthenticatorService extends Service {
     }
   }
 
-  initiateLoginAndRedirect(redirectPathOrUrl: string) {
+  initiateLoginAndRedirectTo(redirectPathOrUrl: string) {
     if (redirectPathOrUrl.startsWith(`${config.x.backendUrl}`)) {
       window.location.href = `${config.x.backendUrl}/login?next=` + redirectPathOrUrl;
     } else if (redirectPathOrUrl.startsWith('/')) {

--- a/app/services/authenticator.ts
+++ b/app/services/authenticator.ts
@@ -74,16 +74,16 @@ export default class AuthenticatorService extends Service {
 
   initiateLogin() {
     if (this.router.currentURL) {
-      window.location.href = `${config.x.backendUrl}/login?next=` + encodeURIComponent(`${window.origin}${this.router.currentURL}`);
+      this.initiateLoginAndRedirectTo(`${window.origin}${this.router.currentURL}`);
     } else {
-      window.location.href = `${config.x.backendUrl}/login?next=` + encodeURIComponent(window.origin);
+      this.initiateLoginAndRedirectTo(window.origin);
     }
   }
 
   initiateLoginAndRedirectTo(redirectPathOrUrl: string) {
-    const fullRedirectUrl = redirectPathOrUrl.startsWith('/') ? `${window.origin}${redirectPathOrUrl}` : redirectPathOrUrl;
+    const redirectUrl = redirectPathOrUrl.startsWith('/') ? `${window.origin}${redirectPathOrUrl}` : redirectPathOrUrl;
 
-    window.location.href = `${config.x.backendUrl}/login?next=` + encodeURIComponent(fullRedirectUrl);
+    window.location.href = `${config.x.backendUrl}/login?next=` + encodeURIComponent(redirectUrl);
   }
 
   logout(): void {

--- a/app/services/authenticator.ts
+++ b/app/services/authenticator.ts
@@ -81,15 +81,9 @@ export default class AuthenticatorService extends Service {
   }
 
   initiateLoginAndRedirectTo(redirectPathOrUrl: string) {
-    const loginBaseUrl = `${config.x.backendUrl}/login?next=`;
+    const fullRedirectUrl = redirectPathOrUrl.startsWith('/') ? `${window.origin}${redirectPathOrUrl}` : redirectPathOrUrl;
 
-    if (redirectPathOrUrl.startsWith(config.x.backendUrl)) {
-      window.location.href = loginBaseUrl + redirectPathOrUrl;
-    } else {
-      const fullRedirectUrl = redirectPathOrUrl.startsWith('/') ? `${window.origin}${redirectPathOrUrl}` : redirectPathOrUrl;
-
-      window.location.href = loginBaseUrl + encodeURIComponent(fullRedirectUrl);
-    }
+    window.location.href = `${config.x.backendUrl}/login?next=` + encodeURIComponent(fullRedirectUrl);
   }
 
   logout(): void {

--- a/app/services/authenticator.ts
+++ b/app/services/authenticator.ts
@@ -72,17 +72,27 @@ export default class AuthenticatorService extends Service {
     await this.syncCurrentUser();
   }
 
-  initiateLogin(redirectPath: string | null) {
-    const isFullUrl = redirectPath?.startsWith(`${config.x.backendUrl}`);
+  initiateLogin(redirectPathOrUrl: string | null = null) {
+    if (redirectPathOrUrl) {
+      this.initiateLoginAndRedirect(redirectPathOrUrl);
 
-    if (isFullUrl) {
-      window.location.href = `${config.x.backendUrl}/login?next=` + redirectPath;
-    } else if (redirectPath) {
-      window.location.href = `${config.x.backendUrl}/login?next=` + encodeURIComponent(`${window.origin}${redirectPath}`);
-    } else if (this.router.currentURL) {
+      return;
+    }
+
+    if (this.router.currentURL) {
       window.location.href = `${config.x.backendUrl}/login?next=` + encodeURIComponent(`${window.origin}${this.router.currentURL}`);
     } else {
       window.location.href = `${config.x.backendUrl}/login?next=` + encodeURIComponent(window.origin);
+    }
+  }
+
+  initiateLoginAndRedirect(redirectPathOrUrl: string) {
+    if (redirectPathOrUrl.startsWith(`${config.x.backendUrl}`)) {
+      window.location.href = `${config.x.backendUrl}/login?next=` + redirectPathOrUrl;
+    } else if (redirectPathOrUrl.startsWith('/')) {
+      window.location.href = `${config.x.backendUrl}/login?next=` + encodeURIComponent(`${window.origin}${redirectPathOrUrl}`);
+    } else {
+      window.location.href = `${config.x.backendUrl}/login?next=` + encodeURIComponent(redirectPathOrUrl);
     }
   }
 

--- a/app/utils/base-route.ts
+++ b/app/utils/base-route.ts
@@ -29,9 +29,9 @@ export default class BaseRoute extends Route {
 
       if (params.length > 0) {
         const paramValues = params.map(([_, value]) => value);
-        this.authenticator.initiateLogin(this.router.urlFor(transition.to?.name || 'catalog', ...paramValues));
+        this.authenticator.initiateLoginAndRedirectTo(this.router.urlFor(transition.to?.name || 'catalog', ...paramValues));
       } else {
-        this.authenticator.initiateLogin(this.router.urlFor(transition.to?.name || 'catalog'));
+        this.authenticator.initiateLoginAndRedirectTo(this.router.urlFor(transition.to?.name || 'catalog'));
       }
 
       transition.abort();

--- a/tests/acceptance/concepts-test.js
+++ b/tests/acceptance/concepts-test.js
@@ -143,7 +143,7 @@ module('Acceptance | concepts-test', function (hooks) {
 
     assert.strictEqual(
       windowMock.location.href,
-      `${windowMock.location.origin}/login?next=${nextUrl}`,
+      `${windowMock.location.origin}/login?next=${encodeURIComponent(nextUrl)}`,
       'should redirect to login URL with correct mark_as_complete endpoint',
     );
   });
@@ -194,7 +194,7 @@ module('Acceptance | concepts-test', function (hooks) {
 
     assert.strictEqual(
       windowMock.location.href,
-      `${windowMock.location.origin}/login?next=${nextUrl}`,
+      `${windowMock.location.origin}/login?next=${encodeURIComponent(nextUrl)}`,
       'should redirect to login URL with correct mark_as_complete endpoint',
     );
   });


### PR DESCRIPTION
Update multiple components to call initiateLogin without a null parameter, simplifying login initiation across the application

**Checklist**:

- [x] I've thoroughly self-reviewed my changes
- [ ] I've added tests for my changes, unless they affect admin-only areas (or are otherwise not worth testing)
- [ ] I've verified any visual changes using Percy (add a commit with `[percy]` in the message to trigger)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced the login experience by automatically redirecting users to their intended destinations after signing in.
	- Introduced a new method for handling login initiation with redirection capabilities.

- **Refactor**
	- Streamlined authentication calls across various pages by removing unnecessary parameters, simplifying the login process.

These updates result in a smoother and more cohesive login process on several user-facing pages, improving overall navigation and reducing friction during authentication.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->