### PR TITLE
Disallow direct access to `_empty.html` and `_empty_notags.html` files

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -2,6 +2,8 @@
   "buildCommand": "scripts/build-vercel-output.sh",
   "installCommand": "npm install --no-fund --no-audit",
   "redirects": [
+    { "source": "/_empty.html", "destination": "/404" },
+    { "source": "/_empty_notags.html", "destination": "/404" },
     { "source": "/package.json", "destination": "/404" },
     { "source": "/prerender/:path*", "destination": "/404" },
     { "source": "/", "destination": "/catalog" },


### PR DESCRIPTION
### Brief

Just noticed that these files can be accessed directly by visiting `/_empty.html`, and while it's not harmful — they are certainly not intended to be accessed directly.

### Details

Disallowed using Vercel's redirects.

### Checklist

- [x] I've thoroughly self-reviewed my changes
- [x] I've added tests for my changes, unless they affect admin-only areas (or are otherwise not worth testing)
- [x] I've verified any visual changes using Percy (add a commit with `[percy]` in the message to trigger)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced redirection so that accessing certain placeholder pages now routes users to the standard error page, ensuring a more consistent navigation experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->