### PR TITLE
Update `@codemirror/view` and `@codemirror/merge` to latest versions

### DIFF
--- a/app/components/code-mirror.hbs
+++ b/app/components/code-mirror.hbs
@@ -28,7 +28,16 @@
   {{did-update
     this.optionDidChange
     "originalDocumentOrDiffRelatedOption"
-    (array @originalDocument @mergeControls @collapseUnchanged @highlightChanges @syntaxHighlightDeletions @unchangedMargin @unchangedMinSize)
+    (array
+      @originalDocument
+      @mergeControls
+      @collapseUnchanged
+      @highlightChanges
+      @syntaxHighlightDeletions
+      @unchangedMargin
+      @unchangedMinSize
+      @allowInlineDiffs
+    )
   }}
   {{did-update this.optionDidChange "placeholder" @placeholder}}
   {{did-update this.optionDidChange "readOnly" @readOnly}}

--- a/app/components/code-mirror.ts
+++ b/app/components/code-mirror.ts
@@ -128,6 +128,7 @@ const OPTION_HANDLERS: { [key: string]: OptionHandler } = {
     syntaxHighlightDeletions,
     unchangedMargin = 3,
     unchangedMinSize = 4,
+    allowInlineDiffs,
   }) => {
     return originalDocument
       ? [
@@ -137,6 +138,7 @@ const OPTION_HANDLERS: { [key: string]: OptionHandler } = {
             collapseUnchanged: collapseUnchanged ? { margin: unchangedMargin, minSize: unchangedMinSize } : undefined,
             highlightChanges: !!highlightChanges,
             syntaxHighlightDeletions: !!syntaxHighlighting && !!syntaxHighlightDeletions,
+            allowInlineDiffs: !!allowInlineDiffs,
           }),
           collapseUnchanged ? collapseUnchangedGutter() : [],
         ]
@@ -190,6 +192,10 @@ export interface Signature {
        * Theme to use for the editor
        */
       theme?: Extension;
+      /**
+       * Display chunks with only limited inline changes inline in the code
+       */
+      allowInlineDiffs?: boolean;
       /**
        * Allow multiple selections by using CTRL/CMD key
        */

--- a/app/controllers/demo/code-mirror.ts
+++ b/app/controllers/demo/code-mirror.ts
@@ -30,6 +30,7 @@ const LINE_SEPARATORS = [
 
 const OPTION_DEFAULTS = {
   allowMultipleSelections: true,
+  allowInlineDiffs: false,
   autocompletion: true,
   bracketMatching: true,
   closeBrackets: true,
@@ -84,6 +85,7 @@ export default class DemoCodeMirrorController extends Controller {
   @service declare darkMode: DarkModeService;
 
   queryParams = [
+    'allowInlineDiffs',
     'allowMultipleSelections',
     'autocompletion',
     'bracketMatching',
@@ -135,6 +137,7 @@ export default class DemoCodeMirrorController extends Controller {
     'unchangedMinSize',
   ];
 
+  @tracked allowInlineDiffs = OPTION_DEFAULTS.allowInlineDiffs;
   @tracked allowMultipleSelections = OPTION_DEFAULTS.allowMultipleSelections;
   @tracked autocompletion = OPTION_DEFAULTS.autocompletion;
   @tracked bracketMatching = OPTION_DEFAULTS.bracketMatching;

--- a/app/routes/demo/code-mirror.ts
+++ b/app/routes/demo/code-mirror.ts
@@ -1,6 +1,7 @@
 import Route from '@ember/routing/route';
 
 const QUERY_PARAMS = [
+  'allowInlineDiffs',
   'allowMultipleSelections',
   'autocompletion',
   'bracketMatching',

--- a/app/templates/demo/code-mirror.hbs
+++ b/app/templates/demo/code-mirror.hbs
@@ -270,7 +270,11 @@
     </label>
     <label class="{{labelClasses}}" title="Enable syntax highlighting in the deleted chunks of the diff">
       <Input @type="checkbox" @checked={{this.syntaxHighlightDeletions}} disabled={{or (not this.originalDocument) (not this.syntaxHighlighting)}} />
-      <span class="ml-2 {{unless this.originalDocument 'text-gray-300'}}">syntaxHighlightDeletions</span>
+      <span class="ml-2 {{unless (and this.originalDocument this.syntaxHighlighting) 'text-gray-300'}}">syntaxHighlightDeletions</span>
+    </label>
+    <label class="{{labelClasses}}" title="Display chunks with only limited inline changes inline in the code">
+      <Input @type="checkbox" @checked={{this.allowInlineDiffs}} disabled={{not this.originalDocument}} />
+      <span class="ml-2 {{unless this.originalDocument 'text-gray-300'}}">allowInlineDiffs</span>
     </label>
   </codemirror-options>
 
@@ -321,6 +325,7 @@
   @tabSize={{if this.tabSize this.selectedTabSize}}
   @theme={{if this.theme this.selectedTheme}}
   {{! Boolean Options }}
+  @allowInlineDiffs={{this.allowInlineDiffs}}
   @allowMultipleSelections={{this.allowMultipleSelections}}
   @autocompletion={{this.autocompletion}}
   @bracketMatching={{this.bracketMatching}}

--- a/app/utils/code-mirror-themes.ts
+++ b/app/utils/code-mirror-themes.ts
@@ -63,6 +63,16 @@ const BASE_STYLE = {
           color: 'rgb(102 153 0)',
         },
       },
+
+      '&.cm-inlineChangedLineGutter': {
+        background: 'rgba(0, 255, 0, 0.15)',
+
+        '&:before': {
+          content: '"+"',
+          padding: '0 0.5rem',
+          color: 'rgb(102 153 0)',
+        },
+      },
     },
   },
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -34,7 +34,7 @@
         "@codecov/webpack-plugin": "^1.8.0",
         "@codemirror/language-data": "^6.5.0",
         "@codemirror/merge": "^6.8.0",
-        "@codemirror/view": "^6.36.2",
+        "@codemirror/view": "^6.36.5",
         "@ember/optional-features": "^2.2.0",
         "@ember/render-modifiers": "^2.0.4",
         "@ember/string": "^3.1.1",
@@ -2730,9 +2730,9 @@
       }
     },
     "node_modules/@codemirror/view": {
-      "version": "6.36.2",
-      "resolved": "https://registry.npmjs.org/@codemirror/view/-/view-6.36.2.tgz",
-      "integrity": "sha512-DZ6ONbs8qdJK0fdN7AB82CgI6tYXf4HWk1wSVa0+9bhVznCuuvhQtX8bFBoy3dv8rZSQqUd8GvhVAcielcidrA==",
+      "version": "6.36.5",
+      "resolved": "https://registry.npmjs.org/@codemirror/view/-/view-6.36.5.tgz",
+      "integrity": "sha512-cd+FZEUlu3GQCYnguYm3EkhJ8KJVisqqUsCOKedBoAt/d9c76JUUap6U0UrpElln5k6VyrEOYliMuDAKIeDQLg==",
       "dev": true,
       "dependencies": {
         "@codemirror/state": "^6.5.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -33,7 +33,7 @@
         "@babel/plugin-proposal-decorators": "^7.25.9",
         "@codecov/webpack-plugin": "^1.8.0",
         "@codemirror/language-data": "^6.5.0",
-        "@codemirror/merge": "^6.8.0",
+        "@codemirror/merge": "^6.10.0",
         "@codemirror/view": "^6.36.5",
         "@ember/optional-features": "^2.2.0",
         "@ember/render-modifiers": "^2.0.4",
@@ -2697,9 +2697,9 @@
       }
     },
     "node_modules/@codemirror/merge": {
-      "version": "6.8.0",
-      "resolved": "https://registry.npmjs.org/@codemirror/merge/-/merge-6.8.0.tgz",
-      "integrity": "sha512-EcCD4OJlGz6lJaqZOFM/RE6fqM4XSQlWNWVxm2CJS1snbrbkgYLTvj8c++pFUWpJOUiNgcxvYMYkMisnC0aR6g==",
+      "version": "6.10.0",
+      "resolved": "https://registry.npmjs.org/@codemirror/merge/-/merge-6.10.0.tgz",
+      "integrity": "sha512-Omn0gU6MM5cKQGqgKoIhFjUqCNWH/nukCMLXzu/1jOdtiHsxAu3GdENBf1QYkoIC3FSgkF7X/ClOqYeUATQ4Sw==",
       "dev": true,
       "dependencies": {
         "@codemirror/language": "^6.0.0",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "@babel/plugin-proposal-decorators": "^7.25.9",
     "@codecov/webpack-plugin": "^1.8.0",
     "@codemirror/language-data": "^6.5.0",
-    "@codemirror/merge": "^6.8.0",
+    "@codemirror/merge": "^6.10.0",
     "@codemirror/view": "^6.36.5",
     "@ember/optional-features": "^2.2.0",
     "@ember/render-modifiers": "^2.0.4",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "@codecov/webpack-plugin": "^1.8.0",
     "@codemirror/language-data": "^6.5.0",
     "@codemirror/merge": "^6.8.0",
-    "@codemirror/view": "^6.36.2",
+    "@codemirror/view": "^6.36.5",
     "@ember/optional-features": "^2.2.0",
     "@ember/render-modifiers": "^2.0.4",
     "@ember/string": "^3.1.1",

--- a/tests/integration/components/code-mirror-test.js
+++ b/tests/integration/components/code-mirror-test.js
@@ -86,6 +86,18 @@ module('Integration | Component | code-mirror', function (hooks) {
   });
 
   module('Options', function () {
+    module('allowInlineDiffs', function () {
+      test("it doesn't break the editor when passed", async function (assert) {
+        this.set('allowInlineDiffs', true);
+        await render(hbs`<CodeMirror @allowInlineDiffs={{this.allowInlineDiffs}} />`);
+        assert.ok(codeMirror.hasRendered);
+        this.set('allowInlineDiffs', false);
+        assert.ok(codeMirror.hasRendered);
+      });
+
+      skip('it does something useful with the editor');
+    });
+
     module('allowMultipleSelections', function () {
       test("it doesn't break the editor when passed", async function (assert) {
         this.set('allowMultipleSelections', true);


### PR DESCRIPTION
Related to #1231 

### Brief

This updates CodeMirror to use latest versions of `@codemirror/view@6.36.5` and `@codemirror/merge@6.10.0`

### Details

New option `@allowInlineDiffs` is now [supported](https://github.com/codemirror/dev/issues/1419) by the inline diff view

https://github.com/user-attachments/assets/a7671542-1a37-403a-a370-5153d59c06c9

### Checklist

- [x] I've thoroughly self-reviewed my changes
- [x] I've added tests for my changes, unless they affect admin-only areas (or are otherwise not worth testing)
- [x] I've verified any visual changes using Percy (add a commit with `[percy]` in the message to trigger)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an inline diff option in the code viewer, enabling users to toggle the display of inline changes during document comparisons.

- **Style**
  - Improved visual cues for inline modifications with enhanced color highlighting for easier identification of changes.

- **Tests**
  - Introduced tests to ensure the editor renders reliably when the inline diff option is toggled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->