### PR TITLE
fix: update labels for attempt and completion rates

### DIFF
--- a/app/models/course-stage-participation-analysis.ts
+++ b/app/models/course-stage-participation-analysis.ts
@@ -78,7 +78,7 @@ export default class CourseStageParticipationAnalysisModel extends Model {
     if (this.attemptPercentage === null) {
       return {
         title: 'Attempt Rate',
-        label: 'attempt rate',
+        label: 'attempt', // 10% attempt
         value: null,
         color: 'gray',
         explanationMarkdown: attemptRateStatisticExplanationMarkdown,
@@ -86,7 +86,7 @@ export default class CourseStageParticipationAnalysisModel extends Model {
     } else {
       return {
         title: 'Attempt Rate',
-        label: 'attempt rate',
+        label: 'attempt', // 10% attempt
         value: `${Math.floor(this.attemptPercentage)}%`,
         color: this.calculateColorUsingThresholds(this.attemptPercentage, attemptRateThresholds),
         explanationMarkdown: attemptRateStatisticExplanationMarkdown,
@@ -102,7 +102,7 @@ export default class CourseStageParticipationAnalysisModel extends Model {
     if (this.attemptToCompletionPercentage === null) {
       return {
         title: 'Attempt to Completion Rate',
-        label: 'completion rate',
+        label: 'complete', // 15% complete
         value: null,
         color: 'gray',
         explanationMarkdown: completionRateStatisticExplanationMarkdown,
@@ -110,7 +110,7 @@ export default class CourseStageParticipationAnalysisModel extends Model {
     } else {
       return {
         title: 'Attempt to Completion Rate',
-        label: 'completion rate',
+        label: 'complete', // 15% complete
         value: `${Math.floor(this.attemptToCompletionPercentage)}%`,
         color: this.calculateColorUsingThresholds(this.attemptToCompletionPercentage, completionRateThresholds),
         explanationMarkdown: completionRateStatisticExplanationMarkdown,


### PR DESCRIPTION
Simplify the labels in the course stage participation analysis model 
by changing "attempt rate" to "attempt" and "completion rate" 
to "complete." This enhances clarity and maintains consistency 
in the terminology used across the metrics.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Style**
  - Simplified the wording in course progress metrics with clearer labels. Users will now see "attempt" and "complete" instead of the longer former labels, making the displayed statistics more concise and easier to understand.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->