### PR TITLE
refactor(vercel): remove maintenance redirect rule

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -2,7 +2,6 @@
   "buildCommand": "scripts/build-vercel-output.sh",
   "installCommand": "npm install --no-fund --no-audit",
   "redirects": [
-    { "source": "/(.*)", "destination": "https://codecrafters.io/heroku_pages/maintenance.html", "permanent": false },
     { "source": "/package.json", "destination": "/404" },
     { "source": "/prerender/:path*", "destination": "/404" },
     { "source": "/", "destination": "/catalog" },


### PR DESCRIPTION
Remove the redirect rule for the maintenance page in the Vercel 
configuration. This change enhances user experience by directing 
users to relevant pages such as the catalog instead of a 
maintenance page, simplifying the navigation process.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved navigation by removing an unintended redirection that previously routed all visitors to a maintenance page. With this update, users now experience direct access to the intended content, eliminating unnecessary detours. All other specific redirection rules remain in place, ensuring targeted routes work as expected and overall site performance is enhanced.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->