### PR TITLE
feat(routes): add language model handling in catalog and track

### DIFF
--- a/app/routes/catalog.ts
+++ b/app/routes/catalog.ts
@@ -7,6 +7,7 @@ import BaseRoute from 'codecrafters-frontend/utils/base-route';
 import RepositoryPoller from 'codecrafters-frontend/utils/repository-poller';
 import { hash as RSVPHash } from 'rsvp';
 import RouteInfoMetadata, { RouteColorScheme } from 'codecrafters-frontend/utils/route-info-metadata';
+import type LanguageModel from 'codecrafters-frontend/models/language';
 
 export type ModelType = {
   repositories?: RepositoryModel[];
@@ -26,6 +27,7 @@ export default class CatalogRoute extends BaseRoute {
     const modelPromises: {
       repositories?: Promise<RepositoryModel[]>;
       courses?: Promise<CourseModel[]>;
+      _languages?: Promise<LanguageModel[]>;
     } = {};
 
     if (this.authenticator.isAuthenticated) {
@@ -38,6 +40,11 @@ export default class CatalogRoute extends BaseRoute {
     modelPromises.courses = this.store.findAll('course', {
       include: 'extensions,stages,language-configurations.language',
     }) as unknown as Promise<CourseModel[]>;
+
+    // Resources required by the track page
+    modelPromises._languages = this.store.findAll('language', {
+      include: 'primer-concept-group,primer-concept-group.author,primer-concept-group.concepts,primer-concept-group.concepts.author',
+    }) as unknown as Promise<LanguageModel[]>;
 
     return RSVPHash(modelPromises) as Promise<ModelType>;
   }

--- a/tests/acceptance/course-page/attempt-course-stage-test.js
+++ b/tests/acceptance/course-page/attempt-course-stage-test.js
@@ -35,8 +35,9 @@ module('Acceptance | course-page | attempt-course-stage', function (hooks) {
     assert.strictEqual(
       apiRequestsCount(this.server),
       [
-        'fetch courses (courses listing page)',
-        'fetch repositories (courses listing page)',
+        'fetch courses (catalog)',
+        'fetch repositories (catalog)',
+        'fetch languages (catalog)',
         'fetch courses (course page)',
         'fetch repositories (course page)',
         'fetch leaderboard entries (course page)',

--- a/tests/acceptance/course-page/resume-course-test.js
+++ b/tests/acceptance/course-page/resume-course-test.js
@@ -33,8 +33,9 @@ module('Acceptance | course-page | resume-course-test', function (hooks) {
     assert.strictEqual(
       apiRequestsCount(this.server),
       [
-        'fetch courses (courses listing page)',
-        'fetch repositories (courses listing page)',
+        'fetch courses (catalog)',
+        'fetch repositories (catalog)',
+        'fetch languages (catalog)',
         'fetch courses (course page)',
         'fetch repositories (course page)',
         'fetch leaderboard entries (course page)',

--- a/tests/acceptance/course-page/start-course-test.js
+++ b/tests/acceptance/course-page/start-course-test.js
@@ -58,8 +58,9 @@ module('Acceptance | course-page | start-course', function (hooks) {
     assert.strictEqual(currentURL(), '/courses/dummy/introduction', 'current URL is course page URL');
 
     let baseRequestsCount = [
-      'fetch courses (courses listing page)',
-      'fetch repositories (courses listing page)',
+      'fetch courses (catalog)',
+      'fetch repositories (catalog)',
+      'fetch languages (catalog)',
       'fetch leaderboard entries (course overview page)',
       'refresh course (course overview page)',
       'fetch courses (course page)',

--- a/tests/acceptance/course-page/switch-repository-test.js
+++ b/tests/acceptance/course-page/switch-repository-test.js
@@ -39,8 +39,9 @@ module('Acceptance | course-page | switch-repository', function (hooks) {
     await catalogPage.clickOnCourse('Build your own Redis');
 
     const baseRequestsCount = [
-      'fetch courses (courses listing page)',
-      'fetch repositories (courses listing page)',
+      'fetch courses (catalog)',
+      'fetch repositories (catalog)',
+      'fetch languages (catalog)',
       'fetch courses (course page)',
       'fetch repositories (course page)',
       'fetch leaderboard entries (course page)',

--- a/tests/acceptance/course-page/try-other-language-test.js
+++ b/tests/acceptance/course-page/try-other-language-test.js
@@ -30,8 +30,9 @@ module('Acceptance | course-page | try-other-language', function (hooks) {
     });
 
     let expectedRequestsCount = [
-      'fetch courses (courses listing page)',
-      'fetch repositories (courses listing page)',
+      'fetch courses (catalog)',
+      'fetch repositories (catalog)',
+      'fetch languages (catalog)',
       'fetch courses (course page)',
       'fetch repositories (course page)',
       'fetch leaderboard entries (course page)',


### PR DESCRIPTION
Add support for fetching and managing language models in the 
Catalog and Track routes. Introduce a new promise for languages 
in the Catalog route and update the Track route to retrieve 
languages based on the track slug. This enhances the data 
availability for language-related features and improves 
authentication handling for repository data.