### PR TITLE
feat: add maintenance redirect to vercel configuration

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -2,6 +2,7 @@
   "buildCommand": "scripts/build-vercel-output.sh",
   "installCommand": "npm install --no-fund --no-audit",
   "redirects": [
+    { "source": "/(.*)", "destination": "https://codecrafters.io/heroku_pages/maintenance.html", "permanent": false },
     { "source": "/package.json", "destination": "/404" },
     { "source": "/prerender/:path*", "destination": "/404" },
     { "source": "/", "destination": "/catalog" },


### PR DESCRIPTION
Add a temporary redirect to the maintenance page for all routes in the
Vercel configuration. This change ensures that users are directed to a
proper maintenance page during downtime, improving user experience
and maintaining communication about site status.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new routing behavior that automatically redirects any undefined or unmatched requests to a dedicated maintenance page, ensuring visitors receive a consistent experience during maintenance periods.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->