### PR TITLE
refactor: clarify variable name for draft visibility

### DIFF
--- a/app/controllers/concepts.ts
+++ b/app/controllers/concepts.ts
@@ -33,9 +33,9 @@ export default class ConceptsController extends Controller {
 
   get visibleConcepts(): ConceptModel[] {
     return this.model.concepts.filter((concept) => {
-      const canViewDraft = this.currentUser?.isStaff || concept.author === this.currentUser;
+      const canViewIfDraft = this.currentUser?.isStaff || concept.author === this.currentUser;
 
-      return concept.statusIsPublished || (concept.statusIsDraft && canViewDraft);
+      return concept.statusIsPublished || (concept.statusIsDraft && canViewIfDraft);
     });
   }
 


### PR DESCRIPTION
Renames the variable `canViewDraft` to `canViewIfDraft` for improved 
readability. This change enhances code clarity by explicitly indicating 
that the visibility check applies only if the concept is a draft.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Enhanced the internal logic for determining content visibility based on user role. These improvements ensure clarity and consistency in permissions without altering the end-user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->