### PR TITLE
fix: improve logging in build-vercel-output script

### DIFF
--- a/scripts/build-vercel-output.sh
+++ b/scripts/build-vercel-output.sh
@@ -8,7 +8,7 @@ LOG_FILENAME="build-output.log"
 VERCEL_FUNCTIONS_DESTINATION="/vercel/output/functions"
 
 # Run `npm run build` and capture the output into build output log
-npm run build > >(tee -a "${LOG_FILENAME}") 2> >(tee -a "${LOG_FILENAME}" >&2)
+npm run build 2>&1 | tee -a "${LOG_FILENAME}"
 
 # If there are errors in build output log - exit with error status code
 if cat "${LOG_FILENAME}" | grep -qi "error"; then


### PR DESCRIPTION
Redirect both stdout and stderr to the log file using a single 
pipeline. This change simplifies the command and ensures that 
all output, including errors, is captured in the build output 
log for better debugging and monitoring.