### PR TITLE
Fix rejected sub-comments with code blocks overflowing

### DIFF
--- a/app/components/comment-card/index.hbs
+++ b/app/components/comment-card/index.hbs
@@ -1,4 +1,4 @@
-<div data-test-comment-card class="w-full {{if @comment.parentComment '' 'bg-white dark:bg-gray-850 rounded'}}" ...attributes>
+<div data-test-comment-card class="w-full {{if @comment.parentComment 'min-w-0' 'bg-white dark:bg-gray-850 rounded'}}" ...attributes>
   {{#if this.isEditing}}
     <CommentForm
       @comment={{@comment}}


### PR DESCRIPTION
Follow-up to https://github.com/codecrafters-io/frontend/pull/2780
Related to https://github.com/codecrafters-io/frontend/issues/1591

### Brief

Additional tiny fix for rejected sub-comments with `code` blocks overflowing their allocated space.

### Before

<img width="588" alt="Знімок екрана 2025-05-04 о 11 40 20" src="https://github.com/user-attachments/assets/a3dac551-dab9-4558-921b-abbe5b31aa17" />

### After

<img width="549" alt="Знімок екрана 2025-05-04 о 11 40 48" src="https://github.com/user-attachments/assets/5fff82c8-6d76-4ddb-963c-ade4dec0ab4f" />

### Test links

https://app.codecrafters.io/courses/http-server/stages/at4
https://frontend-git-another-comment-width-fix.ccio.dev/courses/http-server/stages/at4

### Checklist

- [x] I've thoroughly self-reviewed my changes
- [x] I've added tests for my changes, unless they affect admin-only areas (or are otherwise not worth testing)
- [x] I've verified any visual changes using Percy (add a commit with `[percy]` in the message to trigger)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Updated the styling of comment cards to apply a new layout class for comments that have a parent comment. Comments without a parent retain their previous appearance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->