### PR TITLE
Fix redirect to 404 from concept route when concept is not found

### DIFF
--- a/tests/acceptance/concepts-test.js
+++ b/tests/acceptance/concepts-test.js
@@ -87,6 +87,28 @@ module('Acceptance | concepts-test', function (hooks) {
     await percySnapshot('Concept - Completed');
   });
 
+  test('visiting a non-existing concept redirects to 404', async function (assert) {
+    testScenario(this.server);
+    createConcepts(this.server);
+
+    signInAsStaff(this.owner, this.server);
+
+    this.server.schema.conceptGroups.create({
+      conceptSlugs: ['network-protocols', 'tcp-overview'],
+      descriptionMarkdown: 'This is a group about network concepts',
+      slug: 'network-primer',
+      title: 'Network Primer',
+    });
+
+    await conceptsPage.visitConcept({ concept_slug: 'network-protocols' });
+
+    assert.strictEqual(currentURL(), '/concepts/network-protocols', 'Existing concept renders on correct concept URL');
+
+    await conceptsPage.visitConcept({ concept_slug: 'nonexistent-concept' });
+
+    assert.strictEqual(currentURL(), '/404', 'Non-existing concept redirects to /404');
+  });
+
   test('anonymous users can view concepts linked to a concept group', async function (assert) {
     testScenario(this.server);
     createConcepts(this.server);

--- a/tests/pages/concepts-page.ts
+++ b/tests/pages/concepts-page.ts
@@ -29,4 +29,5 @@ export default createPage({
   helpscoutBeacon: helpscoutBeacon,
 
   visit: visitable('/concepts'),
+  visitConcept: visitable('/concepts/:concept_slug'),
 });


### PR DESCRIPTION
Related to #2607
Follow-up to https://github.com/codecrafters-io/frontend/pull/2670

### Brief

This fixes the redirection to `/404` from the `/concepts/concept` route when the requested Concept could not be found

### Details

- Moved the redirection into the `afterModel` hook
  - it redirects to `404` if the `model` hook returned `undefined`
  - the `model` hook returns `undefined` if Concept doesn't exist
  - doing the redirect directly in the `model` hook causes a `TransactionAborted` error
- Added a test for redirection of non-existing concepts to `/404`
- Renamed `findOrCreateConceptEngagement` to `#findCachedOrCreateNewConceptEngagement`

### Screenshot

<img width="864" alt="Знімок екрана 2025-02-22 о 12 14 34" src="https://github.com/user-attachments/assets/53798019-6ea6-42c1-96d6-3c04fc3bd393" />

### Checklist

- [x] I've thoroughly self-reviewed my changes
- [x] I've added tests for my changes, unless they affect admin-only areas (or are otherwise not worth testing)
- [x] I've verified any visual changes using Percy (add a commit with `[percy]` in the message to trigger)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced navigation by adding a method to visit specific concept pages using dynamic URLs.
  
- **Bug Fixes**
  - Improved error handling for missing content to provide a smoother navigation experience.
  - Adjusted data loading so that engagement information is only fetched for authenticated users.
  - Added a test to ensure proper redirection to a 404 error page for non-existing concepts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->