### PR TITLE
refactor: update concept group handling in components

### DIFF
--- a/app/components/concept-group-page/content.hbs
+++ b/app/components/concept-group-page/content.hbs
@@ -1,7 +1,7 @@
 <div class="bg-white">
   <div class="container mx-auto lg:max-w-screen-lg pt-6 md:pt-10 pb-10 md:pb-48 px-3 md:px-6">
     <div class="grid grid-cols-1 gap-3 md:gap-6 md:grid-cols-2">
-      {{#each @concepts as |concept|}}
+      {{#each this.sortedConcepts as |concept|}}
         <ConceptsPage::ConceptCard @concept={{concept}} />
       {{/each}}
     </div>

--- a/app/components/concept-group-page/content.ts
+++ b/app/components/concept-group-page/content.ts
@@ -1,15 +1,19 @@
 import Component from '@glimmer/component';
-import ConceptModel from 'codecrafters-frontend/models/concept';
+import ConceptGroupModel from 'codecrafters-frontend/models/concept-group';
 
 interface Signature {
   Element: HTMLDivElement;
 
-  Args: {
-    concepts: Array<ConceptModel>;
-  };
+  Args: { conceptGroup: ConceptGroupModel };
 }
 
-export default class ContentComponent extends Component<Signature> {}
+export default class ContentComponent extends Component<Signature> {
+  get sortedConcepts() {
+    return this.args.conceptGroup.concepts.toArray().sort((a, b) => {
+      return this.args.conceptGroup.conceptSlugs.indexOf(a.slug) - this.args.conceptGroup.conceptSlugs.indexOf(b.slug);
+    });
+  }
+}
 
 declare module '@glint/environment-ember-loose/registry' {
   export default interface Registry {

--- a/app/models/concept-group.ts
+++ b/app/models/concept-group.ts
@@ -1,8 +1,10 @@
-import Model, { belongsTo, attr } from '@ember-data/model';
+import Model, { belongsTo, attr, hasMany } from '@ember-data/model';
 import UserModel from 'codecrafters-frontend/models/user';
+import ConceptModel from 'codecrafters-frontend/models/concept';
 
 export default class ConceptGroupModel extends Model {
   @belongsTo('user', { async: false, inverse: null }) author!: UserModel;
+  @hasMany('concept', { async: false, inverse: null }) concepts!: ConceptModel[];
 
   @attr() conceptSlugs!: Array<string>;
   @attr('string') descriptionMarkdown!: string;

--- a/app/models/language.ts
+++ b/app/models/language.ts
@@ -1,5 +1,6 @@
 import CourseLanguageConfigurationModel from './course-language-configuration';
-import Model, { attr, hasMany } from '@ember-data/model';
+import ConceptGroupModel from './concept-group';
+import Model, { attr, hasMany, belongsTo } from '@ember-data/model';
 import colorLogoC from '/assets/images/language-logos/c-color.svg';
 import colorLogoCpp from '/assets/images/language-logos/cpp-color.svg';
 import colorLogoClojure from '/assets/images/language-logos/clojure-color.svg';
@@ -75,6 +76,8 @@ import tealLogoZig from '/assets/images/language-logos/zig-teal-500.svg';
 
 export default class LanguageModel extends Model {
   @hasMany('course-language-configuration', { async: false, inverse: 'language' }) declare courseConfigurations: CourseLanguageConfigurationModel[];
+
+  @belongsTo('concept-group', { async: false, inverse: null }) declare primerConceptGroup: ConceptGroupModel | null;
 
   @attr('string') declare name: string;
   @attr('string') declare slug: string;

--- a/app/routes/concept-group.ts
+++ b/app/routes/concept-group.ts
@@ -1,6 +1,5 @@
 import type AuthenticatorService from 'codecrafters-frontend/services/authenticator';
 import BaseRoute from 'codecrafters-frontend/utils/base-route';
-import ConceptModel from 'codecrafters-frontend/models/concept';
 import ConceptGroupModel from 'codecrafters-frontend/models/concept-group';
 import config from 'codecrafters-frontend/config/environment';
 import HeadDataService from 'codecrafters-frontend/services/meta-data';
@@ -28,33 +27,19 @@ export default class ConceptGroupRoute extends BaseRoute {
   }
 
   async model(params: { concept_group_slug: string }) {
-    const conceptGroup = await this.store.queryRecord('concept-group', { slug: params.concept_group_slug, include: 'author' });
+    const conceptGroup = await this.store.queryRecord('concept-group', {
+      slug: params.concept_group_slug,
+      include: 'author,concepts,concepts.author',
+    });
 
     if (!conceptGroup) {
       this.router.transitionTo('/');
     }
 
-    const allConcepts = await this.store.findAll('concept', { include: 'author,questions' });
-
-    const concepts = conceptGroup.conceptSlugs.reduce((acc: Array<ConceptModel>, slug: string) => {
-      const concept = allConcepts.find((concept) => concept.slug === slug);
-
-      if (concept) {
-        acc.push(concept);
-      }
-
-      return acc;
-    }, []);
-
     if (this.authenticator.isAuthenticated) {
-      await this.store.findAll('concept-engagement', {
-        include: 'concept,user',
-      });
+      await this.store.findAll('concept-engagement', { include: 'concept,user' });
     }
 
-    return {
-      conceptGroup,
-      concepts,
-    };
+    return { conceptGroup };
   }
 }

--- a/app/templates/concept-group.hbs
+++ b/app/templates/concept-group.hbs
@@ -1,4 +1,4 @@
 {{page-title "Collections"}}
 
 <ConceptGroupPage::Header @conceptGroup={{this.model.conceptGroup}} data-test-concept-group-header />
-<ConceptGroupPage::Content @concepts={{this.model.concepts}} data-test-concept-group-content />
+<ConceptGroupPage::Content @conceptGroup={{this.model.conceptGroup}} data-test-concept-group-content />

--- a/tests/acceptance/concept-groups-test.js
+++ b/tests/acceptance/concept-groups-test.js
@@ -20,10 +20,14 @@ module('Acceptance | concept-groups-test', function (hooks) {
     testScenario(this.server);
     createConcepts(this.server);
 
+    const tcpOverviewConcept = this.server.schema.concepts.findBy({ slug: 'tcp-overview' });
+    const networkProtocolsConcept = this.server.schema.concepts.findBy({ slug: 'network-protocols' });
+
     const user = this.server.schema.users.first();
     this.conceptGroup = this.server.create('concept-group', {
       author: user,
       description_markdown: 'Dummy description',
+      concepts: [tcpOverviewConcept, networkProtocolsConcept],
       concept_slugs: ['tcp-overview', 'network-protocols'],
       slug: 'test-concept-group',
       title: 'Test Concept Group',


### PR DESCRIPTION
Refactor the `ContentComponent` to accept a `conceptGroup` 
instead of individual concepts. Implement a computed property 
`sortedConcepts` to sort concepts based on their slugs. Update 
the `ConceptGroupRoute` to include related concepts in the 
model query and remove unnecessary concept fetching logic. 
Adjust the template to use the new `conceptGroup` structure. 
These changes streamline data handling and improve code 
readability.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a computed property that sorts concepts for display.
  - Enhanced data relationships to associate a group with multiple concepts.
  - Updated tests to directly reference concept objects in the concept group.

- **Refactor**
  - Updated component interfaces to accept a concept group instead of an independent list.
  - Streamlined data retrieval and UI bindings to focus on displaying grouped concept information.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->