### PR TITLE
Much simpler method of removing default meta tags after page load

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -8,8 +8,8 @@
     <!-- DEFAULT_META_TAGS -->
 
     <script type="text/javascript">
-      // Remove default meta tags between DEFAULT_META_TAGS_BEGIN & DEFAULT_META_TAGS_END to prevent duplication after Ember loads
-      !function () { var e = !1, t = [], n = document.head.childNodes; for (var o = 0; o < n.length; o++) { var d = n[o]; if (d.nodeType === Node.COMMENT_NODE) { if ("DEFAULT_META_TAGS_BEGIN" === d.textContent.trim()) { e = !0; continue } if ("DEFAULT_META_TAGS_END" === d.textContent.trim()) break } else "META" === d.nodeName && e && t.push(d) } for (var i = 0; i < t.length; i++)t[i].parentNode.removeChild(t[i]) }();
+      // Remove default meta tags to prevent tag duplication after Ember loads
+      !function () { var tags = document.head.querySelectorAll('meta[data-default-meta-tag]'); for (var i = 0; i < tags.length; i++) { tags[i].parentNode.removeChild(tags[i]); } }();
     </script>
 
     {{content-for "head"}}

--- a/lib/default-meta-tags/index.js
+++ b/lib/default-meta-tags/index.js
@@ -40,7 +40,7 @@ module.exports = {
 
     const metaString = metaTags
       .map(([namePrefix, nameSuffix, content]) => {
-        return `<meta ${namePrefix}="${nameSuffix}" content="${encode(content)}">`;
+        return `<meta ${namePrefix}="${nameSuffix}" content="${encode(content)}" data-default-meta-tag>`;
       })
       .join('\n    ');
 
@@ -48,12 +48,7 @@ module.exports = {
     fs.copyFileSync(emptyHtmlPath, path.resolve(directory, '_empty_notags.html'));
 
     // Rewrite `_empty.html` and insert default meta tags
-    fs.writeFileSync(
-      emptyHtmlPath,
-      fs
-        .readFileSync(emptyHtmlPath, 'utf8')
-        .replace('<!-- DEFAULT_META_TAGS -->', `<!-- DEFAULT_META_TAGS_BEGIN -->${metaString}<!-- DEFAULT_META_TAGS_END -->`),
-    );
+    fs.writeFileSync(emptyHtmlPath, fs.readFileSync(emptyHtmlPath, 'utf8').replace('<!-- DEFAULT_META_TAGS -->', metaString));
     console.debug('Inserted default meta tags into _empty.html file');
   },
 


### PR DESCRIPTION
Follow-up to: https://github.com/codecrafters-io/frontend/pull/2761

### Brief

Instead of removing default meta tags between `<!-- DEFAULT_META_TAGS_BEGIN -->` and `<!-- DEFAULT_META_TAGS_END -->` **comments**, add `data-default-meta-tag` attribute to them, and then remove using much simpler `querySelectorAll('meta[data-default-meta-tag]')` selector.

### Checklist

- [x] I've thoroughly self-reviewed my changes
- [x] I've added tests for my changes, unless they affect admin-only areas (or are otherwise not worth testing)
- [x] I've verified any visual changes using Percy (add a commit with `[percy]` in the message to trigger)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Streamlined meta information handling to ensure a cleaner and more efficient page setup.
  - Optimized the generation and removal of meta tags for consistent metadata management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->