### PR TITLE
Pre-render one Concept & one User page with Prember to catch errors during deployment

### DIFF
--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -56,7 +56,7 @@ module.exports = function (defaults) {
     prember: {
       urls: async function generatePremberUrls() {
         // Default routes to pre-generate with FastBoot
-        const urls = ['/', '/catalog'];
+        const urls = ['/', '/catalog', '/concepts/test-concept-for-ci', '/users/codecrafters-bot'];
 
         // Get a list of Courses and Languages from the API
         const apiResponse = await fetch(`${config.x.backendUrl}/api/v1/courses?include=language-configurations.language`);


### PR DESCRIPTION
Closes #2782

### Brief

This adds pre-rendering of `/concepts/test-concept-for-ci` and `/users/codecrafters-bot` to Prember, so that any potential errors happen during deployment, where they would be intercepted by our Vercel build script and abort the deployment.

### Details

As a[n expected] side-effect, these two pages would become static HTML files and will not be processed by the  Prerender functions.

### Checklist

- [x] I've thoroughly self-reviewed my changes
- [x] I've added tests for my changes, unless they affect admin-only areas (or are otherwise not worth testing)
- [x] I've verified any visual changes using Percy (add a commit with `[percy]` in the message to trigger)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Expanded the pre-rendering process to include additional pages.
  - End-users now benefit from improved load times and direct access to new content, including a conceptual overview and a dedicated user page.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->