### PR TITLE
Fix possible null-reference when reading `router.currentRoute.metadata`

### DIFF
--- a/app/services/meta-data.ts
+++ b/app/services/meta-data.ts
@@ -7,7 +7,7 @@ export default class HeadDataService extends Service {
   @service declare router: RouterService;
 
   get shouldRenderNoIndexTag() {
-    const routeMeta = this.router.currentRoute.metadata;
+    const routeMeta = this.router.currentRoute?.metadata;
     const allowsAnonymousAccess = routeMeta instanceof RouteInfoMetadata && routeMeta.allowsAnonymousAccess;
 
     return !allowsAnonymousAccess;


### PR DESCRIPTION
### Brief

Fix possible null-reference when reading `router.currentRoute.metadata`

### Checklist

- [x] I've thoroughly self-reviewed my changes
- [x] I've added tests for my changes, unless they affect admin-only areas (or are otherwise not worth testing)
- [x] I've verified any visual changes using Percy (add a commit with `[percy]` in the message to trigger)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved app stability by preventing potential errors when accessing route metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->