### PR TITLE
Add support for {{language_name}} in instructions markdown

### DIFF
--- a/app/components/course-page/course-stage-step/your-task-card/index.ts
+++ b/app/components/course-page/course-stage-step/your-task-card/index.ts
@@ -31,6 +31,9 @@ export default class YourTaskCardComponent extends Component<Signature> {
       variables[`lang_is_${(language as LanguageModel).slug}`] = this.args.repository.language === language;
     });
 
+    // Set placeholder language_name to a concrete one (Python) since it's the least awkward among all other options
+    variables['language_name'] = this.args.repository.language?.name || 'Python';
+
     return Mustache.render(this.args.courseStage.descriptionMarkdownTemplate, variables);
   }
 


### PR DESCRIPTION
**Checklist**:

- [x] I've thoroughly self-reviewed my changes
- [ ] I've added tests for my changes, unless they affect admin-only areas (or are otherwise not worth testing)
- [ ] I've verified any visual changes using Percy (add a commit with `[percy]` in the message to trigger)
