### PR TITLE
Cleanly change the border color for the code borders

### DIFF
--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -63,16 +63,22 @@ module.exports = {
       typography: {
         DEFAULT: {
           css: {
+            '--tw-prose-body': colors.slate[700],
             '--tw-prose-bold': colors.slate[800],
             '--tw-prose-code': colors.slate[700],
+            '--tw-prose-code-border': colors.gray[200],
+            '--tw-prose-headings': colors.slate[800],
             '--tw-prose-links': colors.sky[500],
             '--tw-prose-pre-bg': colors.slate[100],
             '--tw-prose-pre-code': colors.slate[700],
+            '--tw-prose-invert-body': colors.slate[300],
             '--tw-prose-invert-bold': colors.slate[200],
             '--tw-prose-invert-code': colors.slate[300],
+            '--tw-prose-invert-code-border': 'rgba(255,255,255,0.1)',
             '--tw-prose-invert-headings': colors.slate[200],
             '--tw-prose-invert-links': colors.sky[500],
             '--tw-prose-invert-pre-bg': colors.slate[900],
+            '--tw-prose-invert-pre-code': colors.slate[300],
             maxWidth: '90ch', // Default is 65ch
             a: {
               fontWeight: '600',
@@ -99,10 +105,13 @@ module.exports = {
               fontWeight: 'normal',
               padding: '0.2em 0.4em',
               borderWidth: '1px',
-              borderColor: colors.gray[200],
+              borderColor: 'var(--tw-prose-code-border)',
               borderRadius: '4px',
               whiteSpace: 'nowrap',
               backgroundColor: 'var(--tw-prose-pre-bg)',
+            },
+            '.dark code': {
+              borderColor: 'var(--tw-prose-invert-code-border)',
             },
             'code::before': { content: 'none' },
             'code::after': { content: 'none' },

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -63,22 +63,16 @@ module.exports = {
       typography: {
         DEFAULT: {
           css: {
-            '--tw-prose-body': colors.slate[700],
             '--tw-prose-bold': colors.slate[800],
             '--tw-prose-code': colors.slate[700],
-            '--tw-prose-code-border': colors.gray[200],
-            '--tw-prose-headings': colors.slate[800],
             '--tw-prose-links': colors.sky[500],
             '--tw-prose-pre-bg': colors.slate[100],
             '--tw-prose-pre-code': colors.slate[700],
-            '--tw-prose-invert-body': colors.slate[300],
             '--tw-prose-invert-bold': colors.slate[200],
             '--tw-prose-invert-code': colors.slate[300],
-            '--tw-prose-invert-code-border': 'rgba(255,255,255,0.1)',
             '--tw-prose-invert-headings': colors.slate[200],
             '--tw-prose-invert-links': colors.sky[500],
             '--tw-prose-invert-pre-bg': colors.slate[900],
-            '--tw-prose-invert-pre-code': colors.slate[300],
             maxWidth: '90ch', // Default is 65ch
             a: {
               fontWeight: '600',
@@ -105,13 +99,13 @@ module.exports = {
               fontWeight: 'normal',
               padding: '0.2em 0.4em',
               borderWidth: '1px',
-              borderColor: 'var(--tw-prose-code-border)',
+              borderColor: colors.gray[200],
               borderRadius: '4px',
               whiteSpace: 'nowrap',
               backgroundColor: 'var(--tw-prose-pre-bg)',
-            },
-            '.dark code': {
-              borderColor: 'var(--tw-prose-invert-code-border)',
+              '.dark &': {
+                borderColor: 'rgba(255,255,255,0.1)',
+              },
             },
             'code::before': { content: 'none' },
             'code::after': { content: 'none' },


### PR DESCRIPTION
New Version:
<img width="859" alt="Screenshot 2025-05-04 at 21 51 10" src="https://github.com/user-attachments/assets/ed56d1a4-4b22-4c79-a977-79cb76689d77" />

Old Version: 
<img width="895" alt="Screenshot 2025-05-04 at 21 52 09" src="https://github.com/user-attachments/assets/3ff7db24-165d-4e3f-809d-d0a073ef3849" />


**Checklist**:

- [x] I've thoroughly self-reviewed my changes
- [x] I've added tests for my changes, unless they affect admin-only areas (or are otherwise not worth testing)
- [x] I've verified any visual changes using Percy (add a commit with `[percy]` in the message to trigger)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Style**
  - Enhanced typography color customization for both default and dark modes.
  - Increased the maximum width of prose content for improved readability.
  - Improved code element styling and dark mode support for code borders.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->