### PR TITLE
chore: update PostHog API host for production usage

### DIFF
--- a/app/instance-initializers/posthog.ts
+++ b/app/instance-initializers/posthog.ts
@@ -5,7 +5,7 @@ export function initialize() {
   // @ts-expect-error FastBoot is not typed
   if (typeof FastBoot === 'undefined' && config.environment === 'production') {
     posthog.init('phc_jCl1mm3XbnvyIUr4h54oORqWEqj37gxhZIOebREBwxb', {
-      api_host: 'https://app.posthog.com',
+      api_host: 'https://us.i.posthog.com',
       autocapture: false, // We have our own events
       capture_pageview: false,
       capture_pageleave: false,


### PR DESCRIPTION
Change the PostHog API host from the default app URL to the US 
specific endpoint. This ensures better performance and compliance 
with regional data handling requirements in the production 
environment.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the analytics configuration to use a new data endpoint, ensuring improved data handling and performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->