### PR TITLE
Don't set `x-meta-click-id` cookies under FastBoot

### DIFF
--- a/app/adapters/application.ts
+++ b/app/adapters/application.ts
@@ -22,12 +22,14 @@ export default class ApplicationAdapter extends JSONAPIAdapter {
       headers['x-session-token'] = this.sessionTokenStorage.currentToken;
     }
 
-    if (this.cookies.read('_fbp')) {
-      headers['x-meta-browser-id'] = this.cookies.read('_fbp')!;
-    }
+    if (!this.fastboot.isFastBoot) {
+      if (this.cookies.read('_fbp')) {
+        headers['x-meta-browser-id'] = this.cookies.read('_fbp')!;
+      }
 
-    if (this.cookies.read('_fbc')) {
-      headers['x-meta-click-id'] = this.cookies.read('_fbc')!;
+      if (this.cookies.read('_fbc')) {
+        headers['x-meta-click-id'] = this.cookies.read('_fbc')!;
+      }
     }
 
     headers['x-codecrafters-client-version'] = this.versionTracker.currentVersion;


### PR DESCRIPTION
Follow-up to https://github.com/codecrafters-io/frontend/pull/2736

### Brief

This fixes pre-rendering of User and Concept pages by NOT trying to set cookies under FastBoot

### Checklist

- [x] I've thoroughly self-reviewed my changes
- [x] I've added tests for my changes, unless they affect admin-only areas (or are otherwise not worth testing)
- [x] I've verified any visual changes using Percy (add a commit with `[percy]` in the message to trigger)
