### PR TITLE
refactor: enhance currentBlockGroupIndex logic

### DIFF
--- a/app/components/concept/index.ts
+++ b/app/components/concept/index.ts
@@ -40,11 +40,6 @@ export default class ConceptComponent extends Component<Signature> {
 
     if (bgiQueryParam) {
       this.lastRevealedBlockGroupIndex = parseInt(bgiQueryParam);
-    } else {
-      const progressPercentage = this.args.latestConceptEngagement.currentProgressPercentage;
-      const completedBlocksCount = Math.round((progressPercentage / 100) * this.allBlocks.length);
-      const blockGroupIndex = this.findCurrentBlockGroupIndex(completedBlocksCount);
-      this.lastRevealedBlockGroupIndex = blockGroupIndex;
     }
   }
 
@@ -76,8 +71,15 @@ export default class ConceptComponent extends Component<Signature> {
     }
   }
 
-  get currentBlockGroupIndex() {
-    return this.lastRevealedBlockGroupIndex || 0;
+  get currentBlockGroupIndex(): number {
+    return this.lastRevealedBlockGroupIndex || this.lastRevealedBlockGroupIndexFromConceptEngagement;
+  }
+
+  get lastRevealedBlockGroupIndexFromConceptEngagement(): number {
+    const progressPercentage = this.args.latestConceptEngagement.currentProgressPercentage;
+    const completedBlocksCount = Math.round((progressPercentage / 100) * this.allBlocks.length);
+
+    return this.findCurrentBlockGroupIndex(completedBlocksCount);
   }
 
   get visibleBlockGroups() {


### PR DESCRIPTION
Update the logic for calculating the currentBlockGroupIndex to include 
the last revealed block group index from concept engagement. Add a new 
getter for lastRevealedBlockGroupIndexFromConceptEngagement that computes 
the index based on engagement progress. This change improves accuracy in 
tracking the user's progress within the concept.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Enhanced content progression tracking by refining the calculations based on real-time engagement. This update ensures that the active content stage more accurately reflects user progress, providing a smoother and more intuitive experience when navigating through content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->