### PR TITLE
feat(profile): limit language logos to 5 in course progress items

### DIFF
--- a/app/components/user-page/course-progress-list-item/index.hbs
+++ b/app/components/user-page/course-progress-list-item/index.hbs
@@ -45,7 +45,7 @@
     {{/if}}
 
     <div class="flex items-center space-x-1.5">
-      {{#each @courseParticipations as |courseParticipation|}}
+      {{#each this.languagesToDisplay as |courseParticipation|}}
         {{#if courseParticipation.isCompleted}}
           <LanguageLogo @language={{courseParticipation.language}} @variant="teal" class="h-4" />
         {{else}}


### PR DESCRIPTION
- Display max 5 language logos per course progress item
- Prioritize completed languages first
- Sort by recency (completed or last submission date)
- Show recent incomplete languages if fewer than 5 completed ones

**Checklist**:

- [ ] I've thoroughly self-reviewed my changes
- [ ] I've added tests for my changes, unless they affect admin-only areas (or are otherwise not worth testing)
- [ ] I've verified any visual changes using Percy (add a commit with `[percy]` in the message to trigger)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced the course progress display on the user page to show a curated set of language icons. Now, up to five languages are presented by prioritizing the most recently completed courses with recent in-progress ones supplementing as needed.
  
- **Refactor**
  - Streamlined the ordering and display logic to ensure a clearer and more relevant presentation of your language progress.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->