### PR TITLE
feat: add design preview for code example insights listing

### DIFF
--- a/app/components/course-admin/code-example-insights-index-page/stage-list-item/index.hbs
+++ b/app/components/course-admin/code-example-insights-index-page/stage-list-item/index.hbs
@@ -1,0 +1,29 @@
+<LinkTo
+  class="flex items-center justify-between flex-wrap gap-x-6 gap-y-2 py-3 group/stage-list-item hover:bg-gray-50 px-1"
+  data-test-version-list-item
+  role="button"
+  @route="course.stage.code-examples"
+  @models={{array @stage.course.slug @stage.slug}}
+  ...attributes
+>
+  <div class="min-w-0">
+    <div class="flex items-center flex-wrap gap-2">
+      <div class="font-semibold text-sm text-gray-700">{{@stage.name}}</div>
+      <svg viewBox="0 0 2 2" class="h-0.5 w-0.5 fill-current text-gray-300">
+        <circle cx="1" cy="1" r="1" />
+      </svg>
+      <CourseAdmin::CodeExampleInsightsIndexPage::StageListItem::Statistic @color="green" @label="examples" @value={{20}} />
+    </div>
+  </div>
+  <div class="flex flex-none items-center gap-x-2">
+    <CourseAdmin::CodeExampleInsightsIndexPage::StageListItem::Statistic @color="green" @label="upvotes" @value={{1}} />
+    <svg viewBox="0 0 2 2" class="h-0.5 w-0.5 fill-current text-gray-300">
+      <circle cx="1" cy="1" r="1" />
+    </svg>
+    <CourseAdmin::CodeExampleInsightsIndexPage::StageListItem::Statistic @color="green" @label="downvotes" @value={{1}} />
+    {{!-- <svg viewBox="0 0 2 2" class="h-0.5 w-0.5 fill-current text-gray-300">
+      <circle cx="1" cy="1" r="1" />
+    </svg>
+    <CourseAdmin::CodeExampleInsightsIndexPage::StageListItem::Statistic @color="green" @label="dummy" @value={{1}} /> --}}
+  </div>
+</LinkTo>

--- a/app/components/course-admin/code-example-insights-index-page/stage-list-item/index.hbs
+++ b/app/components/course-admin/code-example-insights-index-page/stage-list-item/index.hbs
@@ -16,14 +16,14 @@
     </div>
   </div>
   <div class="flex flex-none items-center gap-x-2">
+    <CourseAdmin::CodeExampleInsightsIndexPage::StageListItem::Statistic @color="green" @label="loc" @value={{15}} />
+    <svg viewBox="0 0 2 2" class="h-0.5 w-0.5 fill-current text-gray-300">
+      <circle cx="1" cy="1" r="1" />
+    </svg>
     <CourseAdmin::CodeExampleInsightsIndexPage::StageListItem::Statistic @color="green" @label="upvotes" @value={{1}} />
     <svg viewBox="0 0 2 2" class="h-0.5 w-0.5 fill-current text-gray-300">
       <circle cx="1" cy="1" r="1" />
     </svg>
     <CourseAdmin::CodeExampleInsightsIndexPage::StageListItem::Statistic @color="green" @label="downvotes" @value={{1}} />
-    {{!-- <svg viewBox="0 0 2 2" class="h-0.5 w-0.5 fill-current text-gray-300">
-      <circle cx="1" cy="1" r="1" />
-    </svg>
-    <CourseAdmin::CodeExampleInsightsIndexPage::StageListItem::Statistic @color="green" @label="dummy" @value={{1}} /> --}}
   </div>
 </LinkTo>

--- a/app/components/course-admin/code-example-insights-index-page/stage-list-item/index.ts
+++ b/app/components/course-admin/code-example-insights-index-page/stage-list-item/index.ts
@@ -1,0 +1,18 @@
+import Component from '@glimmer/component';
+import type CourseStageModel from 'codecrafters-frontend/models/course-stage';
+
+interface Signature {
+  Element: HTMLAnchorElement;
+
+  Args: {
+    stage: CourseStageModel;
+  };
+}
+
+export default class StageListItemComponent extends Component<Signature> {}
+
+declare module '@glint/environment-ember-loose/registry' {
+  export default interface Registry {
+    'CourseAdmin::CodeExampleInsightsIndexPage::StageListItem': typeof StageListItemComponent;
+  }
+}

--- a/app/components/course-admin/code-example-insights-index-page/stage-list-item/statistic.hbs
+++ b/app/components/course-admin/code-example-insights-index-page/stage-list-item/statistic.hbs
@@ -1,0 +1,20 @@
+<div class="inline-flex items-center gap-x-1 text-xs">
+  <div class="{{this.valueColorClasses}}">
+    {{#if @value}}
+      <span class="font-semibold">
+        {{@value}}
+      </span>
+    {{else}}
+      -
+    {{/if}}
+  </div>
+  <div class="text-gray-400">
+    {{@label}}
+  </div>
+
+  <EmberTooltip>
+    <div class="prose prose-sm prose-invert text-white">
+      {{markdown-to-html "Dummy tooltip text!"}}
+    </div>
+  </EmberTooltip>
+</div>

--- a/app/components/course-admin/code-example-insights-index-page/stage-list-item/statistic.ts
+++ b/app/components/course-admin/code-example-insights-index-page/stage-list-item/statistic.ts
@@ -1,0 +1,28 @@
+import Component from '@glimmer/component';
+
+interface Signature {
+  Element: HTMLDivElement;
+
+  Args: {
+    color: 'green' | 'yellow' | 'red' | 'gray';
+    label: string;
+    value: number | null;
+  };
+}
+
+export default class StatisticComponent extends Component<Signature> {
+  get valueColorClasses(): string {
+    return {
+      green: 'text-teal-500',
+      yellow: 'text-yellow-500',
+      red: 'text-red-500',
+      gray: 'text-gray-500',
+    }[this.args.color];
+  }
+}
+
+declare module '@glint/environment-ember-loose/registry' {
+  export default interface Registry {
+    'CourseAdmin::CodeExampleInsightsIndexPage::StageListItem::Statistic': typeof StatisticComponent;
+  }
+}

--- a/app/router.ts
+++ b/app/router.ts
@@ -27,15 +27,17 @@ Router.map(function () {
   this.route('courses');
 
   this.route('course-admin', { path: '/courses/:course_slug/admin' }, function () {
-    this.route('buildpacks');
     this.route('buildpack', { path: '/buildpacks/:buildpack_id' });
+    this.route('buildpacks');
     this.route('code-example', { path: '/code-examples/:code_example_id' });
-    this.route('code-example-evaluators');
     this.route('code-example-evaluator', { path: '/code-example-evaluators/:evaluator_slug' });
+    this.route('code-example-evaluators');
+    this.route('code-example-insights', { path: '/code-examples/stage/:stage_slug' });
+    this.route('code-example-insights-index', { path: '/code-examples' });
     this.route('feedback');
     this.route('insights');
-    this.route('stage-insights-index', { path: '/stage-insights' });
     this.route('stage-insights', { path: '/stage-insights/:stage_slug' });
+    this.route('stage-insights-index', { path: '/stage-insights' });
     this.route('submissions');
     this.route('tester-version', { path: '/tester-versions/:tester_version_id' });
     this.route('tester-versions');

--- a/app/routes/course-admin/code-example-insights-index.ts
+++ b/app/routes/course-admin/code-example-insights-index.ts
@@ -1,0 +1,26 @@
+import { inject as service } from '@ember/service';
+import BaseRoute from 'codecrafters-frontend/utils/base-route';
+import Store from '@ember-data/store';
+import type CourseModel from 'codecrafters-frontend/models/course';
+
+export type ModelType = {
+  course: CourseModel;
+};
+
+export default class CodeExampleInsightsIndexRoute extends BaseRoute {
+  @service declare store: Store;
+
+  async model(): Promise<ModelType> {
+    // @ts-ignore
+    const course = this.modelFor('course-admin').course as CourseModel;
+
+    // (await this.store.query('course-stage-participation-analysis', {
+    //   course_id: course.id,
+    //   include: 'stage',
+    // })) as unknown as CourseStageParticipationAnalysisModel[];
+
+    return {
+      course: course,
+    };
+  }
+}

--- a/app/templates/course-admin/code-example-insights-index.hbs
+++ b/app/templates/course-admin/code-example-insights-index.hbs
@@ -1,0 +1,48 @@
+<div class="bg-white min-h-screen">
+  <div class="container mx-auto pt-4 pb-10 px-6">
+    <div class="pt-3 pb-6 border-b flex items-start justify-between">
+      <div>
+        <h3 class="text-lg font-bold text-gray-800 mb-1">
+          Code Examples 🚧 (Work in progress!)
+        </h3>
+        <div class="text-xs text-gray-400">
+          Summaries of code examples submitted by users.
+        </div>
+      </div>
+      <div>
+        <LanguageDropdown
+          @languages={{@model.course.betaOrLiveLanguages}}
+          @onRequestedLanguageChange={{(noop)}}
+          @requestedLanguage={{null}}
+          @selectedLanguage={{@model.course.betaOrLiveLanguages.lastObject}}
+          @shouldShowAllLanguagesOption={{false}}
+        />
+      </div>
+    </div>
+
+    {{#if (gt @model.course.stages.length 0)}}
+      <ul role="list" class="divide-y divide-gray-100">
+        {{#each @model.course.sortedBaseStages as |stage|}}
+          <CourseAdmin::CodeExampleInsightsIndexPage::StageListItem @stage={{stage}} />
+        {{/each}}
+      </ul>
+
+      {{#each @model.course.sortedExtensions as |extension|}}
+        <h3 class="font-semibold text-gray-400 text-center relative mt-8 mb-3">
+          <span class="block h-px w-full bg-gray-200 absolute top-50-percent -mt-px"></span>
+          <span class="relative px-6 bg-white">{{extension.name}}</span>
+        </h3>
+
+        <ul role="list" class="divide-y divide-gray-100">
+          {{#each extension.sortedStages as |stage|}}
+            <CourseAdmin::CodeExampleInsightsIndexPage::StageListItem @stage={{stage}} />
+          {{/each}}
+        </ul>
+      {{/each}}
+    {{else}}
+      <div class="text-gray-400 py-32 flex items-center justify-center">
+        No stages found.
+      </div>
+    {{/if}}
+  </div>
+</div>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a new Code Example Insights page in the course admin interface, featuring a header, language selection dropdown, and organized lists of stages and extensions.
  - Added interactive stage list items displaying stage names and statistics for code examples, lines of code, upvotes, and downvotes.
  - Included clear messaging when no stages are available.
- **Navigation**
  - Added new routes for accessing code example insights by stage and for the overall insights index within course admin.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->