### PR TITLE
fix(logging): change warning to log for HelpScout Beacon

### DIFF
--- a/app/components/helpscout-beacon.js
+++ b/app/components/helpscout-beacon.js
@@ -2,6 +2,7 @@ import Component from '@glimmer/component';
 import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
 import config from 'codecrafters-frontend/config/environment';
+import Sentry from '@sentry/ember';
 
 export default class HelpScoutBeaconComponent extends Component {
   @tracked beaconInitialized = false;
@@ -26,7 +27,8 @@ export default class HelpScoutBeaconComponent extends Component {
         window.Beacon('init', config.x.helpscoutBeaconId);
         this.beaconInitialized = true;
       } else {
-        console.warn('HelpScout Beacon not available after script load.  Check network request.');
+        console.log('HelpScout Beacon not available after script load.');
+        Sentry.captureMessage('HelpScout Beacon not available after script load.');
       }
     } catch (error) {
       console.error('Error loading HelpScout Beacon:', error);

--- a/app/components/helpscout-beacon.js
+++ b/app/components/helpscout-beacon.js
@@ -2,7 +2,7 @@ import Component from '@glimmer/component';
 import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
 import config from 'codecrafters-frontend/config/environment';
-import Sentry from '@sentry/ember';
+import * as Sentry from '@sentry/ember';
 
 export default class HelpScoutBeaconComponent extends Component {
   @tracked beaconInitialized = false;


### PR DESCRIPTION
Updates the logging level for HelpScout Beacon initialization failure 
from a warning to a log statement. This change aims to reduce 
the severity of the message in the console, making it less 
intrusive while still providing necessary information for 
debugging purposes.