### PR TITLE
refactor: remove trial subscription functionality

### DIFF
--- a/app/components/membership-page/actions-section.hbs
+++ b/app/components/membership-page/actions-section.hbs
@@ -1,13 +1,5 @@
 <MembershipPage::Section @title="Actions" ...attributes>
-  {{#if @subscription.isTrialing}}
-    <ButtonWithSpinner
-      class="bg-red-600 hover:bg-red-700 text-sm mt-4 text-white"
-      {{on "click" @onCancelSubscriptionButtonClick}}
-      data-test-cancel-trial-button
-    >
-      Cancel Trial
-    </ButtonWithSpinner>
-  {{else if (and @subscription.isActive (not @subscription.cancelAt))}}
+  {{#if (and @subscription.isActive (not @subscription.cancelAt))}}
     <ButtonWithSpinner
       class="bg-red-600 hover:bg-red-700 text-sm mt-4 text-white"
       {{on "click" @onCancelSubscriptionButtonClick}}

--- a/app/components/membership-page/cancel-subscription-modal.js
+++ b/app/components/membership-page/cancel-subscription-modal.js
@@ -21,8 +21,9 @@ export default class CancelSubscriptionModalComponent extends Component {
     return this.selectedReason || (this.otherReasonIsSelected && this.reasonDescription.length > 0);
   }
 
+  // TODO: See if we can remove this
   get cancellationIsWithinTrialPeriod() {
-    return this.subscription.isTrialing;
+    return false;
   }
 
   get placeholderTextForReasonDescriptionInput() {

--- a/app/components/membership-page/membership-plan-section.hbs
+++ b/app/components/membership-page/membership-plan-section.hbs
@@ -1,11 +1,7 @@
 {{! @glint-nocheck: not typesafe yet }}
 <MembershipPage::Section @title="Membership Plan" data-test-membership-plan-section>
   <div class="text-gray-700 {{if @subscription.user.isVip 'line-through' ''}}" data-test-membership-plan-description>
-    {{#if @subscription.isTrialing}}
-      Your trial for the
-      <b class="font-semibold">{{@subscription.pricingPlanName}}</b>
-      plan is currently active.
-    {{else if @subscription.isActive}}
+    {{#if @subscription.isActive}}
       {{#if @subscription.cancelAt}}
         <p class="mb-3">
           Your CodeCrafters membership is valid until

--- a/app/models/subscription.ts
+++ b/app/models/subscription.ts
@@ -8,7 +8,6 @@ export default class SubscriptionModel extends Model {
   @attr('date') declare endedAt: Date | null;
   @attr('string') declare pricingPlanName: string;
   @attr('date') declare startDate: Date;
-  @attr('date') declare trialEnd: Date | null;
 
   @belongsTo('user', { async: false, inverse: 'subscriptions' }) declare user: UserModel;
 
@@ -18,10 +17,6 @@ export default class SubscriptionModel extends Model {
 
   get isInactive() {
     return this.endedAt;
-  }
-
-  get isTrialing() {
-    return this.isActive && this.trialEnd && new Date() < this.trialEnd;
   }
 
   declare cancel: (this: Model, payload: unknown) => Promise<void>;

--- a/tests/acceptance/manage-membership-test.js
+++ b/tests/acceptance/manage-membership-test.js
@@ -1,7 +1,7 @@
 import { module, test } from 'qunit';
 import { setupApplicationTest } from 'codecrafters-frontend/tests/helpers';
 import { setupWindowMock } from 'ember-window-mock/test-support';
-import { signInAsSubscriber, signInAsTrialingSubscriber } from 'codecrafters-frontend/tests/support/authentication-helpers';
+import { signInAsSubscriber } from 'codecrafters-frontend/tests/support/authentication-helpers';
 import catalogPage from 'codecrafters-frontend/tests/pages/catalog-page';
 import { formatWithOptions } from 'date-fns/fp';
 import membershipPage from 'codecrafters-frontend/tests/pages/membership-page';
@@ -55,36 +55,6 @@ module('Acceptance | manage-membership-test', function (hooks) {
     assert
       .dom('[data-test-membership-plan-section] div:nth-of-type(3)')
       .includesText('🎉 You have VIP access to all CodeCrafters content, valid until');
-  });
-
-  test('subscriber can cancel trial', async function (assert) {
-    testScenario(this.server);
-    signInAsTrialingSubscriber(this.owner, this.server);
-
-    await membershipPage.visit();
-    assert.strictEqual(membershipPage.membershipPlanSection.descriptionText, 'Your trial for the Monthly plan is currently active.');
-
-    await membershipPage.clickOnCancelTrialButton();
-    assert.ok(membershipPage.cancelSubscriptionModal.isVisible);
-    assert.ok(membershipPage.cancelSubscriptionModal.cancelButtonIsDisabled, 'cancel button is disabled without selecting a reason');
-
-    await membershipPage.cancelSubscriptionModal.selectReason('I need more content');
-    assert.notOk(membershipPage.cancelSubscriptionModal.cancelButtonIsDisabled, 'cancel button is enabled after selecting a reason');
-
-    await membershipPage.cancelSubscriptionModal.selectReason('Other reason');
-    assert.ok(membershipPage.cancelSubscriptionModal.cancelButtonIsDisabled, 'cancel button is disabled if other reason is selected');
-
-    await membershipPage.cancelSubscriptionModal.fillInReasonDescription('Feeling Blue');
-    assert.notOk(membershipPage.cancelSubscriptionModal.cancelButtonIsDisabled, 'cancel button is enabled if other reason is provided');
-
-    assert.strictEqual(membershipPage.cancelSubscriptionModal.cancelButtonText, 'Cancel Trial');
-
-    await membershipPage.cancelSubscriptionModal.clickOnCancelSubscriptionButton();
-    await settled(); // Investigate why clickable() doesn't call settled()
-
-    assert.notOk(membershipPage.cancelSubscriptionModal.isVisible);
-
-    assert.strictEqual(membershipPage.membershipPlanSection.descriptionText, 'Your CodeCrafters membership is currently inactive.');
   });
 
   test('subscriber can cancel subscription', async function (assert) {

--- a/tests/acceptance/vote-page/course-ideas-test.js
+++ b/tests/acceptance/vote-page/course-ideas-test.js
@@ -16,12 +16,13 @@ module('Acceptance | vote-page | course-ideas', function (hooks) {
     createCourseIdeas(this.server);
 
     let courseIdea = this.server.schema.courseIdeas.first();
-    courseIdea.update({ votesCount: 1 });
+    courseIdea.update({ votesCount: 1, developmentStatus: 'released' });
 
     await votePage.visit();
     await percySnapshot('Challenge Ideas (anonymous)');
 
     assert.strictEqual(votePage.findCourseIdeaCard(courseIdea.name).voteButtonText, '1 vote');
+    assert.ok(votePage.findCourseIdeaCard(courseIdea.name).isGreyedOut, 'should be greyed out if released');
 
     const releasedIdeaCard = votePage.findCourseIdeaCard('Build your own Regex Parser');
     const notStartedIdeaCard = votePage.findCourseIdeaCard('Build your own Shell');

--- a/tests/support/authentication-helpers.js
+++ b/tests/support/authentication-helpers.js
@@ -106,17 +106,3 @@ export function signInAsSubscribedTeamMember(owner, server) {
 
   return signIn(owner, server, user);
 }
-
-// TODO: Remove this?
-export function signInAsTrialingSubscriber(owner, server, user) {
-  user = user || server.schema.users.find('63c51e91-e448-4ea9-821b-a80415f266d3');
-
-  server.create('subscription', {
-    currentPeriodEnd: new Date(new Date().getTime() + 24 * 60 * 60 * 1000),
-    user: user,
-    pricingPlanName: 'Monthly',
-    trialEnd: new Date(new Date().getTime() + 24 * 60 * 60 * 1000),
-  });
-
-  return signIn(owner, server, user);
-}


### PR DESCRIPTION
Remove the trial subscription logic from the SubscriptionModel 
and related components. This streamlines the cancellation 
process, ensuring only active subscriptions are handled. 
Update tests to reflect these changes and ensure 
they pass without the trial-related assertions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Streamlined membership management by removing trial-specific buttons and messages. Users with active subscriptions now see only a "Cancel Subscription" option.
  
- **New Features**
  - Improved course idea display on the Vote page: released course ideas now appear with a greyed-out visual treatment for clearer status indication.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->