### PR TITLE
feat: add download button to copy prompt file contents

### DIFF
--- a/app/components/course-admin/code-example-page/evaluation-card/prompt-tab.hbs
+++ b/app/components/course-admin/code-example-page/evaluation-card/prompt-tab.hbs
@@ -1,5 +1,5 @@
-<TertiaryButton class="mb-2" {{on "click" this.handleDownloadPromptButtonClick}}>
-  Download prompt
+<TertiaryButton class="mb-4" {{on "click" this.handleCopyPromptButtonClick}}>
+  Copy prompt
 </TertiaryButton>
 
 <div class="bg-gray-800 border border-gray-700 rounded overflow-y-auto relative flex-grow p-3">

--- a/app/components/course-admin/code-example-page/evaluation-card/prompt-tab.hbs
+++ b/app/components/course-admin/code-example-page/evaluation-card/prompt-tab.hbs
@@ -1,3 +1,7 @@
+<TertiaryButton class="mb-2" {{on "click" this.handleDownloadPromptButtonClick}}>
+  Download prompt
+</TertiaryButton>
+
 <div class="bg-gray-800 border border-gray-700 rounded overflow-y-auto relative flex-grow p-3">
   {{#if @evaluation.promptFileContents}}
     <pre class="font-mono text-xs text-white whitespace-pre-wrap"><code>{{ansi-to-html @evaluation.promptFileContents}}</code></pre>

--- a/app/components/course-admin/code-example-page/evaluation-card/prompt-tab.ts
+++ b/app/components/course-admin/code-example-page/evaluation-card/prompt-tab.ts
@@ -1,3 +1,4 @@
+import { action } from '@ember/object';
 import Component from '@glimmer/component';
 import type CommunitySolutionEvaluationModel from 'codecrafters-frontend/models/community-solution-evaluation';
 
@@ -9,7 +10,16 @@ export interface Signature {
   };
 }
 
-export default class PromptTabComponent extends Component<Signature> {}
+export default class PromptTabComponent extends Component<Signature> {
+  @action
+  handleDownloadPromptButtonClick() {
+    if (this.args.evaluation.promptFileContents) {
+      navigator.clipboard.writeText(this.args.evaluation.promptFileContents);
+    } else {
+      alert('Error, contact us at hello@codecrafters.io if this keeps happening!');
+    }
+  }
+}
 
 declare module '@glint/environment-ember-loose/registry' {
   export default interface Registry {

--- a/app/components/course-admin/code-example-page/evaluation-card/prompt-tab.ts
+++ b/app/components/course-admin/code-example-page/evaluation-card/prompt-tab.ts
@@ -12,7 +12,7 @@ export interface Signature {
 
 export default class PromptTabComponent extends Component<Signature> {
   @action
-  handleDownloadPromptButtonClick() {
+  handleCopyPromptButtonClick() {
     if (this.args.evaluation.promptFileContents) {
       navigator.clipboard.writeText(this.args.evaluation.promptFileContents);
     } else {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Added a "Copy prompt" button to the evaluation interface, enabling users to quickly copy prompt content to their clipboard. An error alert notifies users if the prompt content is unavailable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->