### PR TITLE
CC-1637: Fix Autofocus after pressing continue from concept-questions

### DIFF
--- a/app/components/concept-page/content.hbs
+++ b/app/components/concept-page/content.hbs
@@ -35,9 +35,11 @@
               <FeedbackButton @source="concept_completed" as |dd|>
                 <div
                   role="button"
+                  tabindex="0"
                   class="rounded border
                     {{if dd.isOpen 'border-gray-600' 'border-gray-200'}}
                     hover:border-gray-600 transition-colors px-3 py-2 text-sm text-gray-600"
+                    {{focus-on-insert}}
                   data-test-feedback-button
                 >
                   Share Feedback

--- a/app/components/concept-page/content.hbs
+++ b/app/components/concept-page/content.hbs
@@ -39,7 +39,7 @@
                   class="rounded border
                     {{if dd.isOpen 'border-gray-600' 'border-gray-200'}}
                     hover:border-gray-600 transition-colors px-3 py-2 text-sm text-gray-600"
-                    {{focus-on-insert}}
+                  {{focus-on-insert}}
                   data-test-feedback-button
                 >
                   Share Feedback

--- a/app/components/concept-page/question-card.ts
+++ b/app/components/concept-page/question-card.ts
@@ -77,7 +77,7 @@ export default class QuestionCardComponent extends Component<Signature> {
   handleDidInsertOptionsList(element: HTMLElement) {
     const firstOptionElement = element.children[0];
 
-    if (firstOptionElement instanceof HTMLElement) {
+    if (this.args.isCurrentBlock && firstOptionElement instanceof HTMLElement) {
       // focus() doesn't seem to work unless it's called after the current runloop
       next(() => {
         firstOptionElement?.focus({ preventScroll: true });

--- a/app/components/concept/continue-or-step-back.ts
+++ b/app/components/concept/continue-or-step-back.ts
@@ -24,11 +24,7 @@ export default class ContinueOrStepBackComponent extends Component<Signature> {
   }
 
   @action
-  handleEnterKeyPress(event: KeyboardEvent, element: HTMLButtonElement): void {
-    if (element instanceof HTMLElement) {
-      element.blur();
-    }
-
+  handleEnterKeyPress(event: KeyboardEvent): void {
     if (event.target === this.continueButtonElement) {
       return; // Continue button already has a click handler
     }

--- a/app/components/concept/continue-or-step-back.ts
+++ b/app/components/concept/continue-or-step-back.ts
@@ -24,7 +24,11 @@ export default class ContinueOrStepBackComponent extends Component<Signature> {
   }
 
   @action
-  handleEnterKeyPress(event: KeyboardEvent): void {
+  handleEnterKeyPress(event: KeyboardEvent, element: HTMLButtonElement): void {
+    if (element instanceof HTMLElement) {
+      element.blur();
+    }
+
     if (event.target === this.continueButtonElement) {
       return; // Continue button already has a click handler
     }


### PR DESCRIPTION
**Checklist**:

- [x] I've thoroughly self-reviewed my changes
- [ ] I've added tests for my changes, unless they affect admin-only areas (or are otherwise not worth testing)
- [ ] I've verified any visual changes using Percy (add a commit with `[percy]` in the message to trigger)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved interactive element focus management by ensuring focus is applied only when the content is active.
  - Enhanced accessibility for the feedback button by making it keyboard navigable and managing focus automatically on insertion.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->