### PR TITLE
Update visibility conditions for action buttons and tabs to include 'gleam-chess-bot-js'

### DIFF
--- a/app/components/course-page/course-stage-step/your-task-card/action-button-list.ts
+++ b/app/components/course-page/course-stage-step/your-task-card/action-button-list.ts
@@ -28,7 +28,7 @@ export default class ActionButtonListComponent extends Component<Signature> {
 
   get shouldShowCodeExamplesButton() {
     // TODO: Remove. Temporary measure for private course
-    return !this.args.courseStage.isFirst && this.args.courseStage.slug !== 'gleam-chess-bot';
+    return !this.args.courseStage.isFirst && this.args.courseStage.slug !== 'gleam-chess-bot' && this.args.courseStage.slug !== 'gleam-chess-bot-js';
   }
 
   get shouldShowViewScreencastsButton() {

--- a/app/components/course-page/header/tab-list.ts
+++ b/app/components/course-page/header/tab-list.ts
@@ -104,7 +104,7 @@ export default class TabListComponent extends Component<Signature> {
     });
 
     // TODO: Remove. Temporary measure for private course
-    if (this.args.course.slug !== 'gleam-chess-bot') {
+    if (this.args.course.slug !== 'gleam-chess-bot' && this.args.course.slug !== 'gleam-chess-bot-js') {
       tabs.push({
         icon: 'code',
         name: 'Code Examples',

--- a/app/models/course.ts
+++ b/app/models/course.ts
@@ -132,6 +132,7 @@ export default class CourseModel extends Model {
         docker: dockerLogo,
         git: gitLogo,
         'gleam-chess-bot': gleamChessBotLogo,
+        'gleam-chess-bot-js': gleamChessBotLogo,
         grep: grepLogo,
         'http-server': httpServerLogo,
         interpreter: interpreterLogo,
@@ -165,6 +166,7 @@ export default class CourseModel extends Model {
       'sqlite',
       'dns-server',
       'gleam-chess-bot',
+      'gleam-chess-bot-js',
     ];
     const index = orderedSlugs.indexOf(this.slug);
 


### PR DESCRIPTION
Enhance course-related logic to ensure that the 'gleam-chess-bot-js' course is considered in the visibility conditions for action buttons and tabs.

**Checklist**:

- [x] I've thoroughly self-reviewed my changes
- [ ] I've added tests for my changes, unless they affect admin-only areas (or are otherwise not worth testing)
- [ ] I've verified any visual changes using Percy (add a commit with `[percy]` in the message to trigger)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for a new course, "gleam-chess-bot-js", including its logo and sorting position in course lists.

- **Bug Fixes**
  - Updated the display logic to ensure the "Code Examples" button and tab are correctly hidden for both "gleam-chess-bot" and "gleam-chess-bot-js" courses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->