### PR TITLE
Include trusted evaluations in course admin resource fetching

### DIFF
--- a/app/components/course-admin/code-example-page/evaluation-card/index.ts
+++ b/app/components/course-admin/code-example-page/evaluation-card/index.ts
@@ -63,12 +63,16 @@ export default class EvaluationCard extends Component<Signature> {
 
   @action
   handleExpandButtonClick() {
-    this.args.evaluation.fetchLogsFileContentsIfNeeded();
-    this.args.evaluation.fetchPromptFileContentsIfNeeded();
-
-    next(() => {
+    if (!this.args.evaluation.logsFileUrl) {
       this.isExpanded = true;
-    });
+    } else {
+      this.args.evaluation.fetchLogsFileContentsIfNeeded();
+      this.args.evaluation.fetchPromptFileContentsIfNeeded();
+ 
+      next(() => {
+        this.isExpanded = true;
+      });
+    }
   }
 }
 

--- a/app/routes/course-admin/code-example.ts
+++ b/app/routes/course-admin/code-example.ts
@@ -48,6 +48,9 @@ export default class CodeExampleRoute extends BaseRoute {
 
       // Trusted evaluations
       this.store.query('trusted-community-solution-evaluation', {
+        course_id: course.id, 
+        // TODO: we might open this page from the "wrong" course's admin page
+        // For now, later on we should add an index page for all code examples
         community_solution_id: params.code_example_id,
         include: ['community-solution', 'evaluator'].join(','),
       }),

--- a/app/routes/course-admin/code-example.ts
+++ b/app/routes/course-admin/code-example.ts
@@ -20,10 +20,16 @@ export default class CodeExampleRoute extends BaseRoute {
     // @ts-ignore
     const course = this.modelFor('course-admin').course;
 
+    // Include trusted evaluations for admin UI
+    const solutionIncludes = [
+      ...CommunityCourseStageSolutionModel.defaultIncludedResources,
+      'trusted-evaluations',
+    ];
+
     const [solution, comparisons, evaluations] = await Promise.all([
       // Solution
       this.store.findRecord('community-course-stage-solution', params.code_example_id, {
-        include: CommunityCourseStageSolutionModel.defaultIncludedResources.join(','),
+        include: solutionIncludes.join(','),
       }),
 
       // Comparisons

--- a/app/routes/course-admin/code-example.ts
+++ b/app/routes/course-admin/code-example.ts
@@ -20,13 +20,10 @@ export default class CodeExampleRoute extends BaseRoute {
     // @ts-ignore
     const course = this.modelFor('course-admin').course;
 
-    // Include trusted evaluations for admin UI
-    const solutionIncludes = [...CommunityCourseStageSolutionModel.defaultIncludedResources, 'trusted-evaluations'];
-
     const [solution, comparisons, evaluations, trustedEvaluations] = await Promise.all([
       // Solution
       this.store.findRecord('community-course-stage-solution', params.code_example_id, {
-        include: solutionIncludes.join(','),
+        include: CommunityCourseStageSolutionModel.defaultIncludedResources.join(','),
       }),
 
       // Comparisons


### PR DESCRIPTION
Enhance the course admin UI by including trusted evaluations in the resource fetching process.

**Checklist**:

- [ ] I've thoroughly self-reviewed my changes
- [ ] I've added tests for my changes, unless they affect admin-only areas (or are otherwise not worth testing)
- [ ] I've verified any visual changes using Percy (add a commit with `[percy]` in the message to trigger)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Expanded the information displayed for course stage solutions to include trusted evaluations.
- **Bug Fixes**
  - Improved evaluation expansion behavior by conditionally fetching file contents only when available, enhancing responsiveness.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->