### PR TITLE
Don't show Continue/Back if the concept has been completed

### DIFF
--- a/app/components/concept/index.hbs
+++ b/app/components/concept/index.hbs
@@ -23,16 +23,18 @@
           />
         {{else if (eq block.type "click_to_continue")}}
           {{#if (eq blockGroup.index this.currentBlockGroupIndex)}}
-            <Concept::ContinueOrStepBack
-              {{! @glint-expect-error: buttonTextForDisplay not typecast yet }}
-              @continueButtonText={{block.buttonTextForDisplay}}
-              @onContinueButtonClick={{this.handleContinueButtonClick}}
-              @onStepBackButtonClick={{this.handleStepBackButtonClick}}
-              @shouldHighlightKeyboardShortcuts={{true}}
-              @shouldShowContinueButton={{true}}
-              @shouldShowStepBackButton={{not-eq this.currentBlockGroupIndex 0}}
-              class="mb-6"
-            />
+            {{#unless this.hasFinished}}
+              <Concept::ContinueOrStepBack
+                {{! @glint-expect-error: buttonTextForDisplay not typecast yet }}
+                @continueButtonText={{block.buttonTextForDisplay}}
+                @onContinueButtonClick={{this.handleContinueButtonClick}}
+                @onStepBackButtonClick={{this.handleStepBackButtonClick}}
+                @shouldHighlightKeyboardShortcuts={{true}}
+                @shouldShowContinueButton={{true}}
+                @shouldShowStepBackButton={{not-eq this.currentBlockGroupIndex 0}}
+                class="mb-6"
+              />
+            {{/unless}}
           {{/if}}
         {{else}}
           <div class="mb-6">

--- a/tests/acceptance/concepts-test.js
+++ b/tests/acceptance/concepts-test.js
@@ -918,4 +918,30 @@ module('Acceptance | concepts-test', function (hooks) {
     assert.strictEqual(conceptsPage.conceptCards[3].title, 'New Concept', 'Draft concepts are visible to concept author');
     assert.ok(conceptsPage.conceptCards[3].draftLabel.isVisible, 'Draft label is visible for draft concepts');
   });
+
+  test('can use Delete and Backspace keys in the feedback popup', async function (assert) {
+    testScenario(this.server);
+    createConcepts(this.server);
+
+    signInAsStaff(this.owner, this.server);
+
+    await conceptsPage.visit();
+
+    await conceptsPage.clickOnConceptCard('Dummy Concept');
+
+    await conceptPage.clickOnContinueButton();
+    await conceptPage.clickOnContinueButton();
+    await conceptPage.questionCards[0].keydown({ keyCode: 75 }); // Send k key
+    await conceptPage.questionCards[0].focusedOption.click(); // Simulate ENTER on focused option
+    await conceptPage.questionCards[0].keydown({ keyCode: 'Enter' });
+    await conceptPage.questionCards[0].keydown({ keyCode: 'Enter' });
+    await conceptPage.feedbackDropdown.toggle();
+    await conceptPage.feedbackDropdown.fillInExplanation('Testing feedback');
+    await conceptPage.feedbackDropdown.focusTextArea();
+    await conceptPage.feedbackDropdown.sendKeyToTextArea({ keyCode: 'Enter' });
+    await conceptPage.feedbackDropdown.sendKeyToTextArea({ keyCode: 'Backspace' });
+    await conceptPage.feedbackDropdown.sendKeyToTextArea({ keyCode: 'Backspace' });
+
+    assert.ok(conceptPage.feedbackDropdown.isVisible, 'Feedback dropdown is open');
+  });
 });

--- a/tests/acceptance/submit-site-feedback-test.js
+++ b/tests/acceptance/submit-site-feedback-test.js
@@ -27,15 +27,15 @@ module('Acceptance | submit-site-feedback', function (hooks) {
     await catalogPage.visit();
 
     await feedbackDropdown.toggle();
-    assert.ok(feedbackDropdown.isOpen, 'Feedback dropdown is open');
+    assert.ok(feedbackDropdown.isVisible, 'Feedback dropdown is open');
 
     await percySnapshot('Feedback widget - before submission');
 
     await feedbackDropdown.toggle();
-    assert.notOk(feedbackDropdown.isOpen, 'Feedback dropdown is closed');
+    assert.notOk(feedbackDropdown.isVisible, 'Feedback dropdown is closed');
 
     await feedbackDropdown.toggle();
-    assert.ok(feedbackDropdown.isOpen, 'Feedback dropdown is open');
+    assert.ok(feedbackDropdown.isVisible, 'Feedback dropdown is open');
 
     await feedbackDropdown.clickOnSendButton();
     assert.ok(feedbackDropdown.sendButtonIsVisible, 'Send button is still visible');
@@ -44,7 +44,7 @@ module('Acceptance | submit-site-feedback', function (hooks) {
 
     await feedbackDropdown.clickOnSendButton();
     assert.notOk(feedbackDropdown.sendButtonIsVisible, 'Send button is not visible');
-    assert.ok(feedbackDropdown.isOpen, 'Feedback dropdown is still open (has completed message)');
+    assert.ok(feedbackDropdown.isVisible, 'Feedback dropdown is still open (has completed message)');
 
     const feedbackSubmission = server.schema.siteFeedbackSubmissions.first();
     assert.strictEqual(feedbackSubmission.source, 'header');

--- a/tests/pages/components/feedback-dropdown.ts
+++ b/tests/pages/components/feedback-dropdown.ts
@@ -1,0 +1,11 @@
+import { clickable, create, fillable, focusable, isVisible, triggerable } from 'ember-cli-page-object';
+
+export default create({
+  scope: '[data-test-feedback-dropdown-content]',
+  clickOnSendButton: clickable('[data-test-send-button]'),
+  fillInExplanation: fillable('textarea'),
+  focusTextArea: focusable('textarea'),
+  sendKeyToTextArea: triggerable('keydown', 'textarea'),
+  sendButtonIsVisible: isVisible('[data-test-send-button]'),
+  toggle: clickable('[data-test-feedback-button]:last', { resetScope: true }),
+});

--- a/tests/pages/components/header.js
+++ b/tests/pages/components/header.js
@@ -1,20 +1,13 @@
-import { clickOnText, collection, clickable, fillable, isVisible } from 'ember-cli-page-object';
+import { clickOnText, collection } from 'ember-cli-page-object';
 import BillingStatusBadge from 'codecrafters-frontend/tests/pages/components/billing-status-badge';
+import FeedbackDropdown from 'codecrafters-frontend/tests/pages/components/feedback-dropdown';
 
 export default {
   clickOnHeaderLink: clickOnText('[data-test-header-link]'),
 
   discountTimerBadge: BillingStatusBadge.discountTimerBadge,
 
-  feedbackDropdown: {
-    clickOnSendButton: clickable('[data-test-send-button]'),
-    fillInExplanation: fillable('textarea'),
-    isOpen: isVisible('[data-test-feedback-dropdown-content]', { resetScope: true }),
-    resetScope: true,
-    sendButtonIsVisible: isVisible('[data-test-send-button]'),
-    scope: '[data-test-feedback-dropdown-content]',
-    toggle: clickable('[data-test-feedback-button]', { resetScope: true }),
-  },
+  feedbackDropdown: FeedbackDropdown,
 
   hasLink: function (linkText) {
     return !!this.links.toArray().find((link) => link.text === linkText);

--- a/tests/pages/concept-page.js
+++ b/tests/pages/concept-page.js
@@ -1,6 +1,7 @@
 import { attribute, clickOnText, clickable, collection, isPresent, text, triggerable, visitable, hasClass } from 'ember-cli-page-object';
 import { animationsSettled } from 'ember-animated/test-support';
 import createPage from 'codecrafters-frontend/tests/support/create-page';
+import FeedbackDropdown from 'codecrafters-frontend/tests/pages/components/feedback-dropdown';
 
 export default createPage({
   blocks: collection('[data-test-block]'),
@@ -23,6 +24,8 @@ export default createPage({
     scope: '[data-test-concept-completed-modal]',
     text: text(),
   },
+
+  feedbackDropdown: FeedbackDropdown,
 
   focusedContinueButton: {
     scope: '[data-test-continue-button]:focus',

--- a/tests/pages/course-page.js
+++ b/tests/pages/course-page.js
@@ -7,6 +7,7 @@ import Header from 'codecrafters-frontend/tests/pages/components/course-page/hea
 import FeedbackPrompt from 'codecrafters-frontend/tests/pages/components/course-page/course-stage-step/feedback-prompt';
 import FirstStageTutorialCard from 'codecrafters-frontend/tests/pages/components/course-page/course-stage-step/first-stage-tutorial-card';
 import LanguageDropdown from './components/language-dropdown';
+import FeedbackDropdown from 'codecrafters-frontend/tests/pages/components/feedback-dropdown';
 import Leaderboard from 'codecrafters-frontend/tests/pages/components/course-page/leaderboard';
 import PrivateLeaderboardFeatureSuggestion from 'codecrafters-frontend/tests/pages/components/private-leaderboard-feature-suggestion';
 import RepositoryDropdown from 'codecrafters-frontend/tests/pages/components/course-page/repository-dropdown';
@@ -16,7 +17,7 @@ import Sidebar from 'codecrafters-frontend/tests/pages/components/course-page/si
 import TestResultsBar from 'codecrafters-frontend/tests/pages/components/course-page/test-results-bar';
 import YourTaskCard from 'codecrafters-frontend/tests/pages/components/course-page/course-stage-step/your-task-card';
 import FileContentsCard from 'codecrafters-frontend/tests/pages/components/file-contents-card';
-import { clickOnText, clickable, collection, create, fillable, hasClass, isVisible, text, triggerable, visitable } from 'ember-cli-page-object';
+import { clickOnText, clickable, collection, create, hasClass, isVisible, text, triggerable, visitable } from 'ember-cli-page-object';
 
 export default create({
   adminButton: {
@@ -166,16 +167,7 @@ export default create({
     clickOnExpandButton: clickable('[data-test-expand-button]'),
     clickOnCollapseButton: clickable('[data-test-collapse-button]'),
 
-    feedbackDropdown: {
-      clickOnSendButton: clickable('[data-test-send-button]'),
-      fillInExplanation: fillable('textarea'),
-      isOpen: isVisible('[data-test-feedback-dropdown-content]', { resetScope: true }),
-      resetScope: true,
-      sendButtonIsVisible: isVisible('[data-test-send-button]'),
-      scope: '[data-test-feedback-dropdown-content]',
-      toggle: clickable('[data-test-feedback-button]', { resetScope: true }),
-    },
-
+    feedbackDropdown: FeedbackDropdown,
     languageDropdown: LanguageDropdown,
     scope: '[data-test-language-guide-card]',
   },


### PR DESCRIPTION
Closes #2727

### Brief

After completing the concept, Continue/Back buttons remain visible, and continue responding to Enter/Backspace key presses, stealing them from the Feedback component.

### Details

This hides Continue/Back buttons if the concept has been completed.

### Checklist

- [x] I've thoroughly self-reviewed my changes
- [x] I've added tests for my changes, unless they affect admin-only areas (or are otherwise not worth testing)
- [x] I've verified any visual changes using Percy (add a commit with `[percy]` in the message to trigger)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a new feedback dropdown component for improved user interactions.
  - Added keyboard navigation support for the feedback popup, allowing users to use Delete and Backspace keys.

- **Bug Fixes**
  - Updated the workflow so that the continue/step back option is now only displayed when further action is needed, ensuring that it no longer appears after the process is finished.

- **Tests**
  - Enhanced acceptance tests for feedback popup interactions and visibility assertions. 
  - Added a new page object for the feedback dropdown to streamline testing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->