### PR TITLE
Update frontend to use `Course#visibility` attribute to selectively render courses

### DIFF
--- a/app/components/user-page/course-progress-list.ts
+++ b/app/components/user-page/course-progress-list.ts
@@ -15,9 +15,8 @@ export default class CourseProgressListComponent extends Component<Signature> {
   get courseParticipationGroups() {
     const participationsGroupedByCourse: CourseParticipationModel[][] = Object.values(
       groupBy(
-        this.args.user.courseParticipations.filter((participation) => 
-          !participation.course.releaseStatusIsDeprecated && 
-          participation.course.visibility !== 'private'
+        this.args.user.courseParticipations.filter(
+          (participation) => !participation.course.releaseStatusIsDeprecated && participation.course.visibility !== 'private',
         ),
         'course',
       ),

--- a/app/components/user-page/course-progress-list.ts
+++ b/app/components/user-page/course-progress-list.ts
@@ -16,7 +16,7 @@ export default class CourseProgressListComponent extends Component<Signature> {
     const participationsGroupedByCourse: CourseParticipationModel[][] = Object.values(
       groupBy(
         this.args.user.courseParticipations.filter(
-          (participation) => !participation.course.releaseStatusIsDeprecated && participation.course.visibility !== 'private',
+          (participation) => !participation.course.releaseStatusIsDeprecated && !participation.course.visibilityIsPrivate,
         ),
         'course',
       ),

--- a/app/components/user-page/course-progress-list.ts
+++ b/app/components/user-page/course-progress-list.ts
@@ -15,7 +15,10 @@ export default class CourseProgressListComponent extends Component<Signature> {
   get courseParticipationGroups() {
     const participationsGroupedByCourse: CourseParticipationModel[][] = Object.values(
       groupBy(
-        this.args.user.courseParticipations.filter((participation) => !participation.course.releaseStatusIsDeprecated),
+        this.args.user.courseParticipations.filter((participation) => 
+          !participation.course.releaseStatusIsDeprecated && 
+          participation.course.visibility !== 'private'
+        ),
         'course',
       ),
     );

--- a/app/controllers/catalog.ts
+++ b/app/controllers/catalog.ts
@@ -104,7 +104,7 @@ export default class CatalogController extends Controller {
       this.authenticator.currentUser && (this.authenticator.currentUser.isStaff || this.authenticator.currentUser.isCourseAuthor(course));
     const userHasRepository = this.authenticator.currentUser && this.authenticator.currentUser.repositories.filterBy('course', course).length > 0;
 
-    if (course.releaseStatusIsDeprecated || course.visibility === 'private') {
+    if (course.releaseStatusIsDeprecated || course.visibilityIsPrivate) {
       return userHasRepository;
     }
 

--- a/app/controllers/catalog.ts
+++ b/app/controllers/catalog.ts
@@ -104,7 +104,7 @@ export default class CatalogController extends Controller {
       this.authenticator.currentUser && (this.authenticator.currentUser.isStaff || this.authenticator.currentUser.isCourseAuthor(course));
     const userHasRepository = this.authenticator.currentUser && this.authenticator.currentUser.repositories.filterBy('course', course).length > 0;
 
-    if (course.releaseStatusIsDeprecated) {
+    if (course.releaseStatusIsDeprecated || course.visibility === 'private') {
       return userHasRepository;
     }
 

--- a/app/controllers/join-track.ts
+++ b/app/controllers/join-track.ts
@@ -12,10 +12,7 @@ export default class JoinTrackController extends Controller {
   @service declare authenticator: AuthenticatorService;
 
   get courses(): CourseModel[] {
-    return this.model.courses
-      .rejectBy('releaseStatusIsAlpha')
-      .rejectBy('releaseStatusIsDeprecated')
-      .rejectBy('visibility', 'private');
+    return this.model.courses.rejectBy('releaseStatusIsAlpha').rejectBy('releaseStatusIsDeprecated').rejectBy('visibility', 'private');
   }
 
   get sortedCourses(): CourseModel[] {

--- a/app/controllers/join-track.ts
+++ b/app/controllers/join-track.ts
@@ -12,7 +12,10 @@ export default class JoinTrackController extends Controller {
   @service declare authenticator: AuthenticatorService;
 
   get courses(): CourseModel[] {
-    return this.model.courses.rejectBy('releaseStatusIsAlpha').rejectBy('releaseStatusIsDeprecated');
+    return this.model.courses
+      .rejectBy('releaseStatusIsAlpha')
+      .rejectBy('releaseStatusIsDeprecated')
+      .rejectBy('visibility', 'private');
   }
 
   get sortedCourses(): CourseModel[] {

--- a/app/controllers/join-track.ts
+++ b/app/controllers/join-track.ts
@@ -12,7 +12,7 @@ export default class JoinTrackController extends Controller {
   @service declare authenticator: AuthenticatorService;
 
   get courses(): CourseModel[] {
-    return this.model.courses.rejectBy('releaseStatusIsAlpha').rejectBy('releaseStatusIsDeprecated').rejectBy('visibility', 'private');
+    return this.model.courses.rejectBy('releaseStatusIsAlpha').rejectBy('releaseStatusIsDeprecated').rejectBy('visibilityIsPrivate');
   }
 
   get sortedCourses(): CourseModel[] {

--- a/app/controllers/track.ts
+++ b/app/controllers/track.ts
@@ -14,7 +14,7 @@ export default class TrackController extends Controller {
       return this.model.courses;
     }
 
-    return this.model.courses.rejectBy('releaseStatusIsAlpha').rejectBy('releaseStatusIsDeprecated').rejectBy('visibility', 'private');
+    return this.model.courses.rejectBy('releaseStatusIsAlpha').rejectBy('releaseStatusIsDeprecated').rejectBy('visibilityIsPrivate');
   }
 
   get sortedCourses(): CourseModel[] {

--- a/app/controllers/track.ts
+++ b/app/controllers/track.ts
@@ -14,10 +14,7 @@ export default class TrackController extends Controller {
       return this.model.courses;
     }
 
-    return this.model.courses
-      .rejectBy('releaseStatusIsAlpha')
-      .rejectBy('releaseStatusIsDeprecated')
-      .rejectBy('visibility', 'private');
+    return this.model.courses.rejectBy('releaseStatusIsAlpha').rejectBy('releaseStatusIsDeprecated').rejectBy('visibility', 'private');
   }
 
   get sortedCourses(): CourseModel[] {

--- a/app/controllers/track.ts
+++ b/app/controllers/track.ts
@@ -14,7 +14,10 @@ export default class TrackController extends Controller {
       return this.model.courses;
     }
 
-    return this.model.courses.rejectBy('releaseStatusIsAlpha').rejectBy('releaseStatusIsDeprecated');
+    return this.model.courses
+      .rejectBy('releaseStatusIsAlpha')
+      .rejectBy('releaseStatusIsDeprecated')
+      .rejectBy('visibility', 'private');
   }
 
   get sortedCourses(): CourseModel[] {

--- a/app/controllers/vote/course-extension-ideas.ts
+++ b/app/controllers/vote/course-extension-ideas.ts
@@ -31,6 +31,7 @@ export default class CourseExtensionIdeasController extends Controller {
       .uniq()
       .rejectBy('releaseStatusIsDeprecated')
       .rejectBy('releaseStatusIsAlpha')
+      .rejectBy('visibility', 'private')
       .sortBy('sortPositionForTrack');
   }
 

--- a/app/controllers/vote/course-extension-ideas.ts
+++ b/app/controllers/vote/course-extension-ideas.ts
@@ -31,7 +31,7 @@ export default class CourseExtensionIdeasController extends Controller {
       .uniq()
       .rejectBy('releaseStatusIsDeprecated')
       .rejectBy('releaseStatusIsAlpha')
-      .rejectBy('visibility', 'private')
+      .rejectBy('visibilityIsPrivate')
       .sortBy('sortPositionForTrack');
   }
 

--- a/app/models/course.ts
+++ b/app/models/course.ts
@@ -44,6 +44,7 @@ export default class CourseModel extends Model {
   @attr('string') declare shortName: string;
   @attr('string') declare slug: string;
   @attr('string') declare testerRepositoryFullName: string;
+  @attr('string') declare visibility: 'public' | 'private';
 
   @attr() declare testimonials: {
     author_name: string;

--- a/app/models/course.ts
+++ b/app/models/course.ts
@@ -81,6 +81,9 @@ export default class CourseModel extends Model {
   @equal('releaseStatus', 'live') declare releaseStatusIsLive: boolean;
   @equal('releaseStatus', 'deprecated') declare releaseStatusIsDeprecated: boolean;
 
+  @equal('visibility', 'public') declare visibilityIsPublic: boolean;
+  @equal('visibility', 'private') declare visibilityIsPrivate: boolean;
+
   @service declare date: DateService;
 
   get baseStages() {

--- a/package-lock.json
+++ b/package-lock.json
@@ -14803,9 +14803,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001666",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001666.tgz",
-      "integrity": "sha512-gD14ICmoV5ZZM1OdzPWmpx+q4GyefaK06zi8hmfHV5xe4/2nOQX3+Dw5o+fSqOws2xVwL9j+anOPFwHzdEdV4g==",
+      "version": "1.0.30001707",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001707.tgz",
+      "integrity": "sha512-3qtRjw/HQSMlDWf+X79N206fepf4SOOU6SQLMaq/0KkZLmSjPxAkBOQQ+FxbHKfHmYLZFfdWsO3KA90ceHPSnw==",
       "dev": true,
       "funding": [
         {
@@ -14820,7 +14820,8 @@
           "type": "github",
           "url": "https://github.com/sponsors/ai"
         }
-      ]
+      ],
+      "license": "CC-BY-4.0"
     },
     "node_modules/canvas-confetti": {
       "version": "1.9.3",

--- a/tests/acceptance/track-page/view-track-test.js
+++ b/tests/acceptance/track-page/view-track-test.js
@@ -140,6 +140,40 @@ module('Acceptance | track-page | view-track', function (hooks) {
     assert.notOk(trackPage.cards.mapBy('title').includes('Build your own Docker'));
   });
 
+  test('it does not show a challenge if it is private', async function (assert) {
+    signIn(this.owner, this.server);
+
+    let redis = this.server.schema.courses.findBy({ slug: 'redis' });
+    redis.update({ visibility: 'private' });
+
+    await visit('/tracks/python');
+    assert.notOk(
+      trackPage.cards.mapBy('title').includes('Build your own Redis'),
+      'private course should not be included'
+    );
+  });
+
+  test('it does not show a challenge if it is private and user has repository', async function (assert) {
+    signIn(this.owner, this.server);
+
+    let currentUser = this.server.schema.users.first();
+    let python = this.server.schema.languages.findBy({ name: 'Python' });
+    let redis = this.server.schema.courses.findBy({ slug: 'redis' });
+    redis.update({ visibility: 'private' });
+
+    this.server.create('repository', {
+      course: redis,
+      language: python,
+      user: currentUser,
+    });
+
+    await visit('/tracks/python');
+    assert.notOk(
+      trackPage.cards.mapBy('title').includes('Build your own Redis'),
+      'private course should not be included'
+    );
+  });
+
   test('visiting from catalog page has no loading page', async function (assert) {
     let loadingIndicatorWasRendered = false;
 

--- a/tests/acceptance/track-page/view-track-test.js
+++ b/tests/acceptance/track-page/view-track-test.js
@@ -147,10 +147,7 @@ module('Acceptance | track-page | view-track', function (hooks) {
     redis.update({ visibility: 'private' });
 
     await visit('/tracks/python');
-    assert.notOk(
-      trackPage.cards.mapBy('title').includes('Build your own Redis'),
-      'private course should not be included'
-    );
+    assert.notOk(trackPage.cards.mapBy('title').includes('Build your own Redis'), 'private course should not be included');
   });
 
   test('it does not show a challenge if it is private and user has repository', async function (assert) {
@@ -168,10 +165,7 @@ module('Acceptance | track-page | view-track', function (hooks) {
     });
 
     await visit('/tracks/python');
-    assert.notOk(
-      trackPage.cards.mapBy('title').includes('Build your own Redis'),
-      'private course should not be included'
-    );
+    assert.notOk(trackPage.cards.mapBy('title').includes('Build your own Redis'), 'private course should not be included');
   });
 
   test('visiting from catalog page has no loading page', async function (assert) {

--- a/tests/acceptance/view-user-profile-test.js
+++ b/tests/acceptance/view-user-profile-test.js
@@ -250,4 +250,38 @@ module('Acceptance | view-user-profile', function (hooks) {
     assert.strictEqual(userPage.courseProgressListItems.length, 1, 'only one course progress list item should be shown');
     assert.strictEqual(userPage.courseProgressListItems[0].name, 'Build your own grep', 'the course progress list item should be for grep');
   });
+
+  test('it does not show private courses in user profile', async function (assert) {
+    testScenario(this.server);
+
+    let currentUser = this.server.schema.users.first();
+    let go = this.server.schema.languages.findBy({ slug: 'go' });
+    let redis = this.server.schema.courses.findBy({ slug: 'redis' });
+    let grep = this.server.schema.courses.findBy({ slug: 'grep' });
+    redis.update({ visibility: 'private' });
+
+    this.server.create('course-participation', {
+      course: grep,
+      language: go,
+      user: currentUser,
+      completedStageSlugs: grep.stages.models.sortBy('position').slice(0, 5).mapBy('slug'),
+      lastSubmissionAt: new Date('2020-10-10'),
+    });
+
+    this.server.create('course-participation', {
+      course: redis,
+      language: go,
+      user: currentUser,
+      completedAt: new Date('2020-01-01'),
+    });
+
+    await userPage.visit({ username: 'rohitpaulk' });
+
+    assert.strictEqual(userPage.courseProgressListItems.length, 1, 'only one course progress list item should be shown');
+    assert.strictEqual(userPage.courseProgressListItems[0].name, 'Build your own grep', 'the course progress list item should be for grep');
+    assert.notOk(
+      userPage.courseProgressListItems.mapBy('name').includes('Build your own Redis'),
+      'private course should not be included'
+    );
+  });
 });

--- a/tests/acceptance/view-user-profile-test.js
+++ b/tests/acceptance/view-user-profile-test.js
@@ -279,9 +279,6 @@ module('Acceptance | view-user-profile', function (hooks) {
 
     assert.strictEqual(userPage.courseProgressListItems.length, 1, 'only one course progress list item should be shown');
     assert.strictEqual(userPage.courseProgressListItems[0].name, 'Build your own grep', 'the course progress list item should be for grep');
-    assert.notOk(
-      userPage.courseProgressListItems.mapBy('name').includes('Build your own Redis'),
-      'private course should not be included'
-    );
+    assert.notOk(userPage.courseProgressListItems.mapBy('name').includes('Build your own Redis'), 'private course should not be included');
   });
 });


### PR DESCRIPTION
Introduce a visibility attribute to the CourseModel and ensure that private courses are filtered out from participation groups, course listings, and extension ideas. This enhances access control and user experience by preventing private courses from appearing in relevant contexts.

**Checklist**:

- [x] I've thoroughly self-reviewed my changes
- [x] I've added tests for my changes, unless they affect admin-only areas (or are otherwise not worth testing)
- [ ] I've verified any visual changes using Percy (add a commit with `[percy]` in the message to trigger)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a visibility setting for courses, allowing them to be marked as public or private.
  - Enhanced the filtering logic across multiple areas to exclude courses marked as private—along with those already restricted due to other statuses—improving the relevance of displayed course lists.

- **Bug Fixes**
  - Ensured private courses are not displayed in various contexts, including user profiles and course catalogs.

- **Tests**
  - Implemented new acceptance tests to verify the correct handling of private courses in the track page, course catalog, and user profile views.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->