### PR TITLE
Add text wrapping to `.prose code`

### DIFF
--- a/app/styles/app.css
+++ b/app/styles/app.css
@@ -54,6 +54,11 @@
   white-space: pre;
 }
 
+.prose code {
+  overflow-wrap: break-word;
+  text-wrap: auto;
+}
+
 .vertical-mask {
   background: linear-gradient(
     to bottom,


### PR DESCRIPTION
Closes #2423 

### Brief

This fixes text overflow inside of inline `code` elements.

### Screenshot

<img width="673" alt="Знімок екрана 2025-04-05 о 11 25 18" src="https://github.com/user-attachments/assets/f9aa02bf-5b3c-482a-816a-39663ad54399" />


### Checklist

- [x] I've thoroughly self-reviewed my changes
- [x] I've added tests for my changes, unless they affect admin-only areas (or are otherwise not worth testing)
- [x] I've verified any visual changes using Percy (add a commit with `[percy]` in the message to trigger)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Improved the readability of code snippets by enhancing text wrapping, ensuring long code elements break and wrap neatly within the layout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->