### PR TITLE
fix(course): update sort order for track slugs

### DIFF
--- a/app/models/course.ts
+++ b/app/models/course.ts
@@ -154,10 +154,10 @@ export default class CourseModel extends Model {
 
   get sortPositionForTrack() {
     const orderedSlugs = [
+      'http-server',
       'shell',
       'grep',
       'interpreter',
-      'http-server',
       'redis',
       'bittorrent',
       'kafka',


### PR DESCRIPTION
Adjust the order of track slugs in the CourseModel to prioritize 
'http-server'. This change ensures that 'http-server' appears 
before 'redis', improving the logical flow of the course 
presentation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Improved the ordering of course listings to prioritize key courses, providing a more intuitive browsing experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->