### PR TITLE
fix(header): update condition for step progress indicator

### DIFF
--- a/app/components/course-page/header/main-section.hbs
+++ b/app/components/course-page/header/main-section.hbs
@@ -31,7 +31,7 @@
 
       {{! For complete steps, we have the "You've completed this step" banner" }}
       {{! For in-progress steps, users shouldn't be focused on this area anyway }}
-      {{#if (not (or (eq @currentStep.status "complete") (eq @currentStep.status "in_progress")))}}
+      {{#if (and (not-eq @currentStep.status "complete") (not-eq @currentStep.status "in_progress"))}}
         <CoursePage::StepProgressIndicator @step={{@currentStep}} class="mt-2 ml-0.5" />
       {{/if}}
     </div>


### PR DESCRIPTION
Refactor the conditional logic for displaying the step progress 
indicator to ensure it shows only when the current step status 
is neither "complete" nor "in_progress". This enhances the 
clarity of the displayed information on the course page.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Refined the display logic for the course progress indicator so it now appears correctly based on the current step's progress, ensuring a more accurate visual representation of course status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->