### PR TITLE
feat: implement loading controller with opacity transitions

### DIFF
--- a/app/components/loading-indicator.ts
+++ b/app/components/loading-indicator.ts
@@ -1,6 +1,10 @@
 import Component from '@glimmer/component';
 
-export default class LoadingIndicatorComponent extends Component {}
+type Signature = {
+  Element: HTMLDivElement;
+};
+
+export default class LoadingIndicatorComponent extends Component<Signature> {}
 
 declare module '@glint/environment-ember-loose/registry' {
   export default interface Registry {

--- a/app/controllers/loading.ts
+++ b/app/controllers/loading.ts
@@ -3,10 +3,10 @@ import { action } from '@ember/object';
 import { later, cancel } from '@ember/runloop';
 
 export default class LoadingController extends Controller {
-  cancellable;
+  cancellable: ReturnType<typeof later> | null = null;
 
   @action
-  async handleDidInsertLoadingIndicator(element) {
+  async handleDidInsertLoadingIndicator(element: HTMLDivElement) {
     this.cancellable = later(() => {
       if (element) {
         element.classList.add('opacity-100');
@@ -17,6 +17,8 @@ export default class LoadingController extends Controller {
 
   @action
   async handleWillDestroyLoadingIndicator() {
-    cancel(this.cancellable);
+    if (this.cancellable) {
+      cancel(this.cancellable);
+    }
   }
 }

--- a/app/templates/loading.hbs
+++ b/app/templates/loading.hbs
@@ -1,4 +1,3 @@
-{{! @glint-nocheck: not typesafe yet }}
 <div data-test-loading class="container mx-auto lg:max-w-screen-lg px-6">
   <div class="flex flex-col items-center justify-center min-h-screen">
     <LoadingIndicator


### PR DESCRIPTION
Add a new loading controller in TypeScript to manage the loading 
indicator's visibility. The controller handles the insertion and 
removal of the loading indicator with opacity transitions, ensuring 
a smoother user experience. The previous JavaScript implementation 
is removed to improve type safety and maintainability.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Updated the loading indicator behavior for a smoother, more consistent display during content load. Enhanced error handling and validations ensure the system gracefully manages potential issues, providing users with a more reliable and stable experience. These improvements help minimize disruptions during loading phases.

- **Chore**
  - Removed redundant commentary in the loading display template to improve code clarity and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->