### PR TITLE
Changed the "Previous Steps Incomplete Modal"

### DIFF
--- a/app/components/course-page/previous-steps-incomplete-modal.hbs
+++ b/app/components/course-page/previous-steps-incomplete-modal.hbs
@@ -10,8 +10,7 @@
 
     <div class="prose dark:prose-invert mb-5 text-center" data-test-completion-message>
       <p class="text-balance">
-        This step depends on previous steps
-        that you haven't completed yet.
+        This step depends on previous steps that you haven't completed yet.
       </p>
     </div>
 

--- a/app/components/course-page/previous-steps-incomplete-modal.hbs
+++ b/app/components/course-page/previous-steps-incomplete-modal.hbs
@@ -30,7 +30,7 @@
       class="mt-3 text-gray-500 hover:text-gray-800 dark:text-gray-300 pb-0.25 border-b border-gray-400 dark:border-gray-500 hover:border-gray-600 dark:hover:border-gray-400 flex-shrink-0 text-xs"
       role="button"
       {{on "click" @onClose}}
-      data-test-view-instructions-button
+      data-test-just-exploring-button
     >
       I'm just exploring 👀
     </div>

--- a/app/components/course-page/previous-steps-incomplete-modal.hbs
+++ b/app/components/course-page/previous-steps-incomplete-modal.hbs
@@ -15,9 +15,9 @@
     </div>
 
     <PrimaryLinkButton
-      @route={{this.stepForNextOrActiveStepButton.routeParams.route}}
-      @models={{this.stepForNextOrActiveStepButton.routeParams.models}}
-      data-test-next-or-active-step-button
+      @route={{@activeStep.routeParams.route}}
+      @models={{@activeStep.routeParams.models}}
+      data-test-active-step-button
       class="flex-shrink-0 w-full"
     >
       <div class="flex items-center justify-center">

--- a/app/components/course-page/previous-steps-incomplete-modal.hbs
+++ b/app/components/course-page/previous-steps-incomplete-modal.hbs
@@ -22,7 +22,7 @@
     >
       <div class="flex items-center justify-center">
         {{svg-jar "arrow-left" class="w-4 mr-1 fill-current flex-shrink-0"}}
-        <span>Back to current stage</span>
+        <span>Back to current {{if (eq @activeStep.type "CourseStageStep") "stage" "step"}}</span>
       </div>
     </PrimaryLinkButton>
 

--- a/app/components/course-page/previous-steps-incomplete-modal.hbs
+++ b/app/components/course-page/previous-steps-incomplete-modal.hbs
@@ -9,8 +9,8 @@
     </div>
 
     <div class="prose dark:prose-invert mb-5 text-center" data-test-completion-message>
-      <p>
-        This step depends on previous steps<br />
+      <p class="text-balance">
+        This step depends on previous steps
         that you haven't completed yet.
       </p>
     </div>

--- a/app/components/course-page/previous-steps-incomplete-modal.hbs
+++ b/app/components/course-page/previous-steps-incomplete-modal.hbs
@@ -1,32 +1,36 @@
 <ModalBody @allowManualClose={{false}} @onClose={{@onClose}} class="w-full" data-test-previous-steps-incomplete-modal ...attributes>
-  <div class="mb-4 font-semibold text-2xl text-gray-800 dark:text-gray-100 mr-6">
-    Previous steps incomplete
-  </div>
+  <div class="flex flex-col items-center w-full">
+    <div class="text-[60px]">
+      ⚠️
+    </div>
 
-  <div class="prose dark:prose-invert mb-6">
-    <p>
-      This step depends on previous steps that you haven't completed yet.
-    </p>
-  </div>
+    <div class="mb-1 font-bold text-2xl text-gray-700 dark:text-gray-100">
+      Previous steps incomplete
+    </div>
 
-  <div class="flex items-center gap-x-6 gap-y-4 flex-wrap">
+    <div class="prose dark:prose-invert mb-5" data-test-completion-message>
+      <p>
+        This step depends on previous steps that you haven't completed yet.
+      </p>
+    </div>
+
     <PrimaryLinkButton
-      @route={{@activeStep.routeParams.route}}
-      @models={{@activeStep.routeParams.models}}
-      data-test-active-step-button
-      class="flex-shrink-0"
+      @route={{this.stepForNextOrActiveStepButton.routeParams.route}}
+      @models={{this.stepForNextOrActiveStepButton.routeParams.models}}
+      data-test-next-or-active-step-button
+      class="flex-shrink-0 w-full"
     >
-      <div class="flex items-center">
-        {{svg-jar "arrow-left" class="w-4 mr-1 fill-current flex-shrink-0"}}
+      <div class="flex items-center justify-center">
+        {{svg-jar "arrow-left" class="w-4 ml-1 fill-current flex-shrink-0"}}
         <span>Back to current {{if (eq @activeStep.type "CourseStageStep") "stage" "step"}}</span>
       </div>
     </PrimaryLinkButton>
 
     <div
-      class="text-gray-500 hover:text-gray-800 dark:text-gray-300 text-sm pb-0.25 border-b border-gray-400 dark:border-gray-500 hover:border-gray-600 dark:hover:border-gray-400 flex-shrink-0"
+      class="mt-3 text-gray-500 hover:text-gray-800 dark:text-gray-300 pb-0.25 border-b border-gray-400 dark:border-gray-500 hover:border-gray-600 dark:hover:border-gray-400 flex-shrink-0 text-xs"
       role="button"
       {{on "click" @onClose}}
-      data-test-just-exploring-button
+      data-test-view-instructions-button
     >
       I'm just exploring 👀
     </div>

--- a/app/components/course-page/previous-steps-incomplete-modal.hbs
+++ b/app/components/course-page/previous-steps-incomplete-modal.hbs
@@ -21,8 +21,8 @@
       class="flex-shrink-0 w-full"
     >
       <div class="flex items-center justify-center">
-        {{svg-jar "arrow-left" class="w-4 ml-1 fill-current flex-shrink-0"}}
-        <span>Back to current {{if (eq @activeStep.type "CourseStageStep") "stage" "step"}}</span>
+        {{svg-jar "arrow-left" class="w-4 mr-1 fill-current flex-shrink-0"}}
+        <span>Back to current stage</span>
       </div>
     </PrimaryLinkButton>
 

--- a/app/components/course-page/previous-steps-incomplete-modal.hbs
+++ b/app/components/course-page/previous-steps-incomplete-modal.hbs
@@ -10,7 +10,8 @@
 
     <div class="prose dark:prose-invert mb-5 text-center" data-test-completion-message>
       <p>
-        This step depends on previous steps<br> that you haven't completed yet.
+        This step depends on previous steps<br />
+        that you haven't completed yet.
       </p>
     </div>
 
@@ -22,7 +23,7 @@
     >
       <div class="flex items-center justify-center">
         {{svg-jar "arrow-left" class="w-4 mr-1 fill-current flex-shrink-0"}}
-        
+
         <span>Back to current {{if (eq @activeStep.type "CourseStageStep") "stage" "step"}}</span>
       </div>
     </PrimaryLinkButton>
@@ -33,7 +34,7 @@
       {{on "click" @onClose}}
       data-test-just-exploring-button
     >
-      I'm just exploring  👀
+      I'm just exploring 👀
     </div>
   </div>
 </ModalBody>

--- a/app/components/course-page/previous-steps-incomplete-modal.hbs
+++ b/app/components/course-page/previous-steps-incomplete-modal.hbs
@@ -1,16 +1,16 @@
 <ModalBody @allowManualClose={{false}} @onClose={{@onClose}} class="w-full" data-test-previous-steps-incomplete-modal ...attributes>
   <div class="flex flex-col items-center w-full">
-    <div class="text-[60px]">
+    <div class="text-[60px] text-center">
       ⚠️
     </div>
 
-    <div class="mb-1 font-bold text-2xl text-gray-700 dark:text-gray-100">
-      Previous steps incomplete
+    <div class="mb-1 font-bold text-2xl text-gray-700 dark:text-gray-100 text-center">
+      Previous steps incomplete!
     </div>
 
-    <div class="prose dark:prose-invert mb-5" data-test-completion-message>
+    <div class="prose dark:prose-invert mb-5 text-center" data-test-completion-message>
       <p>
-        This step depends on previous steps that you haven't completed yet.
+        This step depends on previous steps<br> that you haven't completed yet.
       </p>
     </div>
 
@@ -22,17 +22,18 @@
     >
       <div class="flex items-center justify-center">
         {{svg-jar "arrow-left" class="w-4 mr-1 fill-current flex-shrink-0"}}
+        
         <span>Back to current {{if (eq @activeStep.type "CourseStageStep") "stage" "step"}}</span>
       </div>
     </PrimaryLinkButton>
 
     <div
-      class="mt-3 text-gray-500 hover:text-gray-800 dark:text-gray-300 pb-0.25 border-b border-gray-400 dark:border-gray-500 hover:border-gray-600 dark:hover:border-gray-400 flex-shrink-0 text-xs"
+      class="mt-3 text-gray-500 hover:text-gray-800 dark:text-gray-300 pb-0.25 border-b border-gray-400 dark:border-gray-500 hover:border-gray-600 dark:hover:border-gray-400 flex-shrink-0 text-xs text-center"
       role="button"
       {{on "click" @onClose}}
       data-test-just-exploring-button
     >
-      I'm just exploring 👀
+      I'm just exploring  👀
     </div>
   </div>
 </ModalBody>


### PR DESCRIPTION
**Checklist**:

- [x] I've thoroughly self-reviewed my changes
- [ ] I've added tests for my changes, unless they affect admin-only areas (or are otherwise not worth testing)
- [ ] I've verified any visual changes using Percy (add a commit with `[percy]` in the message to trigger)


Changes from the one without the exclamation works to the one with: 
<img width="855" alt="Screenshot 2025-04-16 at 18 50 01" src="https://github.com/user-attachments/assets/4e03db08-9356-418b-8144-b9774716b577" />
<img width="886" alt="Screenshot 2025-04-16 at 18 49 56" src="https://github.com/user-attachments/assets/91b7e571-747c-444c-9824-ec90b620c27b" />
<img width="875" alt="Screenshot 2025-04-16 at 18 49 50" src="https://github.com/user-attachments/assets/63b3c39c-ad6e-4dc0-9b94-c6d6edee22ff" />
<img width="1192" alt="Screenshot 2025-04-16 at 18 49 42" src="https://github.com/user-attachments/assets/44bc1854-ff43-4096-a3e2-d9ed3738295b" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Style**
  - Improved the modal layout with centered, vertically stacked elements and a large warning emoji for better visual emphasis.
  - Updated button and text styles for enhanced readability and usability.
  - Restyled the "I'm just exploring" option for a cleaner appearance.

- **Bug Fixes**
  - Adjusted test attributes to improve testability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->