### PR TITLE
Add `noindex` tag to `head` of pages that require auth

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -7,6 +7,11 @@
 
     <!-- DEFAULT_META_TAGS -->
 
+    <script type="text/javascript">
+      // Remove default meta tags between DEFAULT_META_TAGS_BEGIN & DEFAULT_META_TAGS_END to prevent duplication after Ember loads
+      !function () { var e = !1, t = [], n = document.head.childNodes; for (var o = 0; o < n.length; o++) { var d = n[o]; if (d.nodeType === Node.COMMENT_NODE) { if ("DEFAULT_META_TAGS_BEGIN" === d.textContent.trim()) { e = !0; continue } if ("DEFAULT_META_TAGS_END" === d.textContent.trim()) break } else "META" === d.nodeName && e && t.push(d) } for (var i = 0; i < t.length; i++)t[i].parentNode.removeChild(t[i]) }();
+    </script>
+
     {{content-for "head"}}
 
     <link integrity="" rel="stylesheet" href="{{rootURL}}assets/vendor.css">

--- a/app/routes/badges.ts
+++ b/app/routes/badges.ts
@@ -11,13 +11,11 @@ export type ModelType = {
 };
 
 export default class BadgesRoute extends BaseRoute {
-  allowsAnonymousAccess = true;
-
   @service declare authenticator: AuthenticatorService;
   @service declare store: Store;
 
   buildRouteInfoMetadata() {
-    return new RouteInfoMetadata({ colorScheme: RouteColorScheme.Dark });
+    return new RouteInfoMetadata({ allowsAnonymousAccess: true, colorScheme: RouteColorScheme.Dark });
   }
 
   async model(): Promise<ModelType> {

--- a/app/routes/catalog.ts
+++ b/app/routes/catalog.ts
@@ -15,12 +15,11 @@ export type ModelType = {
 };
 
 export default class CatalogRoute extends BaseRoute {
-  allowsAnonymousAccess = true;
   @service declare authenticator: AuthenticatorService;
   @service declare store: Store;
 
   buildRouteInfoMetadata(): RouteInfoMetadata {
-    return new RouteInfoMetadata({ colorScheme: RouteColorScheme.Both });
+    return new RouteInfoMetadata({ allowsAnonymousAccess: true, colorScheme: RouteColorScheme.Both });
   }
 
   model(): Promise<ModelType> {

--- a/app/routes/catalog.ts
+++ b/app/routes/catalog.ts
@@ -18,7 +18,7 @@ export default class CatalogRoute extends BaseRoute {
   @service declare authenticator: AuthenticatorService;
   @service declare store: Store;
 
-  buildRouteInfoMetadata(): RouteInfoMetadata {
+  buildRouteInfoMetadata() {
     return new RouteInfoMetadata({ allowsAnonymousAccess: true, colorScheme: RouteColorScheme.Both });
   }
 

--- a/app/routes/code-walkthrough.ts
+++ b/app/routes/code-walkthrough.ts
@@ -2,13 +2,16 @@ import BaseRoute from 'codecrafters-frontend/utils/base-route';
 import { inject as service } from '@ember/service';
 import type Store from '@ember-data/store';
 import type CodeWalkthroughModel from 'codecrafters-frontend/models/code-walkthrough';
+import RouteInfoMetadata from 'codecrafters-frontend/utils/route-info-metadata';
 
 export type ModelType = CodeWalkthroughModel;
 
 export default class CodeWalkthroughRoute extends BaseRoute {
   @service declare store: Store;
 
-  allowsAnonymousAccess = true;
+  buildRouteInfoMetadata() {
+    return new RouteInfoMetadata({ allowsAnonymousAccess: true });
+  }
 
   async model(params: { code_walkthrough_slug: string }): Promise<ModelType> {
     let codeWalkthrough;

--- a/app/routes/concept-group.ts
+++ b/app/routes/concept-group.ts
@@ -6,10 +6,9 @@ import HeadDataService from 'codecrafters-frontend/services/meta-data';
 import Store from '@ember-data/store';
 import RouterService from '@ember/routing/router-service';
 import { inject as service } from '@ember/service';
+import RouteInfoMetadata from 'codecrafters-frontend/utils/route-info-metadata';
 
 export default class ConceptGroupRoute extends BaseRoute {
-  allowsAnonymousAccess = true;
-
   @service declare authenticator: AuthenticatorService;
   @service declare metaData: HeadDataService;
   @service declare store: Store;
@@ -20,6 +19,10 @@ export default class ConceptGroupRoute extends BaseRoute {
   afterModel(model: { conceptGroup: ConceptGroupModel }) {
     this.previousMetaImageUrl = this.metaData.imageUrl;
     this.metaData.imageUrl = `${config.x.metaTagImagesBaseURL}collection-${model.conceptGroup.slug}.png`;
+  }
+
+  buildRouteInfoMetadata() {
+    return new RouteInfoMetadata({ allowsAnonymousAccess: true });
   }
 
   deactivate() {

--- a/app/routes/concept.ts
+++ b/app/routes/concept.ts
@@ -19,7 +19,6 @@ export type ConceptRouteModel = {
 };
 
 export default class ConceptRoute extends BaseRoute {
-  allowsAnonymousAccess = true;
   @service declare authenticator: AuthenticatorService;
   @service declare metaData: MetaDataService;
   @service declare router: RouterService;
@@ -63,7 +62,7 @@ export default class ConceptRoute extends BaseRoute {
   }
 
   buildRouteInfoMetadata() {
-    return new RouteInfoMetadata({ beaconVisibility: HelpscoutBeaconVisibility.Hidden });
+    return new RouteInfoMetadata({ allowsAnonymousAccess: true, beaconVisibility: HelpscoutBeaconVisibility.Hidden });
   }
 
   deactivate() {

--- a/app/routes/concepts.js
+++ b/app/routes/concepts.js
@@ -4,11 +4,10 @@ import RouteInfoMetadata, { HelpscoutBeaconVisibility } from 'codecrafters-front
 import { hash as RSVPHash } from 'rsvp';
 
 export default class ConceptsRoute extends BaseRoute {
-  allowsAnonymousAccess = true;
   @service store;
 
   buildRouteInfoMetadata() {
-    return new RouteInfoMetadata({ beaconVisibility: HelpscoutBeaconVisibility.Hidden });
+    return new RouteInfoMetadata({ allowsAnonymousAccess: true, beaconVisibility: HelpscoutBeaconVisibility.Hidden });
   }
 
   async model() {

--- a/app/routes/contest.ts
+++ b/app/routes/contest.ts
@@ -22,7 +22,7 @@ export default class ContestRoute extends BaseRoute {
     }
   }
 
-  buildRouteInfoMetadata(): RouteInfoMetadata {
+  buildRouteInfoMetadata() {
     return new RouteInfoMetadata({ allowsAnonymousAccess: true, colorScheme: RouteColorScheme.Dark });
   }
 

--- a/app/routes/contest.ts
+++ b/app/routes/contest.ts
@@ -16,8 +16,6 @@ export type ModelType = {
 };
 
 export default class ContestRoute extends BaseRoute {
-  allowsAnonymousAccess = true;
-
   afterModel(model: ModelType): void {
     if (!model || !model.contest) {
       this.router.transitionTo('not-found');
@@ -25,7 +23,7 @@ export default class ContestRoute extends BaseRoute {
   }
 
   buildRouteInfoMetadata(): RouteInfoMetadata {
-    return new RouteInfoMetadata({ colorScheme: RouteColorScheme.Dark });
+    return new RouteInfoMetadata({ allowsAnonymousAccess: true, colorScheme: RouteColorScheme.Dark });
   }
 
   @service declare router: RouterService;

--- a/app/routes/contests.ts
+++ b/app/routes/contests.ts
@@ -14,7 +14,7 @@ export default class ContestsRoute extends BaseRoute {
   @service declare router: RouterService;
   @service declare store: Store;
 
-  buildRouteInfoMetadata(): RouteInfoMetadata {
+  buildRouteInfoMetadata() {
     return new RouteInfoMetadata({ allowsAnonymousAccess: true, colorScheme: RouteColorScheme.Dark });
   }
 

--- a/app/routes/contests.ts
+++ b/app/routes/contests.ts
@@ -11,13 +11,11 @@ export type ModelType = {
 };
 
 export default class ContestsRoute extends BaseRoute {
-  allowsAnonymousAccess = true;
-
   @service declare router: RouterService;
   @service declare store: Store;
 
   buildRouteInfoMetadata(): RouteInfoMetadata {
-    return new RouteInfoMetadata({ colorScheme: RouteColorScheme.Dark });
+    return new RouteInfoMetadata({ allowsAnonymousAccess: true, colorScheme: RouteColorScheme.Dark });
   }
 
   async model(): Promise<ModelType> {

--- a/app/routes/course-overview.ts
+++ b/app/routes/course-overview.ts
@@ -29,7 +29,7 @@ export default class CourseOverviewRoute extends BaseRoute {
     this.metaData.imageUrl = `${config.x.metaTagImagesBaseURL}course-${model.course.slug}.jpg`;
   }
 
-  buildRouteInfoMetadata(): RouteInfoMetadata {
+  buildRouteInfoMetadata() {
     return new RouteInfoMetadata({ allowsAnonymousAccess: true, colorScheme: RouteColorScheme.Both });
   }
 

--- a/app/routes/course-overview.ts
+++ b/app/routes/course-overview.ts
@@ -14,8 +14,6 @@ export interface ModelType {
 }
 
 export default class CourseOverviewRoute extends BaseRoute {
-  allowsAnonymousAccess = true;
-
   @service declare authenticator: AuthenticatorService;
   @service declare store: Store;
   @service declare metaData: MetaDataService;
@@ -32,7 +30,7 @@ export default class CourseOverviewRoute extends BaseRoute {
   }
 
   buildRouteInfoMetadata(): RouteInfoMetadata {
-    return new RouteInfoMetadata({ colorScheme: RouteColorScheme.Both });
+    return new RouteInfoMetadata({ allowsAnonymousAccess: true, colorScheme: RouteColorScheme.Both });
   }
 
   deactivate() {

--- a/app/routes/course.ts
+++ b/app/routes/course.ts
@@ -35,7 +35,7 @@ export default class CourseRoute extends BaseRoute {
     },
   };
 
-  buildRouteInfoMetadata(): RouteInfoMetadata {
+  buildRouteInfoMetadata() {
     return new RouteInfoMetadata({ colorScheme: RouteColorScheme.Both });
   }
 

--- a/app/routes/debug.ts
+++ b/app/routes/debug.ts
@@ -2,7 +2,7 @@ import BaseRoute from 'codecrafters-frontend/utils/base-route';
 import RouteInfoMetadata from 'codecrafters-frontend/utils/route-info-metadata';
 
 export default class DebugRoute extends BaseRoute {
-  buildRouteInfoMetadata(): RouteInfoMetadata {
+  buildRouteInfoMetadata() {
     return new RouteInfoMetadata({ allowsAnonymousAccess: true });
   }
 }

--- a/app/routes/demo.ts
+++ b/app/routes/demo.ts
@@ -2,7 +2,7 @@ import Route from '@ember/routing/route';
 import RouteInfoMetadata, { RouteColorScheme } from 'codecrafters-frontend/utils/route-info-metadata';
 
 export default class DemoRoute extends Route {
-  buildRouteInfoMetadata(): RouteInfoMetadata {
+  buildRouteInfoMetadata() {
     return new RouteInfoMetadata({ colorScheme: RouteColorScheme.Both });
   }
 }

--- a/app/routes/join-course.ts
+++ b/app/routes/join-course.ts
@@ -34,7 +34,7 @@ export default class JoinCourseRoute extends BaseRoute {
     this.metaData.imageUrl = `${config.x.metaTagImagesBaseURL}course-${model.course.slug}.jpg`;
   }
 
-  buildRouteInfoMetadata(): RouteInfoMetadata {
+  buildRouteInfoMetadata() {
     return new RouteInfoMetadata({ allowsAnonymousAccess: true, colorScheme: RouteColorScheme.Both });
   }
 

--- a/app/routes/join-course.ts
+++ b/app/routes/join-course.ts
@@ -16,8 +16,6 @@ export interface ModelType {
 }
 
 export default class JoinCourseRoute extends BaseRoute {
-  allowsAnonymousAccess = true;
-
   @service declare authenticator: AuthenticatorService;
   @service declare metaData: MetaDataService;
   @service declare router: RouterService;
@@ -37,7 +35,7 @@ export default class JoinCourseRoute extends BaseRoute {
   }
 
   buildRouteInfoMetadata(): RouteInfoMetadata {
-    return new RouteInfoMetadata({ colorScheme: RouteColorScheme.Both });
+    return new RouteInfoMetadata({ allowsAnonymousAccess: true, colorScheme: RouteColorScheme.Both });
   }
 
   deactivate() {

--- a/app/routes/join-track.ts
+++ b/app/routes/join-track.ts
@@ -35,7 +35,7 @@ export default class JoinTrackRoute extends BaseRoute {
     this.metaData.imageUrl = `${config.x.metaTagImagesBaseURL}language-${model.language.slug}.jpg`;
   }
 
-  buildRouteInfoMetadata(): RouteInfoMetadata {
+  buildRouteInfoMetadata() {
     return new RouteInfoMetadata({ allowsAnonymousAccess: true, colorScheme: RouteColorScheme.Both });
   }
 

--- a/app/routes/join-track.ts
+++ b/app/routes/join-track.ts
@@ -17,8 +17,6 @@ export interface ModelType {
 }
 
 export default class JoinTrackRoute extends BaseRoute {
-  allowsAnonymousAccess = true;
-
   @service declare authenticator: AuthenticatorService;
   @service declare metaData: MetaDataService;
   @service declare router: RouterService;
@@ -38,7 +36,7 @@ export default class JoinTrackRoute extends BaseRoute {
   }
 
   buildRouteInfoMetadata(): RouteInfoMetadata {
-    return new RouteInfoMetadata({ colorScheme: RouteColorScheme.Both });
+    return new RouteInfoMetadata({ allowsAnonymousAccess: true, colorScheme: RouteColorScheme.Both });
   }
 
   deactivate() {

--- a/app/routes/join.ts
+++ b/app/routes/join.ts
@@ -5,14 +5,13 @@ import type RouterService from '@ember/routing/router-service';
 import type Store from '@ember-data/store';
 import { inject as service } from '@ember/service';
 import type AffiliateLinkModel from 'codecrafters-frontend/models/affiliate-link';
+import RouteInfoMetadata from 'codecrafters-frontend/utils/route-info-metadata';
 
 export type ModelType = {
   affiliateLink: AffiliateLinkModel;
 };
 
 export default class JoinRoute extends BaseRoute {
-  allowsAnonymousAccess = true;
-
   @service declare authenticator: AuthenticatorService;
   @service declare store: Store;
   @service declare router: RouterService;
@@ -25,6 +24,10 @@ export default class JoinRoute extends BaseRoute {
     if (!model.affiliateLink) {
       this.router.transitionTo('not-found');
     }
+  }
+
+  buildRouteInfoMetadata(): RouteInfoMetadata {
+    return new RouteInfoMetadata({ allowsAnonymousAccess: true });
   }
 
   async model(params: { affiliateLinkSlug: string }) {

--- a/app/routes/join.ts
+++ b/app/routes/join.ts
@@ -26,7 +26,7 @@ export default class JoinRoute extends BaseRoute {
     }
   }
 
-  buildRouteInfoMetadata(): RouteInfoMetadata {
+  buildRouteInfoMetadata() {
     return new RouteInfoMetadata({ allowsAnonymousAccess: true });
   }
 

--- a/app/routes/not-found.js
+++ b/app/routes/not-found.js
@@ -1,5 +1,0 @@
-import BaseRoute from 'codecrafters-frontend/utils/base-route';
-
-export default class NotFoundRoute extends BaseRoute {
-  allowsAnonymousAccess = true;
-}

--- a/app/routes/not-found.ts
+++ b/app/routes/not-found.ts
@@ -1,7 +1,7 @@
 import BaseRoute from 'codecrafters-frontend/utils/base-route';
 import RouteInfoMetadata from 'codecrafters-frontend/utils/route-info-metadata';
 
-export default class DebugRoute extends BaseRoute {
+export default class NotFoundRoute extends BaseRoute {
   buildRouteInfoMetadata(): RouteInfoMetadata {
     return new RouteInfoMetadata({ allowsAnonymousAccess: true });
   }

--- a/app/routes/not-found.ts
+++ b/app/routes/not-found.ts
@@ -2,7 +2,7 @@ import BaseRoute from 'codecrafters-frontend/utils/base-route';
 import RouteInfoMetadata from 'codecrafters-frontend/utils/route-info-metadata';
 
 export default class NotFoundRoute extends BaseRoute {
-  buildRouteInfoMetadata(): RouteInfoMetadata {
+  buildRouteInfoMetadata() {
     return new RouteInfoMetadata({ allowsAnonymousAccess: true });
   }
 }

--- a/app/routes/pay.ts
+++ b/app/routes/pay.ts
@@ -4,6 +4,7 @@ import type CourseModel from 'codecrafters-frontend/models/course';
 import type RegionalDiscountModel from 'codecrafters-frontend/models/regional-discount';
 import type AuthenticatorService from 'codecrafters-frontend/services/authenticator';
 import BaseRoute from 'codecrafters-frontend/utils/base-route';
+import RouteInfoMetadata from 'codecrafters-frontend/utils/route-info-metadata';
 import scrollToTop from 'codecrafters-frontend/utils/scroll-to-top';
 
 export type ModelType = {
@@ -12,13 +13,15 @@ export type ModelType = {
 };
 
 export default class PayRoute extends BaseRoute {
-  allowsAnonymousAccess = true;
-
   @service declare authenticator: AuthenticatorService;
   @service declare store: Store;
 
   activate() {
     scrollToTop();
+  }
+
+  buildRouteInfoMetadata(): RouteInfoMetadata {
+    return new RouteInfoMetadata({ allowsAnonymousAccess: true });
   }
 
   async model() {

--- a/app/routes/pay.ts
+++ b/app/routes/pay.ts
@@ -20,7 +20,7 @@ export default class PayRoute extends BaseRoute {
     scrollToTop();
   }
 
-  buildRouteInfoMetadata(): RouteInfoMetadata {
+  buildRouteInfoMetadata() {
     return new RouteInfoMetadata({ allowsAnonymousAccess: true });
   }
 

--- a/app/routes/referral-link.ts
+++ b/app/routes/referral-link.ts
@@ -23,7 +23,7 @@ export default class ReferralLinkRoute extends BaseRoute {
     }
   }
 
-  buildRouteInfoMetadata(): RouteInfoMetadata {
+  buildRouteInfoMetadata() {
     return new RouteInfoMetadata({ allowsAnonymousAccess: true });
   }
 

--- a/app/routes/referral-link.ts
+++ b/app/routes/referral-link.ts
@@ -6,10 +6,9 @@ import scrollToTop from 'codecrafters-frontend/utils/scroll-to-top';
 import RouterService from '@ember/routing/router-service';
 import Store from '@ember-data/store';
 import { inject as service } from '@ember/service';
+import RouteInfoMetadata from 'codecrafters-frontend/utils/route-info-metadata';
 
 export default class ReferralLinkRoute extends BaseRoute {
-  allowsAnonymousAccess = true;
-
   @service declare authenticator: AuthenticatorService;
   @service declare store: Store;
   @service declare router: RouterService;
@@ -22,6 +21,10 @@ export default class ReferralLinkRoute extends BaseRoute {
     if (!model.referralLink) {
       this.router.transitionTo('not-found');
     }
+  }
+
+  buildRouteInfoMetadata(): RouteInfoMetadata {
+    return new RouteInfoMetadata({ allowsAnonymousAccess: true });
   }
 
   async model(params: { referral_link_slug: string }) {

--- a/app/routes/settings.ts
+++ b/app/routes/settings.ts
@@ -13,7 +13,7 @@ export default class SettingsRoute extends BaseRoute {
   @service declare authenticator: AuthenticatorService;
   @service declare router: RouterService;
 
-  buildRouteInfoMetadata(): RouteInfoMetadata {
+  buildRouteInfoMetadata() {
     return new RouteInfoMetadata({ colorScheme: RouteColorScheme.Both });
   }
 

--- a/app/routes/teams/pay.ts
+++ b/app/routes/teams/pay.ts
@@ -11,7 +11,7 @@ import RouteInfoMetadata from 'codecrafters-frontend/utils/route-info-metadata';
 export default class TeamsPayRoute extends BaseRoute {
   @service declare store: Store;
 
-  buildRouteInfoMetadata(): RouteInfoMetadata {
+  buildRouteInfoMetadata() {
     return new RouteInfoMetadata({ allowsAnonymousAccess: true });
   }
 

--- a/app/routes/teams/pay.ts
+++ b/app/routes/teams/pay.ts
@@ -6,11 +6,14 @@ import type Store from '@ember-data/store';
 import type TeamsPayController from 'codecrafters-frontend/controllers/teams/pay';
 import type TeamPaymentFlowModel from 'codecrafters-frontend/models/team-payment-flow';
 import type Transition from '@ember/routing/transition';
+import RouteInfoMetadata from 'codecrafters-frontend/utils/route-info-metadata';
 
 export default class TeamsPayRoute extends BaseRoute {
   @service declare store: Store;
 
-  allowsAnonymousAccess = true;
+  buildRouteInfoMetadata(): RouteInfoMetadata {
+    return new RouteInfoMetadata({ allowsAnonymousAccess: true });
+  }
 
   async model(params: { teamPaymentFlowId?: string }): Promise<TeamPaymentFlowModel> {
     if (params.teamPaymentFlowId) {

--- a/app/routes/track.ts
+++ b/app/routes/track.ts
@@ -16,8 +16,6 @@ export type ModelType = {
 };
 
 export default class TrackRoute extends BaseRoute {
-  allowsAnonymousAccess = true;
-
   @service declare authenticator: AuthenticatorService;
   @service declare metaData: MetaDataService;
   @service declare store: Store;
@@ -34,7 +32,7 @@ export default class TrackRoute extends BaseRoute {
   }
 
   buildRouteInfoMetadata(): RouteInfoMetadata {
-    return new RouteInfoMetadata({ colorScheme: RouteColorScheme.Both });
+    return new RouteInfoMetadata({ allowsAnonymousAccess: true, colorScheme: RouteColorScheme.Both });
   }
 
   deactivate(): void {

--- a/app/routes/track.ts
+++ b/app/routes/track.ts
@@ -31,7 +31,7 @@ export default class TrackRoute extends BaseRoute {
     this.metaData.imageUrl = `${config.x.metaTagImagesBaseURL}language-${slug}.jpg`;
   }
 
-  buildRouteInfoMetadata(): RouteInfoMetadata {
+  buildRouteInfoMetadata() {
     return new RouteInfoMetadata({ allowsAnonymousAccess: true, colorScheme: RouteColorScheme.Both });
   }
 

--- a/app/routes/update-required.ts
+++ b/app/routes/update-required.ts
@@ -2,7 +2,7 @@ import BaseRoute from 'codecrafters-frontend/utils/base-route';
 import RouteInfoMetadata, { RouteColorScheme } from 'codecrafters-frontend/utils/route-info-metadata';
 
 export default class UpdateRequiredRoute extends BaseRoute {
-  buildRouteInfoMetadata(): RouteInfoMetadata {
+  buildRouteInfoMetadata() {
     return new RouteInfoMetadata({ colorScheme: RouteColorScheme.Both });
   }
 }

--- a/app/routes/user.ts
+++ b/app/routes/user.ts
@@ -10,7 +10,6 @@ import RouteInfoMetadata, { HelpscoutBeaconVisibility } from 'codecrafters-front
 export type ModelType = UserModel | undefined;
 
 export default class UserRoute extends BaseRoute {
-  allowsAnonymousAccess = true;
   @service declare authenticator: AuthenticatorService;
   @service declare router: RouterService;
   @service declare store: Store;
@@ -37,7 +36,7 @@ export default class UserRoute extends BaseRoute {
   }
 
   buildRouteInfoMetadata() {
-    return new RouteInfoMetadata({ beaconVisibility: HelpscoutBeaconVisibility.Hidden });
+    return new RouteInfoMetadata({ allowsAnonymousAccess: true, beaconVisibility: HelpscoutBeaconVisibility.Hidden });
   }
 
   deactivate() {

--- a/app/routes/vote.ts
+++ b/app/routes/vote.ts
@@ -30,7 +30,7 @@ export default class VoteRoute extends BaseRoute {
     }
   }
 
-  buildRouteInfoMetadata(): RouteInfoMetadata {
+  buildRouteInfoMetadata() {
     return new RouteInfoMetadata({ allowsAnonymousAccess: true });
   }
 

--- a/app/routes/vote.ts
+++ b/app/routes/vote.ts
@@ -8,6 +8,7 @@ import BaseRoute from 'codecrafters-frontend/utils/base-route';
 import scrollToTop from 'codecrafters-frontend/utils/scroll-to-top';
 import { hash as RSVPHash } from 'rsvp';
 import type Transition from '@ember/routing/transition';
+import RouteInfoMetadata from 'codecrafters-frontend/utils/route-info-metadata';
 
 export type ModelType = {
   courseIdeas: CourseIdeaModel[];
@@ -15,8 +16,6 @@ export type ModelType = {
 };
 
 export default class VoteRoute extends BaseRoute {
-  allowsAnonymousAccess = true;
-
   @service declare authenticator: AuthenticatorService;
   @service declare router: RouterService;
   @service declare store: Store;
@@ -29,6 +28,10 @@ export default class VoteRoute extends BaseRoute {
     if (transition.to?.name === 'vote.index') {
       this.router.transitionTo('vote.course-ideas');
     }
+  }
+
+  buildRouteInfoMetadata(): RouteInfoMetadata {
+    return new RouteInfoMetadata({ allowsAnonymousAccess: true });
   }
 
   async model(): Promise<ModelType> {

--- a/app/routes/vote/course-extension-ideas.js
+++ b/app/routes/vote/course-extension-ideas.js
@@ -1,7 +1,10 @@
 import BaseRoute from 'codecrafters-frontend/utils/base-route';
+import RouteInfoMetadata from 'codecrafters-frontend/utils/route-info-metadata';
 
 export default class CourseExtensionIdeasRoute extends BaseRoute {
-  allowsAnonymousAccess = true;
+  buildRouteInfoMetadata() {
+    return new RouteInfoMetadata({ allowsAnonymousAccess: true });
+  }
 
   setupController(controller, model) {
     super.setupController(controller, model);

--- a/app/services/meta-data.ts
+++ b/app/services/meta-data.ts
@@ -1,7 +1,18 @@
-import Service from '@ember/service';
+import type RouterService from '@ember/routing/router-service';
+import Service, { service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
+import RouteInfoMetadata from 'codecrafters-frontend/utils/route-info-metadata';
 
 export default class HeadDataService extends Service {
+  @service declare router: RouterService;
+
+  get shouldRenderNoIndexTag() {
+    const routeMeta = this.router.currentRoute.metadata;
+    const allowsAnonymousAccess = routeMeta instanceof RouteInfoMetadata && routeMeta.allowsAnonymousAccess;
+
+    return !allowsAnonymousAccess;
+  }
+
   @tracked title?: string;
   @tracked description?: string;
   @tracked imageUrl?: string;

--- a/app/templates/head.hbs
+++ b/app/templates/head.hbs
@@ -21,3 +21,7 @@
 <meta name="twitter:title" content={{or @metaData.title @defaults.title}} />
 <meta name="twitter:description" content={{or @metaData.description @defaults.description}} />
 <meta name="twitter:image" content={{or @metaData.imageUrl @defaults.imageUrl}} />
+
+{{#if @metaData.shouldRenderNoIndexTag}}
+  <meta name="robots" content="noindex" />
+{{/if}}

--- a/app/utils/route-info-metadata.ts
+++ b/app/utils/route-info-metadata.ts
@@ -10,14 +10,21 @@ export enum HelpscoutBeaconVisibility {
 }
 
 export default class RouteInfoMetadata {
-  colorScheme: RouteColorScheme = RouteColorScheme.Light;
+  allowsAnonymousAccess = false;
   beaconVisibility: HelpscoutBeaconVisibility = HelpscoutBeaconVisibility.Visible;
+  colorScheme: RouteColorScheme = RouteColorScheme.Light;
 
   constructor({
-    colorScheme = RouteColorScheme.Light,
+    allowsAnonymousAccess = false,
     beaconVisibility = HelpscoutBeaconVisibility.Visible,
-  }: { colorScheme?: RouteColorScheme; beaconVisibility?: HelpscoutBeaconVisibility } = {}) {
-    this.colorScheme = colorScheme;
+    colorScheme = RouteColorScheme.Light,
+  }: {
+    allowsAnonymousAccess?: boolean;
+    beaconVisibility?: HelpscoutBeaconVisibility;
+    colorScheme?: RouteColorScheme;
+  } = {}) {
+    this.allowsAnonymousAccess = allowsAnonymousAccess;
     this.beaconVisibility = beaconVisibility;
+    this.colorScheme = colorScheme;
   }
 }

--- a/lib/default-meta-tags/index.js
+++ b/lib/default-meta-tags/index.js
@@ -35,6 +35,7 @@ module.exports = {
       ['name', 'twitter:title', defaultMetaTags.title],
       ['name', 'twitter:description', defaultMetaTags.description],
       ['name', 'twitter:image', defaultMetaTags.imageUrl],
+      ['name', 'robots', 'noindex'],
     ];
 
     const metaString = metaTags

--- a/lib/default-meta-tags/index.js
+++ b/lib/default-meta-tags/index.js
@@ -48,7 +48,12 @@ module.exports = {
     fs.copyFileSync(emptyHtmlPath, path.resolve(directory, '_empty_notags.html'));
 
     // Rewrite `_empty.html` and insert default meta tags
-    fs.writeFileSync(emptyHtmlPath, fs.readFileSync(emptyHtmlPath, 'utf8').replace('<!-- DEFAULT_META_TAGS -->', metaString));
+    fs.writeFileSync(
+      emptyHtmlPath,
+      fs
+        .readFileSync(emptyHtmlPath, 'utf8')
+        .replace('<!-- DEFAULT_META_TAGS -->', `<!-- DEFAULT_META_TAGS_BEGIN -->${metaString}<!-- DEFAULT_META_TAGS_END -->`),
+    );
     console.debug('Inserted default meta tags into _empty.html file');
   },
 


### PR DESCRIPTION
Closes #2605 

### Brief

This renders `<meta name="robots" content="noindex" />` tag in the `head` of all pages that require authentication. It is also added to all pages that are not pre-rendered (either via Prember or Prerender Functions).

### Details

Because `allowsAnonymousAccess` property has to be reachable via `router.currentRoute`, an instance of [`RouteInfo`](https://api.emberjs.com/ember/6.2/classes/RouterService/properties/currentRoute?anchor=currentRoute) — I had to move it from being declared directly in `BaseRoute` — into `RouteInfoMetadata` class. It can now be accessed / overridden via the standard `buildRouteInfoMetadata` method.

Also added `<meta name="robots" content="noindex" />` tag to `_empty.html` file, so that all non-pre-rendered pages have this tag as well.

### Video

https://github.com/user-attachments/assets/9fd755ad-9e92-4ed7-a0be-aab7a2a9066b

### Checklist

- [x] I've thoroughly self-reviewed my changes
- [x] I've added tests for my changes, unless they affect admin-only areas (or are otherwise not worth testing)
- [x] I've verified any visual changes using Percy (add a commit with `[percy]` in the message to trigger)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Standardized public page routing by consolidating anonymous access settings into centralized metadata for a more consistent navigation experience.

- **New Features**
  - Added dynamic SEO support that conditionally renders a "noindex" tag based on route metadata, enhancing search engine management.
  - Introduced new methods for building route metadata across various routes, improving the structure and management of route information.
  - Added a new `NotFoundRoute` class to handle routing for non-existent pages.
  - Enhanced the `HeadDataService` to utilize route metadata for rendering behavior based on access permissions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->