### PR TITLE
Dark mode on /vote

### DIFF
--- a/app/components/vote-page/course-extension-idea-card.hbs
+++ b/app/components/vote-page/course-extension-idea-card.hbs
@@ -1,5 +1,5 @@
 <div
-  class="relative group bg-white dark:bg-gray-850 p-5 rounded-md shadow-sm dark:shadow-gray-900/20 flex flex-col justify-between border
+  class="relative group bg-white dark:bg-gray-850 p-5 rounded-md shadow-sm flex flex-col justify-between border
     {{if this.userHasVoted 'border-gray-300 dark:border-gray-700' 'border-gray-200 dark:border-white/5'}}
     {{if @courseExtensionIdea.developmentStatusIsReleased 'opacity-50'}}"
   data-test-course-extension-idea-card
@@ -40,7 +40,7 @@
         </div>
       {{else if @courseExtensionIdea.isNewlyCreated}}
         <div
-          class="text-xs text-teal-500 dark:text-teal-400 font-semibold border border-teal-500 dark:border-teal-400 rounded px-1.5 py-1 ml-3 mt-0.5"
+          class="text-xs text-teal-500 dark:text-teal-600 font-semibold border border-teal-500 rounded px-1.5 py-1 ml-3 mt-0.5"
           data-test-development-status-label
         >
           new

--- a/app/components/vote-page/course-extension-idea-card.hbs
+++ b/app/components/vote-page/course-extension-idea-card.hbs
@@ -1,5 +1,5 @@
 <div
-  class="relative group bg-white dark:bg-gray-850 p-5 rounded-md shadow-sm flex flex-col justify-between border
+  class="relative group bg-white dark:bg-gray-850 p-5 rounded-md shadow-sm dark:shadow-gray-900/20 flex flex-col justify-between border
     {{if this.userHasVoted 'border-gray-300 dark:border-gray-700' 'border-gray-200 dark:border-white/5'}}
     {{if @courseExtensionIdea.developmentStatusIsReleased 'opacity-50'}}"
   data-test-course-extension-idea-card
@@ -13,7 +13,7 @@
 
       {{#if @courseExtensionIdea.developmentStatusIsInProgress}}
         <div
-          class="text-xs text-white font-semibold bg-yellow-500 rounded px-1.5 py-1 ml-3 mt-0.5 flex items-center"
+          class="text-xs text-white font-semibold bg-yellow-500 dark:bg-yellow-600 rounded px-1.5 py-1 ml-3 mt-0.5 flex items-center"
           data-test-development-status-label
         >
           in progress
@@ -27,7 +27,7 @@
         </div>
       {{else if @courseExtensionIdea.developmentStatusIsReleased}}
         <div
-          class="text-xs text-white font-semibold bg-teal-500 rounded px-1.5 py-1 ml-3 mt-0.5 flex items-center"
+          class="text-xs text-white font-semibold bg-teal-500 dark:bg-teal-600 rounded px-1.5 py-1 ml-3 mt-0.5 flex items-center"
           data-test-development-status-label
         >
           <LinkTo @route="catalog">released</LinkTo>
@@ -35,11 +35,14 @@
           <EmberTooltip @text="This challenge extension is now available! Visit the catalog to try it out." />
         </div>
       {{else if this.userHasVoted}}
-        <div class="h-7 w-7 bg-teal-500 rounded flex items-center justify-center">
+        <div class="h-7 w-7 bg-teal-500 dark:bg-teal-600 rounded flex items-center justify-center">
           {{svg-jar "chevron-up" class="w-7 fill-current text-white"}}
         </div>
       {{else if @courseExtensionIdea.isNewlyCreated}}
-        <div class="text-xs text-teal-500 font-semibold border border-teal-500 rounded px-1.5 py-1 ml-3 mt-0.5" data-test-development-status-label>
+        <div
+          class="text-xs text-teal-500 dark:text-teal-400 font-semibold border border-teal-500 dark:border-teal-400 rounded px-1.5 py-1 ml-3 mt-0.5"
+          data-test-development-status-label
+        >
           new
         </div>
       {{/if}}
@@ -60,7 +63,7 @@
       />
 
       {{#if (and this.userHasVoted this.isVotingOrUnvoting)}}
-        <svg class="animate-spin ml-2 w-3 text-teal-500" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
+        <svg class="animate-spin ml-2 w-3 text-teal-500 dark:text-teal-400" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
           <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
           <path
             class="opacity-75"

--- a/app/components/vote-page/course-idea-card.gts
+++ b/app/components/vote-page/course-idea-card.gts
@@ -74,8 +74,8 @@ export default class CourseIdeaCardComponent extends Component<Signature> {
 
   <template>
     <div
-      class='group bg-white p-5 rounded-md shadow-sm flex flex-col justify-between border
-        {{if this.userHasVoted "border-gray-300"}}
+      class='group bg-white dark:bg-gray-850 p-5 rounded-md shadow-sm dark:shadow-gray-900/20 flex flex-col justify-between border
+        {{if this.userHasVoted "border-gray-300 dark:border-gray-700" "border-gray-200 dark:border-white/5"}}
         relative
         {{if @courseIdea.developmentStatusIsReleased "opacity-50"}}'
       data-test-course-idea-card
@@ -83,13 +83,13 @@ export default class CourseIdeaCardComponent extends Component<Signature> {
       {{! Text }}
       <div class='mb-4'>
         <div class='flex items-start justify-between mb-3'>
-          <div class='text-gray-700 mr-2 mb-0.5 font-bold text-xl tracking-tight' data-test-course-idea-name>
+          <div class='text-gray-700 dark:text-gray-200 mr-2 mb-0.5 font-bold text-xl tracking-tight' data-test-course-idea-name>
             {{@courseIdea.name}}
           </div>
 
           {{#if @courseIdea.developmentStatusIsInProgress}}
             <div
-              class='text-xs text-white font-semibold bg-yellow-500 rounded px-1.5 py-1 ml-3 mt-0.5 flex items-center'
+              class='text-xs text-white font-semibold bg-yellow-500 dark:bg-yellow-600 rounded px-1.5 py-1 ml-3 mt-0.5 flex items-center'
               data-test-development-status-label
             >
               in progress
@@ -102,7 +102,7 @@ export default class CourseIdeaCardComponent extends Component<Signature> {
             </div>
           {{else if @courseIdea.developmentStatusIsReleased}}
             <div
-              class='text-xs text-white font-semibold bg-teal-500 rounded px-1.5 py-1 ml-3 mt-0.5 flex items-center'
+              class='text-xs text-white font-semibold bg-teal-500 dark:bg-teal-600 rounded px-1.5 py-1 ml-3 mt-0.5 flex items-center'
               data-test-development-status-label
             >
               <LinkTo @route='catalog'>released</LinkTo>
@@ -110,12 +110,12 @@ export default class CourseIdeaCardComponent extends Component<Signature> {
               <EmberTooltip @text='This challenge is now available! Visit the catalog to try it out.' />
             </div>
           {{else if this.userHasVoted}}
-            <div class='h-7 w-7 bg-teal-500 rounded flex items-center justify-center'>
+            <div class='h-7 w-7 bg-teal-500 dark:bg-teal-600 rounded flex items-center justify-center'>
               {{svgJar 'chevron-up' class='w-7 fill-current text-white'}}
             </div>
           {{else if @courseIdea.isNewlyCreated}}
             <div
-              class='text-xs text-teal-500 font-semibold border border-teal-500 rounded px-1.5 py-1 ml-3 mt-0.5'
+              class='text-xs text-teal-500 dark:text-teal-400 font-semibold border border-teal-500 dark:border-teal-400 rounded px-1.5 py-1 ml-3 mt-0.5'
               data-test-development-status-label
             >
               new
@@ -123,7 +123,7 @@ export default class CourseIdeaCardComponent extends Component<Signature> {
             </div>
           {{/if}}
         </div>
-        <div class='prose prose-sm'>
+        <div class='prose dark:prose-invert prose-sm'>
           {{MarkdownToHtml @courseIdea.descriptionMarkdown}}
         </div>
       </div>
@@ -134,7 +134,7 @@ export default class CourseIdeaCardComponent extends Component<Signature> {
           <VoteButton @idea={{@courseIdea}} @userHasVoted={{this.userHasVoted}} {{on 'click' this.handleVoteButtonClick}} class='mr-2' />
 
           {{#if (and this.userHasVoted this.isVotingOrUnvoting)}}
-            <svg class='animate-spin ml-2 w-3 text-teal-500' xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24'>
+            <svg class='animate-spin ml-2 w-3 text-teal-500 dark:text-teal-400' xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24'>
               <circle class='opacity-25' cx='12' cy='12' r='10' stroke='currentColor' stroke-width='4'></circle>
               <path
                 class='opacity-75'

--- a/app/components/vote-page/course-idea-card.gts
+++ b/app/components/vote-page/course-idea-card.gts
@@ -74,7 +74,7 @@ export default class CourseIdeaCardComponent extends Component<Signature> {
 
   <template>
     <div
-      class='group bg-white dark:bg-gray-850 p-5 rounded-md shadow-sm dark:shadow-gray-900/20 flex flex-col justify-between border
+      class='group bg-white dark:bg-gray-850 p-5 rounded-md shadow-sm flex flex-col justify-between border
         {{if this.userHasVoted "border-gray-300 dark:border-gray-700" "border-gray-200 dark:border-white/5"}}
         relative
         {{if @courseIdea.developmentStatusIsReleased "opacity-50"}}'
@@ -115,7 +115,7 @@ export default class CourseIdeaCardComponent extends Component<Signature> {
             </div>
           {{else if @courseIdea.isNewlyCreated}}
             <div
-              class='text-xs text-teal-500 dark:text-teal-400 font-semibold border border-teal-500 dark:border-teal-400 rounded px-1.5 py-1 ml-3 mt-0.5'
+              class='text-xs text-teal-500 font-semibold border border-teal-500 rounded px-1.5 py-1 ml-3 mt-0.5'
               data-test-development-status-label
             >
               new
@@ -134,7 +134,7 @@ export default class CourseIdeaCardComponent extends Component<Signature> {
           <VoteButton @idea={{@courseIdea}} @userHasVoted={{this.userHasVoted}} {{on 'click' this.handleVoteButtonClick}} class='mr-2' />
 
           {{#if (and this.userHasVoted this.isVotingOrUnvoting)}}
-            <svg class='animate-spin ml-2 w-3 text-teal-500 dark:text-teal-400' xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24'>
+            <svg class='animate-spin ml-2 w-3 text-teal-500' xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24'>
               <circle class='opacity-25' cx='12' cy='12' r='10' stroke='currentColor' stroke-width='4'></circle>
               <path
                 class='opacity-75'

--- a/app/components/vote-page/course-pill.hbs
+++ b/app/components/vote-page/course-pill.hbs
@@ -2,8 +2,8 @@
   class="flex items-center px-3 py-3 rounded-full border
     {{if
       @isSelected
-      'bg-white dark:bg-gray-850 border-teal-500 dark:border-teal-400'
-      'border-gray-300 dark:border-gray-700 bg-gray-100 dark:bg-gray-800 hover:border-gray-400 dark:hover:border-gray-600 hover:bg-white dark:hover:bg-gray-850'
+      'bg-white dark:bg-gray-850 border-teal-500'
+      'border-gray-300 dark:border-gray-700 bg-gray-100 dark:bg-gray-800 hover:border-gray-400 hover:bg-white dark:hover:bg-gray-850'
     }}"
   role="button"
   data-test-course-pill

--- a/app/components/vote-page/course-pill.hbs
+++ b/app/components/vote-page/course-pill.hbs
@@ -1,10 +1,14 @@
 <div
   class="flex items-center px-3 py-3 rounded-full border
-    {{if @isSelected 'bg-white border-teal-500' 'border-gray-300 bg-gray-100 hover:border-gray-400 hover:bg-white'}}"
+    {{if
+      @isSelected
+      'bg-white dark:bg-gray-850 border-teal-500 dark:border-teal-400'
+      'border-gray-300 dark:border-gray-700 bg-gray-100 dark:bg-gray-800 hover:border-gray-400 dark:hover:border-gray-600 hover:bg-white dark:hover:bg-gray-850'
+    }}"
   role="button"
   data-test-course-pill
   ...attributes
 >
   <CourseLogo @course={{@course}} class="h-4 mr-2 flex-shrink-0" />
-  <div class="text-sm text-gray-700 flex-shrink-0">{{@course.name}}</div>
+  <div class="text-sm text-gray-700 dark:text-gray-200 flex-shrink-0">{{@course.name}}</div>
 </div>

--- a/app/components/vote-page/header.hbs
+++ b/app/components/vote-page/header.hbs
@@ -4,7 +4,7 @@
   Help us decide what content to build next.
 </p>
 
-<div class="flex mb-8 border-b dark:border-gray-700 overflow-x-auto">
+<div class="flex mb-8 border-b dark:border-white/5 overflow-x-auto">
   <VotePage::TabLink @text="Challenges" @isActive={{eq this.activeTab "challenges"}} @route="vote.course-ideas" />
   <VotePage::TabLink @text="Challenge Extensions" @isActive={{eq this.activeTab "challenge-extensions"}} @route="vote.course-extension-ideas" />
 </div>

--- a/app/components/vote-page/header.hbs
+++ b/app/components/vote-page/header.hbs
@@ -1,10 +1,10 @@
-<h1 class="text-3xl text-gray-700 font-bold tracking-tighter mb-3">Vote</h1>
+<h1 class="text-3xl text-gray-700 dark:text-gray-200 font-bold tracking-tighter mb-3">Vote</h1>
 
-<p class="text-gray-500 mb-6">
+<p class="text-gray-500 dark:text-gray-400 mb-6">
   Help us decide what content to build next.
 </p>
 
-<div class="flex mb-8 border-b overflow-x-auto">
+<div class="flex mb-8 border-b dark:border-gray-700 overflow-x-auto">
   <VotePage::TabLink @text="Challenges" @isActive={{eq this.activeTab "challenges"}} @route="vote.course-ideas" />
   <VotePage::TabLink @text="Challenge Extensions" @isActive={{eq this.activeTab "challenge-extensions"}} @route="vote.course-extension-ideas" />
 </div>

--- a/app/components/vote-page/idea-card/unvote-button.gts
+++ b/app/components/vote-page/idea-card/unvote-button.gts
@@ -6,7 +6,12 @@ type Signature = {
 
 export default class UnvoteButtonComponent extends Component<Signature> {
   <template>
-    <button type='button' class='flex items-center text-gray-400 hover:text-gray-500 px-2 hover:underline' data-test-unvote-button ...attributes>
+    <button
+      type='button'
+      class='flex items-center text-gray-400 dark:text-gray-500 hover:text-gray-500 dark:hover:text-gray-400 px-2 hover:underline'
+      data-test-unvote-button
+      ...attributes
+    >
       <span class='text-xs'>
         Cancel
       </span>

--- a/app/components/vote-page/idea-card/vote-button.gts
+++ b/app/components/vote-page/idea-card/vote-button.gts
@@ -27,19 +27,15 @@ export default class VoteButtonComponent extends Component<Signature> {
   <template>
     <button
       type='button'
-      class='pr-2.5 pl-2 py-1.5 rounded shadow-sm dark:shadow-gray-900/20 flex items-center border
-        {{if
-          @userHasVoted
-          "border-teal-500 dark:border-teal-400 hover:border-teal-600 dark:hover:border-teal-500"
-          "border-gray-300 dark:border-gray-700 hover:border-gray-400 dark:hover:border-gray-600"
-        }}
+      class='pr-2.5 pl-2 py-1.5 rounded shadow-sm flex items-center border
+        {{if @userHasVoted "border-teal-500 hover:border-teal-600" "border-gray-300 dark:border-gray-700 hover:border-gray-400"}}
         transition-all duration-75 active:shadow active:border-teal-600 dark:active:border-teal-500'
       data-test-vote-button
       ...attributes
     >
-      {{svgJar 'chevron-up' class='w-5 mr-1 text-teal-500 dark:text-teal-400'}}
+      {{svgJar 'chevron-up' class='w-5 mr-1 text-teal-500'}}
 
-      <span class='text-sm {{if @userHasVoted "text-teal-500 dark:text-teal-400" "text-gray-700 dark:text-gray-300"}} transition-all duration-75'>
+      <span class='text-sm {{if @userHasVoted "text-teal-500" "text-gray-700 dark:text-gray-300"}} transition-all duration-75'>
         <span class='font-semibold'>{{this.renderedVotesCount}}</span>
 
         {{#if (eq this.renderedVotesCount 1)}}

--- a/app/components/vote-page/idea-card/vote-button.gts
+++ b/app/components/vote-page/idea-card/vote-button.gts
@@ -27,19 +27,19 @@ export default class VoteButtonComponent extends Component<Signature> {
   <template>
     <button
       type='button'
-      class='pr-2.5 pl-2 py-1.5 rounded shadow-sm flex items-center border
+      class='pr-2.5 pl-2 py-1.5 rounded shadow-sm dark:shadow-gray-900/20 flex items-center border
         {{if
           @userHasVoted
-          "border-teal-500 hover:border-teal-600"
+          "border-teal-500 dark:border-teal-400 hover:border-teal-600 dark:hover:border-teal-500"
           "border-gray-300 dark:border-gray-700 hover:border-gray-400 dark:hover:border-gray-600"
         }}
-        transition-all duration-75 active:shadow active:border-teal-600'
+        transition-all duration-75 active:shadow active:border-teal-600 dark:active:border-teal-500'
       data-test-vote-button
       ...attributes
     >
-      {{svgJar 'chevron-up' class='w-5 mr-1 text-teal-500'}}
+      {{svgJar 'chevron-up' class='w-5 mr-1 text-teal-500 dark:text-teal-400'}}
 
-      <span class='text-sm {{if @userHasVoted "text-teal-500" "text-gray-700 dark:text-gray-300"}} transition-all duration-75'>
+      <span class='text-sm {{if @userHasVoted "text-teal-500 dark:text-teal-400" "text-gray-700 dark:text-gray-300"}} transition-all duration-75'>
         <span class='font-semibold'>{{this.renderedVotesCount}}</span>
 
         {{#if (eq this.renderedVotesCount 1)}}

--- a/app/components/vote-page/submit-course-idea-card.gts
+++ b/app/components/vote-page/submit-course-idea-card.gts
@@ -21,7 +21,7 @@ export default class SubmitCourseIdeaCardComponent extends Component {
 
   <template>
     <div
-      class='group border-2 border-dashed hover:border-gray-400 px-5 py-10 lg:py-20 rounded-md flex flex-col items-center justify-center text-gray-400 hover:text-gray-600'
+      class='group border-2 border-dashed dark:border-white/5 hover:border-gray-400 dark:hover:border-gray-700 px-5 py-10 lg:py-20 rounded-md flex flex-col items-center justify-center text-gray-400 dark:text-gray-600 hover:text-gray-800 dark:hover:text-gray-200'
       data-test-submit-course-idea-card
       role='button'
       {{on 'click' this.handleClick}}

--- a/app/components/vote-page/submit-course-idea-card.gts
+++ b/app/components/vote-page/submit-course-idea-card.gts
@@ -21,7 +21,7 @@ export default class SubmitCourseIdeaCardComponent extends Component {
 
   <template>
     <div
-      class='group border-2 border-dashed dark:border-white/5 hover:border-gray-400 dark:hover:border-gray-700 px-5 py-10 lg:py-20 rounded-md flex flex-col items-center justify-center text-gray-400 dark:text-gray-600 hover:text-gray-800 dark:hover:text-gray-200'
+      class='group border-2 border-dashed dark:border-white/5 hover:border-gray-400 dark:hover:border-gray-700 px-5 py-10 lg:py-20 rounded-md flex flex-col items-center justify-center text-gray-400 dark:text-gray-600 hover:text-gray-600 dark:hover:text-gray-400'
       data-test-submit-course-idea-card
       role='button'
       {{on 'click' this.handleClick}}

--- a/app/components/vote-page/tab-link.hbs
+++ b/app/components/vote-page/tab-link.hbs
@@ -1,9 +1,10 @@
 <LinkTo
   @route={{@route}}
   role="button"
-  class="flex flex-shrink-0 items-center px-3 py-2 mr-2 border-b-2 text-sm {{if @isActive 'border-teal-500' 'border-gray-100'}}"
+  class="flex flex-shrink-0 items-center px-3 py-2 mr-2 border-b-2 text-sm
+    {{if @isActive 'border-teal-500 dark:border-teal-400' 'border-gray-100 dark:border-gray-700'}}"
   data-test-tab-link
   ...attributes
 >
-  <span class={{if @isActive "font-medium text-teal-500" "text-gray-600"}}>{{@text}}</span>
+  <span class={{if @isActive "font-medium text-teal-500 dark:text-teal-400" "text-gray-600 dark:text-gray-400"}}>{{@text}}</span>
 </LinkTo>

--- a/app/routes/vote.ts
+++ b/app/routes/vote.ts
@@ -8,7 +8,7 @@ import BaseRoute from 'codecrafters-frontend/utils/base-route';
 import scrollToTop from 'codecrafters-frontend/utils/scroll-to-top';
 import { hash as RSVPHash } from 'rsvp';
 import type Transition from '@ember/routing/transition';
-import RouteInfoMetadata from 'codecrafters-frontend/utils/route-info-metadata';
+import RouteInfoMetadata, { RouteColorScheme } from 'codecrafters-frontend/utils/route-info-metadata';
 
 export type ModelType = {
   courseIdeas: CourseIdeaModel[];
@@ -31,7 +31,7 @@ export default class VoteRoute extends BaseRoute {
   }
 
   buildRouteInfoMetadata() {
-    return new RouteInfoMetadata({ allowsAnonymousAccess: true });
+    return new RouteInfoMetadata({ allowsAnonymousAccess: true, colorScheme: RouteColorScheme.Both });
   }
 
   async model(): Promise<ModelType> {

--- a/app/routes/vote/course-extension-ideas.js
+++ b/app/routes/vote/course-extension-ideas.js
@@ -1,9 +1,9 @@
 import BaseRoute from 'codecrafters-frontend/utils/base-route';
-import RouteInfoMetadata from 'codecrafters-frontend/utils/route-info-metadata';
+import RouteInfoMetadata, { RouteColorScheme } from 'codecrafters-frontend/utils/route-info-metadata';
 
 export default class CourseExtensionIdeasRoute extends BaseRoute {
   buildRouteInfoMetadata() {
-    return new RouteInfoMetadata({ allowsAnonymousAccess: true });
+    return new RouteInfoMetadata({ allowsAnonymousAccess: true, colorScheme: RouteColorScheme.Both });
   }
 
   setupController(controller, model) {


### PR DESCRIPTION
**Checklist**:

- [x] I've thoroughly self-reviewed my changes
- [x] I've added tests for my changes, unless they affect admin-only areas (or are otherwise not worth testing)
- [ ] I've verified any visual changes using Percy (add a commit with `[percy]` in the message to trigger)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Style**
  - Enhanced dark mode support and visual consistency across all vote page components, including cards, buttons, tabs, pills, and headers.
  - Improved color schemes for backgrounds, borders, text, icons, and status labels in dark mode for a more polished appearance.

- **Chores**
  - Updated internal configuration to ensure the vote pages support both light and dark color schemes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->