### PR TITLE
refactor: improve FastBoot handling in MarkdownToHtml helper

### DIFF
--- a/app/helpers/markdown-to-html.ts
+++ b/app/helpers/markdown-to-html.ts
@@ -31,9 +31,8 @@ export default class MarkdownToHtml extends Helper<Signature> {
       disableForced4SpacesIndentedSublists: true,
     }).makeHtml(markdown);
 
+    // DOMPurify is not available in FastBoot mode, so we return the generated HTML as is
     if (this.fastboot.isFastBoot) {
-      console.warn('DOMPurify unavailable in FastBoot mode, skipping sanitize');
-
       return generatedHtml;
     }
 


### PR DESCRIPTION
Remove unnecessary warning log for DOMPurify in FastBoot mode. 
Return generated HTML directly when in FastBoot, as sanitization 
is not possible. This simplifies the code and avoids confusion 
regarding the sanitization process in this environment.