### PR TITLE
Filter out private courses from various views and components

### DIFF
--- a/app/components/course-page/course-stage-step/first-stage-tutorial-card/submit-code-step.hbs
+++ b/app/components/course-page/course-stage-step/first-stage-tutorial-card/submit-code-step.hbs
@@ -118,7 +118,7 @@
         </ol>
       </div>
 
-      {{#if (eq this.currentCourse.visibility "public")}}
+      {{#if this.currentCourse.visibilityIsPublic}}
         <div class="prose dark:prose-invert prose-sm prose-compact mt-10">
           <p>
             Need help?
@@ -190,7 +190,7 @@
         </ol>
       </div>
 
-      {{#if (eq this.currentCourse.visibility "public")}}
+      {{#if this.currentCourse.visibilityIsPublic}}
         <div class="prose dark:prose-invert prose-sm prose-compact mt-10">
           <p>
             Need help?

--- a/app/components/course-page/course-stage-step/first-stage-tutorial-card/submit-code-step.hbs
+++ b/app/components/course-page/course-stage-step/first-stage-tutorial-card/submit-code-step.hbs
@@ -118,7 +118,7 @@
         </ol>
       </div>
 
-      {{#if (eq this.currentCourse.visibility 'public')}}
+      {{#if (eq this.currentCourse.visibility "public")}}
         <div class="prose dark:prose-invert prose-sm prose-compact mt-10">
           <p>
             Need help?
@@ -190,7 +190,7 @@
         </ol>
       </div>
 
-      {{#if (eq this.currentCourse.visibility 'public')}}
+      {{#if (eq this.currentCourse.visibility "public")}}
         <div class="prose dark:prose-invert prose-sm prose-compact mt-10">
           <p>
             Need help?

--- a/app/components/course-page/course-stage-step/first-stage-tutorial-card/submit-code-step.hbs
+++ b/app/components/course-page/course-stage-step/first-stage-tutorial-card/submit-code-step.hbs
@@ -118,23 +118,25 @@
         </ol>
       </div>
 
-      <div class="prose dark:prose-invert prose-sm prose-compact mt-10">
-        <p>
-          Need help?
-          <a
-            href="https://forum.codecrafters.io/new-topic?category=Challenges&tags=challenge%3A{{this.currentCourse.slug}}&title=%5B{{this.currentCourse.shortName}}%5D%20How%20to%20pass%20the%20first%20stage%3F&body=Checklist%3A%0A%0A1.%20%E2%9C%85%20or%20%E2%9D%8C%3A%20I%27ve%20uncommented%20the%20code.%0A2.%20%E2%9C%85%20or%20%E2%9D%8C%3A%20I%27ve%20saved%20the%20changes.%0A3.%20%E2%9C%85%20or%20%E2%9D%8C%3A%20I%27ve%20run%20the%20git%20commands%3A%0A%0A%60%60%60%0Agit%20commit%20-am%20%22%5Bseeking%20help%20on%20forum%5D%22%0Agit%20push%20origin%20master%0A%60%60%60%0A%0A---%0A%0AHere%E2%80%99s%20a%20screenshot%20showing%20the%20output%20from%20running%20the%20Git%20commands%3A%0A%0A%5BAttach%20screenshot%20here%5D%0A%0A%5BShare%20other%20details%20here%5D"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            Post your issue</a>
-          on the forum —
-          <img
-            alt="avatar"
-            src="https://avatars.githubusercontent.com/u/1450947"
-            class="inline-block ml-1 mr-1.5 my-0 -translate-y-px overflow-hidden rounded-full size-4 filter drop-shadow-sm ring-1 ring-white dark:ring-white/5 shadow"
-          />Andy usually replies within 6 hours.
-        </p>
-      </div>
+      {{#if (eq this.currentCourse.visibility 'public')}}
+        <div class="prose dark:prose-invert prose-sm prose-compact mt-10">
+          <p>
+            Need help?
+            <a
+              href="https://forum.codecrafters.io/new-topic?category=Challenges&tags=challenge%3A{{this.currentCourse.slug}}&title=%5B{{this.currentCourse.shortName}}%5D%20How%20to%20pass%20the%20first%20stage%3F&body=Checklist%3A%0A%0A1.%20%E2%9C%85%20or%20%E2%9D%8C%3A%20I%27ve%20uncommented%20the%20code.%0A2.%20%E2%9C%85%20or%20%E2%9D%8C%3A%20I%27ve%20saved%20the%20changes.%0A3.%20%E2%9C%85%20or%20%E2%9D%8C%3A%20I%27ve%20run%20the%20git%20commands%3A%0A%0A%60%60%60%0Agit%20commit%20-am%20%22%5Bseeking%20help%20on%20forum%5D%22%0Agit%20push%20origin%20master%0A%60%60%60%0A%0A---%0A%0AHere%E2%80%99s%20a%20screenshot%20showing%20the%20output%20from%20running%20the%20Git%20commands%3A%0A%0A%5BAttach%20screenshot%20here%5D%0A%0A%5BShare%20other%20details%20here%5D"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              Post your issue</a>
+            on the forum —
+            <img
+              alt="avatar"
+              src="https://avatars.githubusercontent.com/u/1450947"
+              class="inline-block ml-1 mr-1.5 my-0 -translate-y-px overflow-hidden rounded-full size-4 filter drop-shadow-sm ring-1 ring-white dark:ring-white/5 shadow"
+            />Andy usually replies within 6 hours.
+          </p>
+        </div>
+      {{/if}}
     </ModalBody>
   </ModalBackdrop>
 {{/if}}
@@ -188,23 +190,25 @@
         </ol>
       </div>
 
-      <div class="prose dark:prose-invert prose-sm prose-compact mt-10">
-        <p>
-          Need help?
-          <a
-            href="https://forum.codecrafters.io/new-topic?category=Challenges&tags=challenge%3A{{this.currentCourse.slug}}&title=%5B{{this.currentCourse.shortName}}%5D%20How%20to%20pass%20the%20first%20stage%3F&body=Checklist%3A%0A%0A1.%20%E2%9C%85%20or%20%E2%9D%8C%3A%20I%27ve%20uncommented%20the%20code.%0A2.%20%E2%9C%85%20or%20%E2%9D%8C%3A%20I%27ve%20saved%20the%20changes.%0A3.%20%E2%9C%85%20or%20%E2%9D%8C%3A%20I%27ve%20run%20the%20git%20commands%3A%0A%0A%60%60%60%0Agit%20commit%20-am%20%22%5Bseeking%20help%20on%20forum%5D%22%0Agit%20push%20origin%20master%0A%60%60%60%0A%0A---%0A%0AHere%E2%80%99s%20a%20screenshot%20showing%20the%20output%20from%20running%20the%20Git%20commands%3A%0A%0A%5BAttach%20screenshot%20here%5D%0A%0A%5BShare%20other%20details%20here%5D"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            Post your issue</a>
-          on the forum —
-          <img
-            alt="avatar"
-            src="https://avatars.githubusercontent.com/u/1450947"
-            class="inline-block ml-1 mr-1.5 my-0 -translate-y-px overflow-hidden rounded-full size-4 filter drop-shadow-sm ring-1 ring-white dark:ring-white/5 shadow"
-          />Andy usually replies within 6 hours.
-        </p>
-      </div>
+      {{#if (eq this.currentCourse.visibility 'public')}}
+        <div class="prose dark:prose-invert prose-sm prose-compact mt-10">
+          <p>
+            Need help?
+            <a
+              href="https://forum.codecrafters.io/new-topic?category=Challenges&tags=challenge%3A{{this.currentCourse.slug}}&title=%5B{{this.currentCourse.shortName}}%5D%20How%20to%20pass%20the%20first%20stage%3F&body=Checklist%3A%0A%0A1.%20%E2%9C%85%20or%20%E2%9D%8C%3A%20I%27ve%20uncommented%20the%20code.%0A2.%20%E2%9C%85%20or%20%E2%9D%8C%3A%20I%27ve%20saved%20the%20changes.%0A3.%20%E2%9C%85%20or%20%E2%9D%8C%3A%20I%27ve%20run%20the%20git%20commands%3A%0A%0A%60%60%60%0Agit%20commit%20-am%20%22%5Bseeking%20help%20on%20forum%5D%22%0Agit%20push%20origin%20master%0A%60%60%60%0A%0A---%0A%0AHere%E2%80%99s%20a%20screenshot%20showing%20the%20output%20from%20running%20the%20Git%20commands%3A%0A%0A%5BAttach%20screenshot%20here%5D%0A%0A%5BShare%20other%20details%20here%5D"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              Post your issue</a>
+            on the forum —
+            <img
+              alt="avatar"
+              src="https://avatars.githubusercontent.com/u/1450947"
+              class="inline-block ml-1 mr-1.5 my-0 -translate-y-px overflow-hidden rounded-full size-4 filter drop-shadow-sm ring-1 ring-white dark:ring-white/5 shadow"
+            />Andy usually replies within 6 hours.
+          </p>
+        </div>
+      {{/if}}
     </ModalBody>
   </ModalBackdrop>
 {{/if}}

--- a/app/components/course-page/course-stage-step/your-task-card/action-button-list.ts
+++ b/app/components/course-page/course-stage-step/your-task-card/action-button-list.ts
@@ -27,7 +27,8 @@ export default class ActionButtonListComponent extends Component<Signature> {
   }
 
   get shouldShowCodeExamplesButton() {
-    return !this.args.courseStage.isFirst && this.args.courseStage.course.visibility === 'public';
+    // TODO: Remove. Temporary measure for private course
+    return !this.args.courseStage.isFirst && this.args.courseStage.slug !== 'gleam-chess-bot';
   }
 
   get shouldShowViewScreencastsButton() {

--- a/app/components/course-page/course-stage-step/your-task-card/action-button-list.ts
+++ b/app/components/course-page/course-stage-step/your-task-card/action-button-list.ts
@@ -27,7 +27,7 @@ export default class ActionButtonListComponent extends Component<Signature> {
   }
 
   get shouldShowCodeExamplesButton() {
-    return !this.args.courseStage.isFirst;
+    return !this.args.courseStage.isFirst && this.args.courseStage.course.visibility === 'public';
   }
 
   get shouldShowViewScreencastsButton() {

--- a/app/components/course-page/header/tab-list.ts
+++ b/app/components/course-page/header/tab-list.ts
@@ -103,54 +103,56 @@ export default class TabListComponent extends Component<Signature> {
       isActive: this.router.currentRouteName === 'course.stage.instructions',
     });
 
-    tabs.push({
-      icon: 'code',
-      name: 'Code Examples',
-      slug: 'code_examples',
-      internalLink: {
-        route: 'course.stage.code-examples',
-        models: this.args.currentStep.routeParams.models,
-      },
-      isActive: this.router.currentRouteName === 'course.stage.code-examples',
-    });
-
-    // @ts-ignore
-    if (this.args.currentStep.courseStage && this.args.currentStep.courseStage.hasScreencasts) {
+    if (this.args.course.visibility === 'public') {
       tabs.push({
-        icon: 'play',
-        name: 'Screencasts',
-        slug: 'screencasts',
+        icon: 'code',
+        name: 'Code Examples',
+        slug: 'code_examples',
         internalLink: {
-          route: 'course.stage.screencasts',
+          route: 'course.stage.code-examples',
           models: this.args.currentStep.routeParams.models,
         },
-        isActive: this.router.currentRouteName === 'course.stage.screencasts',
+        isActive: this.router.currentRouteName === 'course.stage.code-examples',
       });
-    }
 
-    // @ts-ignore
-    if (this.args.currentStep.courseStage && this.args.currentStep.courseStage.course.hasConcepts) {
+      // @ts-ignore
+      if (this.args.currentStep.courseStage && this.args.currentStep.courseStage.hasScreencasts) {
+        tabs.push({
+          icon: 'play',
+          name: 'Screencasts',
+          slug: 'screencasts',
+          internalLink: {
+            route: 'course.stage.screencasts',
+            models: this.args.currentStep.routeParams.models,
+          },
+          isActive: this.router.currentRouteName === 'course.stage.screencasts',
+        });
+      }
+
+      // @ts-ignore
+      if (this.args.currentStep.courseStage && this.args.currentStep.courseStage.course.hasConcepts) {
+        tabs.push({
+          icon: 'academic-cap',
+          name: 'Concepts',
+          slug: 'concepts',
+          internalLink: {
+            route: 'course.stage.concepts',
+            models: this.args.currentStep.routeParams.models,
+          },
+          isActive: this.router.currentRouteName === 'course.stage.concepts',
+        });
+      }
+
       tabs.push({
-        icon: 'academic-cap',
-        name: 'Concepts',
-        slug: 'concepts',
-        internalLink: {
-          route: 'course.stage.concepts',
-          models: this.args.currentStep.routeParams.models,
+        icon: 'chat-alt-2',
+        name: 'Forum',
+        slug: 'forum',
+        externalLink: {
+          url: this.args.course.forumUrl,
         },
-        isActive: this.router.currentRouteName === 'course.stage.concepts',
+        isActive: false,
       });
     }
-
-    tabs.push({
-      icon: 'chat-alt-2',
-      name: 'Forum',
-      slug: 'forum',
-      externalLink: {
-        url: this.args.course.forumUrl,
-      },
-      isActive: false,
-    });
 
     return tabs;
   }

--- a/app/components/course-page/header/tab-list.ts
+++ b/app/components/course-page/header/tab-list.ts
@@ -103,7 +103,8 @@ export default class TabListComponent extends Component<Signature> {
       isActive: this.router.currentRouteName === 'course.stage.instructions',
     });
 
-    if (this.args.course.visibility === 'public') {
+    // TODO: Remove. Temporary measure for private course
+    if (this.args.course.slug !== 'gleam-chess-bot') {
       tabs.push({
         icon: 'code',
         name: 'Code Examples',
@@ -114,7 +115,9 @@ export default class TabListComponent extends Component<Signature> {
         },
         isActive: this.router.currentRouteName === 'course.stage.code-examples',
       });
+    }
 
+    if (this.args.course.visibility === 'public') {
       // @ts-ignore
       if (this.args.currentStep.courseStage && this.args.currentStep.courseStage.hasScreencasts) {
         tabs.push({

--- a/app/components/course-page/header/tab-list.ts
+++ b/app/components/course-page/header/tab-list.ts
@@ -117,7 +117,7 @@ export default class TabListComponent extends Component<Signature> {
       });
     }
 
-    if (this.args.course.visibility === 'public') {
+    if (this.args.course.visibilityIsPublic) {
       // @ts-ignore
       if (this.args.currentStep.courseStage && this.args.currentStep.courseStage.hasScreencasts) {
         tabs.push({

--- a/app/controllers/course/stage/code-examples.ts
+++ b/app/controllers/course/stage/code-examples.ts
@@ -97,8 +97,8 @@ export default class CodeExamplesController extends Controller {
       return;
     }
 
-    // Check if course is private before loading solutions
-    if (this.courseStage.course.visibility === 'private') {
+    // TODO: Remove: Temporary measure for private course
+    if (this.courseStage.course.slug === 'gleam-chess-bot') {
       this.router.transitionTo('not-found');
 
       return;

--- a/app/controllers/course/stage/code-examples.ts
+++ b/app/controllers/course/stage/code-examples.ts
@@ -8,6 +8,7 @@ import { inject as service } from '@ember/service';
 import { action } from '@ember/object';
 import type Store from '@ember-data/store';
 import type CommunityCourseStageSolutionModel from 'codecrafters-frontend/models/community-course-stage-solution';
+import type RouterService from '@ember/routing/router-service';
 
 export default class CodeExamplesController extends Controller {
   declare model: {
@@ -16,6 +17,7 @@ export default class CodeExamplesController extends Controller {
   };
 
   @service declare store: Store;
+  @service declare router: RouterService;
 
   rippleSpinnerImage = rippleSpinnerImage;
   @tracked order: 'recommended' | 'recent' | 'affiliated' = 'recommended';
@@ -92,6 +94,12 @@ export default class CodeExamplesController extends Controller {
   @action
   async loadSolutions() {
     if (!this.currentLanguage) {
+      return;
+    }
+
+    // Check if course is private before loading solutions
+    if (this.courseStage.course.visibility === 'private') {
+      this.router.transitionTo('not-found');
       return;
     }
 

--- a/app/controllers/course/stage/code-examples.ts
+++ b/app/controllers/course/stage/code-examples.ts
@@ -97,13 +97,6 @@ export default class CodeExamplesController extends Controller {
       return;
     }
 
-    // TODO: Remove: Temporary measure for private course
-    if (this.courseStage.course.slug === 'gleam-chess-bot') {
-      this.router.transitionTo('not-found');
-
-      return;
-    }
-
     this.isLoading = true;
 
     this.solutions = (await this.store.query('community-course-stage-solution', {

--- a/app/controllers/course/stage/code-examples.ts
+++ b/app/controllers/course/stage/code-examples.ts
@@ -100,6 +100,7 @@ export default class CodeExamplesController extends Controller {
     // Check if course is private before loading solutions
     if (this.courseStage.course.visibility === 'private') {
       this.router.transitionTo('not-found');
+
       return;
     }
 

--- a/app/controllers/course/stage/code-examples.ts
+++ b/app/controllers/course/stage/code-examples.ts
@@ -16,8 +16,8 @@ export default class CodeExamplesController extends Controller {
     activeRepository: RepositoryModel;
   };
 
-  @service declare store: Store;
   @service declare router: RouterService;
+  @service declare store: Store;
 
   rippleSpinnerImage = rippleSpinnerImage;
   @tracked order: 'recommended' | 'recent' | 'affiliated' = 'recommended';

--- a/app/templates/course/stage/instructions.hbs
+++ b/app/templates/course/stage/instructions.hbs
@@ -83,24 +83,26 @@
       </div>
     {{/if}}
 
-    {{#if this.shouldShowStage1ForumLinkCTA}}
-      <div class="prose dark:prose-invert prose-sm prose-compact ml-4 mb-10">
-        <p>
-          Need help?
-          <a
-            href="https://forum.codecrafters.io/new-topic?category=Challenges&tags=challenge%3A{{this.currentCourse.slug}}&title=%5B{{this.currentCourse.shortName}}%5D%20How%20to%20pass%20the%20first%20stage%3F&body=Checklist%3A%0A%0A1.%20%E2%9C%85%20or%20%E2%9D%8C%3A%20I%27ve%20uncommented%20the%20code.%0A2.%20%E2%9C%85%20or%20%E2%9D%8C%3A%20I%27ve%20saved%20the%20changes.%0A3.%20%E2%9C%85%20or%20%E2%9D%8C%3A%20I%27ve%20run%20the%20git%20commands%3A%0A%0A%60%60%60%0Agit%20commit%20-am%20%22%5Bseeking%20help%20on%20forum%5D%22%0Agit%20push%20origin%20master%0A%60%60%60%0A%0A---%0A%0AHere%E2%80%99s%20a%20screenshot%20showing%20the%20output%20from%20running%20the%20Git%20commands%3A%0A%0A%5BAttach%20screenshot%20here%5D%0A%0A%5BShare%20other%20details%20here%5D"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            Post your issue</a>
-          on the forum —
-          <img
-            alt="avatar"
-            src="https://avatars.githubusercontent.com/u/1450947"
-            class="inline-block ml-1 mr-1.5 my-0 -translate-y-px overflow-hidden rounded-full size-4 filter drop-shadow-sm ring-1 ring-white dark:ring-white/5 shadow"
-          />Andy usually replies within 6 hours.
-        </p>
-      </div>
+    {{#if (eq this.currentStep.courseStage.course.visibility "public")}}
+      {{#if this.shouldShowStage1ForumLinkCTA}}
+        <div class="prose dark:prose-invert prose-sm prose-compact ml-4 mb-10">
+          <p>
+            Need help?
+            <a
+              href="https://forum.codecrafters.io/new-topic?category=Challenges&tags=challenge%3A{{this.currentCourse.slug}}&title=%5B{{this.currentCourse.shortName}}%5D%20How%20to%20pass%20the%20first%20stage%3F&body=Checklist%3A%0A%0A1.%20%E2%9C%85%20or%20%E2%9D%8C%3A%20I%27ve%20uncommented%20the%20code.%0A2.%20%E2%9C%85%20or%20%E2%9D%8C%3A%20I%27ve%20saved%20the%20changes.%0A3.%20%E2%9C%85%20or%20%E2%9D%8C%3A%20I%27ve%20run%20the%20git%20commands%3A%0A%0A%60%60%60%0Agit%20commit%20-am%20%22%5Bseeking%20help%20on%20forum%5D%22%0Agit%20push%20origin%20master%0A%60%60%60%0A%0A---%0A%0AHere%E2%80%99s%20a%20screenshot%20showing%20the%20output%20from%20running%20the%20Git%20commands%3A%0A%0A%5BAttach%20screenshot%20here%5D%0A%0A%5BShare%20other%20details%20here%5D"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              Post your issue</a>
+            on the forum —
+            <img
+              alt="avatar"
+              src="https://avatars.githubusercontent.com/u/1450947"
+              class="inline-block ml-1 mr-1.5 my-0 -translate-y-px overflow-hidden rounded-full size-4 filter drop-shadow-sm ring-1 ring-white dark:ring-white/5 shadow"
+            />Andy usually replies within 6 hours.
+          </p>
+        </div>
+      {{/if}}
     {{/if}}
 
     {{! TODO: Remove this temporary CTA  }}

--- a/app/templates/course/stage/instructions.hbs
+++ b/app/templates/course/stage/instructions.hbs
@@ -83,26 +83,24 @@
       </div>
     {{/if}}
 
-    {{#if (eq this.currentStep.courseStage.course.visibility "public")}}
-      {{#if this.shouldShowStage1ForumLinkCTA}}
-        <div class="prose dark:prose-invert prose-sm prose-compact ml-4 mb-10">
-          <p>
-            Need help?
-            <a
-              href="https://forum.codecrafters.io/new-topic?category=Challenges&tags=challenge%3A{{this.currentCourse.slug}}&title=%5B{{this.currentCourse.shortName}}%5D%20How%20to%20pass%20the%20first%20stage%3F&body=Checklist%3A%0A%0A1.%20%E2%9C%85%20or%20%E2%9D%8C%3A%20I%27ve%20uncommented%20the%20code.%0A2.%20%E2%9C%85%20or%20%E2%9D%8C%3A%20I%27ve%20saved%20the%20changes.%0A3.%20%E2%9C%85%20or%20%E2%9D%8C%3A%20I%27ve%20run%20the%20git%20commands%3A%0A%0A%60%60%60%0Agit%20commit%20-am%20%22%5Bseeking%20help%20on%20forum%5D%22%0Agit%20push%20origin%20master%0A%60%60%60%0A%0A---%0A%0AHere%E2%80%99s%20a%20screenshot%20showing%20the%20output%20from%20running%20the%20Git%20commands%3A%0A%0A%5BAttach%20screenshot%20here%5D%0A%0A%5BShare%20other%20details%20here%5D"
-              target="_blank"
-              rel="noopener noreferrer"
-            >
-              Post your issue</a>
-            on the forum —
-            <img
-              alt="avatar"
-              src="https://avatars.githubusercontent.com/u/1450947"
-              class="inline-block ml-1 mr-1.5 my-0 -translate-y-px overflow-hidden rounded-full size-4 filter drop-shadow-sm ring-1 ring-white dark:ring-white/5 shadow"
-            />Andy usually replies within 6 hours.
-          </p>
-        </div>
-      {{/if}}
+    {{#if (and this.shouldShowStage1ForumLinkCTA this.currentCourse.visibilityIsPublic)}}
+      <div class="prose dark:prose-invert prose-sm prose-compact ml-4 mb-10">
+        <p>
+          Need help?
+          <a
+            href="https://forum.codecrafters.io/new-topic?category=Challenges&tags=challenge%3A{{this.currentCourse.slug}}&title=%5B{{this.currentCourse.shortName}}%5D%20How%20to%20pass%20the%20first%20stage%3F&body=Checklist%3A%0A%0A1.%20%E2%9C%85%20or%20%E2%9D%8C%3A%20I%27ve%20uncommented%20the%20code.%0A2.%20%E2%9C%85%20or%20%E2%9D%8C%3A%20I%27ve%20saved%20the%20changes.%0A3.%20%E2%9C%85%20or%20%E2%9D%8C%3A%20I%27ve%20run%20the%20git%20commands%3A%0A%0A%60%60%60%0Agit%20commit%20-am%20%22%5Bseeking%20help%20on%20forum%5D%22%0Agit%20push%20origin%20master%0A%60%60%60%0A%0A---%0A%0AHere%E2%80%99s%20a%20screenshot%20showing%20the%20output%20from%20running%20the%20Git%20commands%3A%0A%0A%5BAttach%20screenshot%20here%5D%0A%0A%5BShare%20other%20details%20here%5D"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            Post your issue</a>
+          on the forum —
+          <img
+            alt="avatar"
+            src="https://avatars.githubusercontent.com/u/1450947"
+            class="inline-block ml-1 mr-1.5 my-0 -translate-y-px overflow-hidden rounded-full size-4 filter drop-shadow-sm ring-1 ring-white dark:ring-white/5 shadow"
+          />Andy usually replies within 6 hours.
+        </p>
+      </div>
     {{/if}}
 
     {{! TODO: Remove this temporary CTA  }}


### PR DESCRIPTION
Introduce a visibility attribute to the CourseModel and ensure private courses are excluded from user profiles, course listings, and participation groups. Update tests to verify the correct behavior regarding private course visibility.

**Checklist**:

- [x] I've thoroughly self-reviewed my changes
- [ ] I've added tests for my changes, unless they affect admin-only areas (or are otherwise not worth testing)
- [ ] I've verified any visual changes using Percy (add a commit with `[percy]` in the message to trigger)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Updated course pages to display help content and forum links only when courses are public.
  - Adjusted action buttons and tabs so that only relevant options appear based on course access.
  - Enhanced dynamic tab rendering based on course visibility and stage properties.
  - Introduced routing capabilities in the Code Examples section for improved navigation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->