### PR TITLE
refactor: rename click handler for clarity

### DIFF
--- a/app/components/track-page/start-track-button.hbs
+++ b/app/components/track-page/start-track-button.hbs
@@ -1,4 +1,4 @@
-<PrimaryButton class="mr-2 flex items-center" data-test-primary-start-track-button {{on "click" this.handleClicked}} @size="large" ...attributes>
+<PrimaryButton class="mr-2 flex items-center" data-test-primary-start-track-button {{on "click" this.handleClick}} @size="large" ...attributes>
   {{! If there's no primer concept group, the user will need to login to start the track }}
   {{#if (and this.authenticator.isAnonymous (not @language.primerConceptGroup))}}
     {{svg-jar "github" class="fill-current w-5 transform transition-all mr-2"}}

--- a/app/components/track-page/start-track-button.ts
+++ b/app/components/track-page/start-track-button.ts
@@ -22,10 +22,10 @@ export default class CourseOverviewStartTrackButtonComponent extends Component<S
   @service declare router: RouterService;
 
   @action
-  handleClicked() {
+  handleClick() {
     if (this.authenticator.isAnonymous) {
       if (this.args.language.primerConceptGroup) {
-        this.router.transitionTo('concept', this.args.language.primerConceptGroup.concepts[0]!.slug);
+        this.router.transitionTo('concept', this.args.language.primerConceptGroup.conceptSlugs[0]!);
       } else {
         this.authenticator.initiateLogin();
       }


### PR DESCRIPTION
Renames the `handleClicked` method to `handleClick` for improved 
clarity and consistency. Updates the corresponding template to 
reflect this change. Additionally, modifies the transition logic 
to use `conceptSlugs` instead of `concepts` for better alignment 
with the data structure.