### PR TITLE
feat(header): update account dropdown visibility in fastboot

### DIFF
--- a/app/components/header/index.hbs
+++ b/app/components/header/index.hbs
@@ -39,8 +39,8 @@
         {{/each}}
       </div>
 
-      {{! Account Dropdown on Desktop }}
-      <div class="invisible md:visible flex items-center ml-6">
+      {{! Account Dropdown on Desktop. Hidden in fastboot since we don't know if the user is authed or not }}
+      <div class="invisible {{unless (is-fastboot) 'md:visible'}} flex items-center ml-6">
         {{#if (and this.authenticator.currentUser.isStaff this.versionTracker.currentVersionIsOutdated)}}
           <OutdatedClientBadge class="mr-4" />
         {{/if}}

--- a/app/helpers/is-fastboot.ts
+++ b/app/helpers/is-fastboot.ts
@@ -1,0 +1,25 @@
+import Helper from '@ember/component/helper';
+import { inject as service } from '@ember/service';
+import FastbootService from 'ember-cli-fastboot/services/fastboot';
+
+export interface Signature {
+  Args: {
+    Positional: [];
+  };
+
+  Return: boolean;
+}
+
+export default class IsFastboot extends Helper<Signature> {
+  @service declare fastboot: FastbootService;
+
+  public compute(): boolean {
+    return this.fastboot.isFastBoot;
+  }
+}
+
+declare module '@glint/environment-ember-loose/registry' {
+  export default interface Registry {
+    'is-fastboot': typeof IsFastboot;
+  }
+}


### PR DESCRIPTION
Enhance the account dropdown component to conditionally render based 
on the Fastboot environment. Introduce a new helper, `is-fastboot`, 
to determine if the app is running in Fastboot mode, ensuring the 
dropdown remains hidden during server-side rendering when user 
authentication status is unknown.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - **Enhanced Header Behavior:** The account dropdown in the header now appears only when the application is fully ready, preventing any premature display during initial rendering.  
  - **Improved Environment Detection:** An updated mechanism ensures that header elements render consistently, providing a smoother and more reliable user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->