### PR TITLE
Fix course comments with code blocks extending past container

### DIFF
--- a/app/components/course-page/comment-list.hbs
+++ b/app/components/course-page/comment-list.hbs
@@ -1,6 +1,6 @@
 <div data-test-comment-list {{did-update this.loadComments @courseStage}}>
   <CoursePage::CommentTimelineItem @author={{this.currentUser}}>
-    <div class="shadow-sm rounded border border-gray-300 dark:border-white/10 w-full mb-4">
+    <div class="shadow-sm rounded border border-gray-300 dark:border-white/10 w-full min-w-0 mb-4">
       {{! TODO: Pass in language here so that users can choose whether their comment is language-specific }}
       <CommentForm @target={{@courseStage}} @commentModelType="course-stage-comment" class="rounded" />
     </div>
@@ -14,7 +14,7 @@
   {{else}}
     {{#each this.sortedComments key="id" as |comment|}}
       <CoursePage::CommentTimelineItem @author={{comment.user}}>
-        <div class="shadow-sm rounded border border-gray-300 dark:border-white/10 w-full mb-4">
+        <div class="shadow-sm rounded border border-gray-300 dark:border-white/10 w-full min-w-0 mb-4">
           {{! @glint-expect-error Not ts-ified yet }}
           <CommentCard @comment={{comment}} />
         </div>
@@ -42,7 +42,7 @@
       {{#if this.rejectedCommentsAreExpanded}}
         {{#each this.rejectedComments key="id" as |comment|}}
           <CoursePage::CommentTimelineItem @author={{comment.user}}>
-            <div class="shadow-sm rounded border border-gray-300 dark:border-white/10 w-full mb-4">
+            <div class="shadow-sm rounded border border-gray-300 dark:border-white/10 w-full min-w-0 mb-4">
               {{! @glint-expect-error Not ts-ified yet }}
               <CommentCard @comment={{comment}} />
             </div>

--- a/app/components/course-page/comment-timeline-item.hbs
+++ b/app/components/course-page/comment-timeline-item.hbs
@@ -1,6 +1,6 @@
-<div class="relative pl-11">
-  <a href={{@author.codecraftersProfileUrl}} class="absolute left-0 top-0.5 flex items-center" target="_blank" rel="noopener noreferrer">
-    <AvatarImage @user={{@author}} class="w-8 h-8 filter drop-shadow-sm ring-1 ring-white dark:ring-white/5 rounded-full shadow" />
+<div class="flex items-start">
+  <a href={{@author.codecraftersProfileUrl}} class="mt-0.5 flex items-center flex-shrink-0" target="_blank" rel="noopener noreferrer">
+    <AvatarImage @user={{@author}} class="w-8 h-8 mr-3 filter drop-shadow-sm ring-1 ring-white dark:ring-white/5 rounded-full shadow" />
   </a>
 
   {{yield}}

--- a/app/components/course-page/comment-timeline-item.hbs
+++ b/app/components/course-page/comment-timeline-item.hbs
@@ -1,6 +1,6 @@
-<div class="flex items-start">
-  <a href={{@author.codecraftersProfileUrl}} class="mt-0.5 flex items-center flex-shrink-0" target="_blank" rel="noopener noreferrer">
-    <AvatarImage @user={{@author}} class="w-8 h-8 mr-3 filter drop-shadow-sm ring-1 ring-white dark:ring-white/5 rounded-full shadow" />
+<div class="relative pl-11">
+  <a href={{@author.codecraftersProfileUrl}} class="absolute left-0 top-0.5 flex items-center" target="_blank" rel="noopener noreferrer">
+    <AvatarImage @user={{@author}} class="w-8 h-8 filter drop-shadow-sm ring-1 ring-white dark:ring-white/5 rounded-full shadow" />
   </a>
 
   {{yield}}


### PR DESCRIPTION
Closes #1591

### Brief

This fixes Course comments with code blocks extending past their container's width.

### Details

After adding `min-w-0` to the comment cards, the sizing logic starts working properly.

### Demo

https://github.com/user-attachments/assets/7b92ac4d-a0a7-477b-a250-d3951d228d4a

### Checklist

- [x] I've thoroughly self-reviewed my changes
- [x] I've added tests for my changes, unless they affect admin-only areas (or are otherwise not worth testing)
- [x] I've verified any visual changes using Percy (add a commit with `[percy]` in the message to trigger)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Style**
  - Improved layout consistency for comment components by adding a new CSS class to enhance their appearance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->