### PR TITLE
Fix fetching languages when pre-rendering tracks

### DIFF
--- a/app/adapters/application.ts
+++ b/app/adapters/application.ts
@@ -2,12 +2,14 @@ import JSONAPIAdapter from '@ember-data/adapter/json-api';
 import { inject as service } from '@ember/service';
 import config from 'codecrafters-frontend/config/environment';
 import { posthog } from 'posthog-js';
+import type FastbootService from 'ember-cli-fastboot/services/fastboot';
 import type SessionTokenStorageService from 'codecrafters-frontend/services/session-token-storage';
 import type VersionTrackerService from 'codecrafters-frontend/services/version-tracker';
 
 export default class ApplicationAdapter extends JSONAPIAdapter {
   namespace = 'api/v1';
 
+  @service declare fastboot: FastbootService;
   @service declare sessionTokenStorage: SessionTokenStorageService;
   @service declare versionTracker: VersionTrackerService;
 
@@ -33,5 +35,17 @@ export default class ApplicationAdapter extends JSONAPIAdapter {
 
   get host() {
     return config.x.backendUrl;
+  }
+
+  shouldBackgroundReloadAll() {
+    // Don't use background reloading under FastBoot, otherwise it will run
+    // after the app is destroyed and crash the build in a very funny way.
+    return !this.fastboot.isFastBoot;
+  }
+
+  shouldBackgroundReloadRecord() {
+    // Don't use background reloading under FastBoot, otherwise it will run
+    // after the app is destroyed and crash the build in a very funny way.
+    return !this.fastboot.isFastBoot;
   }
 }

--- a/app/routes/track.ts
+++ b/app/routes/track.ts
@@ -5,7 +5,6 @@ import config from 'codecrafters-frontend/config/environment';
 import scrollToTop from 'codecrafters-frontend/utils/scroll-to-top';
 import type AuthenticatorService from 'codecrafters-frontend/services/authenticator';
 import type CourseModel from 'codecrafters-frontend/models/course';
-import type FastbootService from 'ember-cli-fastboot/services/fastboot';
 import type LanguageModel from 'codecrafters-frontend/models/language';
 import type MetaDataService from 'codecrafters-frontend/services/meta-data';
 import type Store from '@ember-data/store';
@@ -20,7 +19,6 @@ export default class TrackRoute extends BaseRoute {
   allowsAnonymousAccess = true;
 
   @service declare authenticator: AuthenticatorService;
-  @service declare fastboot: FastbootService;
   @service declare metaData: MetaDataService;
   @service declare store: Store;
 
@@ -49,12 +47,9 @@ export default class TrackRoute extends BaseRoute {
       include: 'extensions,stages,language-configurations.language',
     })) as unknown as CourseModel[];
 
-    // TODO: Investigate why running this in FastBoot causes a build error
-    if (!this.fastboot.isFastBoot) {
-      (await this.store.findAll('language', {
-        include: 'primer-concept-group,primer-concept-group.author,primer-concept-group.concepts,primer-concept-group.concepts.author',
-      })) as unknown as LanguageModel[];
-    }
+    (await this.store.findAll('language', {
+      include: 'primer-concept-group,primer-concept-group.author,primer-concept-group.concepts,primer-concept-group.concepts.author',
+    })) as unknown as LanguageModel[];
 
     const language = this.store.peekAll('language').find((language) => language.slug === params.track_slug)!;
 


### PR DESCRIPTION
Superseeds: https://github.com/codecrafters-io/frontend/pull/2693

### Brief

This fixes a mysterious issue with rendering `/tracks/track` route under FastBoot, caused by `store.findAll` and similar methods late-loading models **after the app has been considered ready** by FastBoot and **torn down**.

### Details

- Disabled `ApplicationAdapter.shouldBackgroundReloadAll` under FastBoot
- Disabled `ApplicationAdapter.shouldBackgroundReloadRecord` under FastBoot
- Removed temporary fix preventing `store.findAll('language')` from running in `/tracks/track` route
- Made `ApplicationSerializer.normalize` throw a human-readable error when writing to shoebox using a destroyed FastBoot service

### Checklist

- [x] I've thoroughly self-reviewed my changes
- [x] I've added tests for my changes, unless they affect admin-only areas (or are otherwise not worth testing)
- [x] I've verified any visual changes using Percy (add a commit with `[percy]` in the message to trigger)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Prevented potential crashes in server-side rendering by refining background data reload behavior.
  - Ensured consistent language data fetching across different execution environments.

- **Refactor**
  - Improved error handling and data processing for more reliable caching and overall application stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->