### PR TITLE
Add `highlightedRanges` support to CodeMirror

### DIFF
--- a/app/components/code-mirror.hbs
+++ b/app/components/code-mirror.hbs
@@ -11,6 +11,7 @@
   {{did-update this.optionDidChange "editable" @editable}}
   {{did-update this.optionDidChange "foldGutter" @foldGutter}}
   {{did-update this.optionDidChange "highlightActiveLine" @highlightActiveLine}}
+  {{did-update this.optionDidChange "highlightedRanges" @highlightedRanges}}
   {{did-update this.optionDidChange "highlightNewlines" @highlightNewlines}}
   {{did-update this.optionDidChange "highlightSelectionMatches" @highlightSelectionMatches}}
   {{did-update this.optionDidChange "highlightSpecialChars" @highlightSpecialChars}}

--- a/app/components/code-mirror.ts
+++ b/app/components/code-mirror.ts
@@ -39,7 +39,8 @@ import { markdown } from '@codemirror/lang-markdown';
 import { highlightNewlines } from 'codecrafters-frontend/utils/code-mirror-highlight-newlines';
 import { collapseUnchangedGutter } from 'codecrafters-frontend/utils/code-mirror-collapse-unchanged-gutter';
 import { highlightActiveLineGutter as highlightActiveLineGutterRS } from 'codecrafters-frontend/utils/code-mirror-gutter-rs';
-import { highlightRanges, type LinesRange } from 'codecrafters-frontend/utils/code-mirror-highlight-ranges';
+import { highlightRanges } from 'codecrafters-frontend/utils/code-mirror-highlight-ranges';
+import type { LinesRange } from 'codecrafters-frontend/utils/code-mirror-documents';
 
 function generateHTMLElement(src: string): HTMLElement {
   const div = document.createElement('div');

--- a/app/components/code-mirror.ts
+++ b/app/components/code-mirror.ts
@@ -40,7 +40,6 @@ import { highlightNewlines } from 'codecrafters-frontend/utils/code-mirror-highl
 import { collapseUnchangedGutter } from 'codecrafters-frontend/utils/code-mirror-collapse-unchanged-gutter';
 import { highlightActiveLineGutter as highlightActiveLineGutterRS } from 'codecrafters-frontend/utils/code-mirror-gutter-rs';
 import { highlightRanges } from 'codecrafters-frontend/utils/code-mirror-highlight-ranges';
-import type { LineRange } from 'codecrafters-frontend/utils/code-mirror-documents';
 
 function generateHTMLElement(src: string): HTMLElement {
   const div = document.createElement('div');
@@ -53,6 +52,8 @@ enum FoldGutterIcon {
   Expanded = '<svg aria-hidden="true" focusable="false" role="img" viewBox="0 0 16 16" width="16" height="16" fill="currentColor" style="display: inline-block; user-select: none; vertical-align: text-bottom; overflow: visible; cursor: pointer;"><path d="M12.78 5.22a.749.749 0 0 1 0 1.06l-4.25 4.25a.749.749 0 0 1-1.06 0L3.22 6.28a.749.749 0 1 1 1.06-1.06L8 8.939l3.72-3.719a.749.749 0 0 1 1.06 0Z"></path></svg>',
   Collapsed = '<svg aria-hidden="true" focusable="false" role="img" viewBox="0 0 16 16" width="16" height="16" fill="currentColor" style="display: inline-block; user-select: none; vertical-align: text-bottom; overflow: visible; cursor: pointer;"><path d="M6.22 3.22a.75.75 0 0 1 1.06 0l4.25 4.25a.75.75 0 0 1 0 1.06l-4.25 4.25a.751.751 0 0 1-1.042-.018.751.751 0 0 1-.018-1.042L9.94 8 6.22 4.28a.75.75 0 0 1 0-1.06Z"></path></svg>',
 }
+
+export type LineRange = { startLine: number; endLine: number };
 
 type DocumentUpdateCallback = (newValue: string) => void;
 

--- a/app/components/code-mirror.ts
+++ b/app/components/code-mirror.ts
@@ -39,6 +39,7 @@ import { markdown } from '@codemirror/lang-markdown';
 import { highlightNewlines } from 'codecrafters-frontend/utils/code-mirror-highlight-newlines';
 import { collapseUnchangedGutter } from 'codecrafters-frontend/utils/code-mirror-collapse-unchanged-gutter';
 import { highlightActiveLineGutter as highlightActiveLineGutterRS } from 'codecrafters-frontend/utils/code-mirror-gutter-rs';
+import type { LinesRange } from 'codecrafters-frontend/utils/code-mirror-documents';
 
 function generateHTMLElement(src: string): HTMLElement {
   const div = document.createElement('div');
@@ -54,7 +55,7 @@ enum FoldGutterIcon {
 
 type DocumentUpdateCallback = (newValue: string) => void;
 
-type Argument = boolean | string | number | undefined | Extension | DocumentUpdateCallback;
+type Argument = boolean | string | number | undefined | Extension | DocumentUpdateCallback | LinesRange[];
 
 type OptionHandler = (args: Signature['Args']['Named']) => Extension[] | Promise<Extension[]>;
 
@@ -69,6 +70,7 @@ const OPTION_HANDLERS: { [key: string]: OptionHandler } = {
   editable: ({ editable }) => [EditorView.editable.of(!!editable)],
   highlightActiveLine: ({ highlightActiveLine: enabled }) =>
     enabled ? [highlightActiveLine(), highlightActiveLineGutter(), highlightActiveLineGutterRS()] : [],
+  highlightedRanges: ({ highlightedRanges }) => (highlightedRanges ? [] : []),
   highlightNewlines: ({ highlightNewlines: enabled }) => (enabled ? [highlightNewlines()] : []),
   highlightSelectionMatches: ({ highlightSelectionMatches: enabled }) => (enabled ? [highlightSelectionMatches()] : []),
   highlightSpecialChars: ({ highlightSpecialChars: enabled }) => (enabled ? [highlightSpecialChars()] : []),
@@ -240,6 +242,10 @@ export interface Signature {
        * Enable inline highlighting of changes in the diff
        */
       highlightChanges?: boolean;
+      /**
+       * Enable highlighting of specified line ranges
+       */
+      highlightedRanges?: LinesRange[];
       /**
        * Enable highlighting of new line symbols
        */

--- a/app/components/code-mirror.ts
+++ b/app/components/code-mirror.ts
@@ -39,8 +39,7 @@ import { markdown } from '@codemirror/lang-markdown';
 import { highlightNewlines } from 'codecrafters-frontend/utils/code-mirror-highlight-newlines';
 import { collapseUnchangedGutter } from 'codecrafters-frontend/utils/code-mirror-collapse-unchanged-gutter';
 import { highlightActiveLineGutter as highlightActiveLineGutterRS } from 'codecrafters-frontend/utils/code-mirror-gutter-rs';
-import type { LinesRange } from 'codecrafters-frontend/utils/code-mirror-documents';
-import { highlightRanges } from 'codecrafters-frontend/utils/code-mirror-highlight-ranges';
+import { highlightRanges, type LinesRange } from 'codecrafters-frontend/utils/code-mirror-highlight-ranges';
 
 function generateHTMLElement(src: string): HTMLElement {
   const div = document.createElement('div');

--- a/app/components/code-mirror.ts
+++ b/app/components/code-mirror.ts
@@ -40,7 +40,7 @@ import { highlightNewlines } from 'codecrafters-frontend/utils/code-mirror-highl
 import { collapseUnchangedGutter } from 'codecrafters-frontend/utils/code-mirror-collapse-unchanged-gutter';
 import { highlightActiveLineGutter as highlightActiveLineGutterRS } from 'codecrafters-frontend/utils/code-mirror-gutter-rs';
 import { highlightRanges } from 'codecrafters-frontend/utils/code-mirror-highlight-ranges';
-import type { LinesRange } from 'codecrafters-frontend/utils/code-mirror-documents';
+import type { LineRange } from 'codecrafters-frontend/utils/code-mirror-documents';
 
 function generateHTMLElement(src: string): HTMLElement {
   const div = document.createElement('div');
@@ -56,7 +56,7 @@ enum FoldGutterIcon {
 
 type DocumentUpdateCallback = (newValue: string) => void;
 
-type Argument = boolean | string | number | undefined | Extension | DocumentUpdateCallback | LinesRange[];
+type Argument = boolean | string | number | undefined | Extension | DocumentUpdateCallback | LineRange[];
 
 type OptionHandler = (args: Signature['Args']['Named']) => Extension[] | Promise<Extension[]>;
 
@@ -249,7 +249,7 @@ export interface Signature {
       /**
        * Enable highlighting of specified line ranges
        */
-      highlightedRanges?: LinesRange[];
+      highlightedRanges?: LineRange[];
       /**
        * Enable highlighting of new line symbols
        */

--- a/app/components/code-mirror.ts
+++ b/app/components/code-mirror.ts
@@ -40,6 +40,7 @@ import { highlightNewlines } from 'codecrafters-frontend/utils/code-mirror-highl
 import { collapseUnchangedGutter } from 'codecrafters-frontend/utils/code-mirror-collapse-unchanged-gutter';
 import { highlightActiveLineGutter as highlightActiveLineGutterRS } from 'codecrafters-frontend/utils/code-mirror-gutter-rs';
 import type { LinesRange } from 'codecrafters-frontend/utils/code-mirror-documents';
+import { highlightRanges } from 'codecrafters-frontend/utils/code-mirror-highlight-ranges';
 
 function generateHTMLElement(src: string): HTMLElement {
   const div = document.createElement('div');
@@ -59,6 +60,9 @@ type Argument = boolean | string | number | undefined | Extension | DocumentUpda
 
 type OptionHandler = (args: Signature['Args']['Named']) => Extension[] | Promise<Extension[]>;
 
+/**
+ * Order of keys in this object matters, do not sort alphabetically
+ */
 const OPTION_HANDLERS: { [key: string]: OptionHandler } = {
   allowMultipleSelections: ({ allowMultipleSelections }) => [EditorState.allowMultipleSelections.of(!!allowMultipleSelections)],
   autocompletion: ({ autocompletion: enabled }) => (enabled ? [autocompletion(), keymap.of(completionKeymap)] : []),
@@ -70,7 +74,7 @@ const OPTION_HANDLERS: { [key: string]: OptionHandler } = {
   editable: ({ editable }) => [EditorView.editable.of(!!editable)],
   highlightActiveLine: ({ highlightActiveLine: enabled }) =>
     enabled ? [highlightActiveLine(), highlightActiveLineGutter(), highlightActiveLineGutterRS()] : [],
-  highlightedRanges: ({ highlightedRanges }) => (highlightedRanges ? [] : []),
+  highlightedRanges: ({ highlightedRanges }) => (highlightedRanges ? highlightRanges(highlightedRanges) : []),
   highlightNewlines: ({ highlightNewlines: enabled }) => (enabled ? [highlightNewlines()] : []),
   highlightSelectionMatches: ({ highlightSelectionMatches: enabled }) => (enabled ? [highlightSelectionMatches()] : []),
   highlightSpecialChars: ({ highlightSpecialChars: enabled }) => (enabled ? [highlightSpecialChars()] : []),

--- a/app/components/file-contents-card.hbs
+++ b/app/components/file-contents-card.hbs
@@ -53,6 +53,7 @@
       @editable={{false}}
       @readOnly={{true}}
       @highlightActiveLine={{false}}
+      @highlightedRanges={{@highlightedRanges}}
       @highlightSelectionMatches={{true}}
       @highlightSpecialChars={{true}}
       @highlightTrailingWhitespace={{true}}

--- a/app/components/file-contents-card.ts
+++ b/app/components/file-contents-card.ts
@@ -3,7 +3,7 @@ import { service } from '@ember/service';
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 import type DarkModeService from 'codecrafters-frontend/services/dark-mode';
-import type { LinesRange } from 'codecrafters-frontend/utils/code-mirror-documents';
+import type { LineRange } from 'codecrafters-frontend/utils/code-mirror-documents';
 import { codeCraftersDark, codeCraftersLight } from 'codecrafters-frontend/utils/code-mirror-themes';
 
 interface Signature {
@@ -38,7 +38,7 @@ interface Signature {
     /**
      * Enable highlighting of specified line ranges
      */
-    highlightedRanges?: LinesRange[];
+    highlightedRanges?: LineRange[];
     /**
      * Scroll the component into view after it's collapsed
      */

--- a/app/components/file-contents-card.ts
+++ b/app/components/file-contents-card.ts
@@ -3,6 +3,7 @@ import { service } from '@ember/service';
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 import type DarkModeService from 'codecrafters-frontend/services/dark-mode';
+import type { LinesRange } from 'codecrafters-frontend/utils/code-mirror-highlight-ranges';
 import { codeCraftersDark, codeCraftersLight } from 'codecrafters-frontend/utils/code-mirror-themes';
 
 interface Signature {
@@ -34,6 +35,10 @@ interface Signature {
      * Show a tooltip in the header when collapsible & collapsed
      */
     headerTooltipText?: string;
+    /**
+     * Enable highlighting of specified line ranges
+     */
+    highlightedRanges?: LinesRange[];
     /**
      * Scroll the component into view after it's collapsed
      */

--- a/app/components/file-contents-card.ts
+++ b/app/components/file-contents-card.ts
@@ -3,7 +3,7 @@ import { service } from '@ember/service';
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 import type DarkModeService from 'codecrafters-frontend/services/dark-mode';
-import type { LinesRange } from 'codecrafters-frontend/utils/code-mirror-highlight-ranges';
+import type { LinesRange } from 'codecrafters-frontend/utils/code-mirror-documents';
 import { codeCraftersDark, codeCraftersLight } from 'codecrafters-frontend/utils/code-mirror-themes';
 
 interface Signature {

--- a/app/components/file-contents-card.ts
+++ b/app/components/file-contents-card.ts
@@ -3,7 +3,7 @@ import { service } from '@ember/service';
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 import type DarkModeService from 'codecrafters-frontend/services/dark-mode';
-import type { LineRange } from 'codecrafters-frontend/utils/code-mirror-documents';
+import type { LineRange } from 'codecrafters-frontend/components/code-mirror';
 import { codeCraftersDark, codeCraftersLight } from 'codecrafters-frontend/utils/code-mirror-themes';
 
 interface Signature {

--- a/app/components/file-diff-card.hbs
+++ b/app/components/file-diff-card.hbs
@@ -17,6 +17,7 @@
         @drawSelection={{true}}
         @rectangularSelection={{true}}
         @readOnly={{true}}
+        @highlightedRanges={{@highlightedRanges}}
         @highlightSelectionMatches={{true}}
         @highlightSpecialChars={{true}}
         @theme={{this.codeMirrorTheme}}

--- a/app/components/file-diff-card.ts
+++ b/app/components/file-diff-card.ts
@@ -1,6 +1,7 @@
 import { service } from '@ember/service';
 import Component from '@glimmer/component';
 import type DarkModeService from 'codecrafters-frontend/services/dark-mode';
+import type { LinesRange } from 'codecrafters-frontend/utils/code-mirror-highlight-ranges';
 import { codeCraftersDark, codeCraftersLight } from 'codecrafters-frontend/utils/code-mirror-themes';
 
 interface Signature {
@@ -20,6 +21,10 @@ interface Signature {
      * Always render CodeMirror/SyntaxHighlightedDiff using Dark Theme
      */
     forceDarkTheme?: boolean;
+    /**
+     * Enable highlighting of specified line ranges
+     */
+    highlightedRanges?: LinesRange[];
     /**
      * Override language auto-detected from `filename` and set it manually
      */

--- a/app/components/file-diff-card.ts
+++ b/app/components/file-diff-card.ts
@@ -1,7 +1,7 @@
 import { service } from '@ember/service';
 import Component from '@glimmer/component';
 import type DarkModeService from 'codecrafters-frontend/services/dark-mode';
-import type { LinesRange } from 'codecrafters-frontend/utils/code-mirror-highlight-ranges';
+import type { LinesRange } from 'codecrafters-frontend/utils/code-mirror-documents';
 import { codeCraftersDark, codeCraftersLight } from 'codecrafters-frontend/utils/code-mirror-themes';
 
 interface Signature {

--- a/app/components/file-diff-card.ts
+++ b/app/components/file-diff-card.ts
@@ -1,7 +1,7 @@
 import { service } from '@ember/service';
 import Component from '@glimmer/component';
 import type DarkModeService from 'codecrafters-frontend/services/dark-mode';
-import type { LineRange } from 'codecrafters-frontend/utils/code-mirror-documents';
+import type { LineRange } from 'codecrafters-frontend/components/code-mirror';
 import { codeCraftersDark, codeCraftersLight } from 'codecrafters-frontend/utils/code-mirror-themes';
 
 interface Signature {

--- a/app/components/file-diff-card.ts
+++ b/app/components/file-diff-card.ts
@@ -1,7 +1,7 @@
 import { service } from '@ember/service';
 import Component from '@glimmer/component';
 import type DarkModeService from 'codecrafters-frontend/services/dark-mode';
-import type { LinesRange } from 'codecrafters-frontend/utils/code-mirror-documents';
+import type { LineRange } from 'codecrafters-frontend/utils/code-mirror-documents';
 import { codeCraftersDark, codeCraftersLight } from 'codecrafters-frontend/utils/code-mirror-themes';
 
 interface Signature {
@@ -24,7 +24,7 @@ interface Signature {
     /**
      * Enable highlighting of specified line ranges
      */
-    highlightedRanges?: LinesRange[];
+    highlightedRanges?: LineRange[];
     /**
      * Override language auto-detected from `filename` and set it manually
      */

--- a/app/controllers/demo/code-mirror.ts
+++ b/app/controllers/demo/code-mirror.ts
@@ -44,6 +44,7 @@ const OPTION_DEFAULTS = {
   foldGutter: true,
   highlightActiveLine: true,
   highlightChanges: false,
+  highlightedRanges: false,
   highlightNewlines: false,
   highlightSelectionMatches: true,
   highlightSpecialChars: true,
@@ -100,6 +101,7 @@ export default class DemoCodeMirrorController extends Controller {
     'foldGutter',
     'highlightActiveLine',
     'highlightChanges',
+    'highlightedRanges',
     'highlightNewlines',
     'highlightSelectionMatches',
     'highlightSpecialChars',
@@ -152,6 +154,7 @@ export default class DemoCodeMirrorController extends Controller {
   @tracked foldGutter = OPTION_DEFAULTS.foldGutter;
   @tracked highlightActiveLine = OPTION_DEFAULTS.highlightActiveLine;
   @tracked highlightChanges = OPTION_DEFAULTS.highlightChanges;
+  @tracked highlightedRanges = OPTION_DEFAULTS.highlightedRanges;
   @tracked highlightNewlines = OPTION_DEFAULTS.highlightNewlines;
   @tracked highlightSelectionMatches = OPTION_DEFAULTS.highlightSelectionMatches;
   @tracked highlightSpecialChars = OPTION_DEFAULTS.highlightSpecialChars;

--- a/app/controllers/demo/file-contents-card.ts
+++ b/app/controllers/demo/file-contents-card.ts
@@ -5,6 +5,7 @@ import EXAMPLE_DOCUMENTS, { ExampleDocument } from 'codecrafters-frontend/utils/
 
 const OPTION_DEFAULTS = {
   headerTooltipText: false,
+  highlightedRanges: false,
   isCollapsed: false,
   isCollapsible: false,
   scrollIntoViewOnCollapse: true,
@@ -16,6 +17,7 @@ export default class DemoFileContentsCardController extends Controller {
 
   @tracked documents: ExampleDocument[] = EXAMPLE_DOCUMENTS;
   @tracked headerTooltipText: boolean = OPTION_DEFAULTS.headerTooltipText;
+  @tracked highlightedRanges: boolean = OPTION_DEFAULTS.highlightedRanges;
   @tracked isCollapsed: boolean = OPTION_DEFAULTS.isCollapsed;
   @tracked isCollapsible: boolean = OPTION_DEFAULTS.isCollapsible;
   @tracked scrollIntoViewOnCollapse: boolean = OPTION_DEFAULTS.scrollIntoViewOnCollapse;

--- a/app/controllers/demo/file-diff-card.ts
+++ b/app/controllers/demo/file-diff-card.ts
@@ -5,6 +5,7 @@ import EXAMPLE_DOCUMENTS, { DiffBasedExampleDocument } from 'codecrafters-fronte
 
 const OPTION_DEFAULTS = {
   forceDarkTheme: false,
+  highlightedRanges: false,
   selectedDocumentIndex: 1,
   useCodeMirror: true,
 };
@@ -13,6 +14,7 @@ export default class DemoFileDiffCardController extends Controller {
   @tracked documents: DiffBasedExampleDocument[] = EXAMPLE_DOCUMENTS;
 
   @tracked forceDarkTheme: boolean = OPTION_DEFAULTS.forceDarkTheme;
+  @tracked highlightedRanges: boolean = OPTION_DEFAULTS.highlightedRanges;
   @tracked selectedDocumentIndex: number = OPTION_DEFAULTS.selectedDocumentIndex;
   @tracked useCodeMirror: boolean = OPTION_DEFAULTS.useCodeMirror;
 

--- a/app/routes/demo/code-mirror.ts
+++ b/app/routes/demo/code-mirror.ts
@@ -15,6 +15,7 @@ const QUERY_PARAMS = [
   'filename',
   'foldGutter',
   'highlightActiveLine',
+  'highlightedRanges',
   'highlightChanges',
   'highlightNewlines',
   'highlightSelectionMatches',

--- a/app/routes/demo/file-contents-card.ts
+++ b/app/routes/demo/file-contents-card.ts
@@ -1,6 +1,14 @@
 import Route from '@ember/routing/route';
 
-const QUERY_PARAMS = ['foldGutter', 'headerTooltipText', 'isCollapsed', 'isCollapsible', 'scrollIntoViewOnCollapse', 'selectedDocumentIndex'];
+const QUERY_PARAMS = [
+  'foldGutter',
+  'headerTooltipText',
+  'highlightedRanges',
+  'isCollapsed',
+  'isCollapsible',
+  'scrollIntoViewOnCollapse',
+  'selectedDocumentIndex',
+];
 
 interface QueryParamOptions {
   [key: string]: {

--- a/app/routes/demo/file-diff-card.ts
+++ b/app/routes/demo/file-diff-card.ts
@@ -1,6 +1,6 @@
 import Route from '@ember/routing/route';
 
-const QUERY_PARAMS = ['forceDarkTheme', 'selectedDocumentIndex', 'useCodeMirror'];
+const QUERY_PARAMS = ['forceDarkTheme', 'highlightedRanges', 'selectedDocumentIndex', 'useCodeMirror'];
 
 interface QueryParamOptions {
   [key: string]: {

--- a/app/templates/demo/code-mirror.hbs
+++ b/app/templates/demo/code-mirror.hbs
@@ -99,6 +99,10 @@
         <Input @type="checkbox" @checked={{this.filename}} disabled={{eq this.language true}} />
         <span class="ml-2 {{if this.language 'text-gray-300'}}">filename</span>
       </label>
+      <label class="{{labelClasses}}" title="Enable highlighting of specified line ranges">
+        <Input @type="checkbox" @checked={{this.highlightedRanges}} />
+        <span class="ml-2">highlightedRanges</span>
+      </label>
     </codemirror-options-left>
     <codemirror-options-right class="flex flex-wrap">
       <label class="{{labelClasses}}" title="Placeholder text to show when document is empty or not passed">
@@ -337,6 +341,7 @@
   @foldGutter={{this.foldGutter}}
   @highlightActiveLine={{this.highlightActiveLine}}
   @highlightChanges={{this.highlightChanges}}
+  @highlightedRanges={{if this.highlightedRanges this.selectedDocument.highlightedRanges}}
   @highlightNewlines={{this.highlightNewlines}}
   @highlightSelectionMatches={{this.highlightSelectionMatches}}
   @highlightSpecialChars={{this.highlightSpecialChars}}

--- a/app/templates/demo/code-mirror.hbs
+++ b/app/templates/demo/code-mirror.hbs
@@ -108,7 +108,7 @@
     </codemirror-options-right>
   </codemirror-options>
 
-  <codemirror-options class="{{groupClasses}} border-dotted">
+  <codemirror-options class="{{groupClasses}} border-dotted flex-nowrap">
     <codemirror-options-left class="flex flex-grow flex-wrap">
       <label class="{{labelClasses}}" title="Enable unified diff editor by passing the original document">
         <Input @type="checkbox" @checked={{this.originalDocument}} />
@@ -122,8 +122,12 @@
         <Input @type="checkbox" @checked={{this.collapseUnchanged}} disabled={{not this.originalDocument}} />
         <span class="ml-2 {{unless this.originalDocument 'text-gray-300'}}">collapseUnchanged</span>
       </label>
+      <label class="{{labelClasses}}" title="Display chunks with only limited inline changes inline in the code">
+        <Input @type="checkbox" @checked={{this.allowInlineDiffs}} disabled={{not this.originalDocument}} />
+        <span class="ml-2 {{unless this.originalDocument 'text-gray-300'}}">allowInlineDiffs</span>
+      </label>
     </codemirror-options-left>
-    <codemirror-options-right class="flex flex-wrap">
+    <codemirror-options-right class="flex flex-wrap justify-end h-[20px]">
       <label class="{{labelClasses}}" title="Number of lines to leave visible after/before a change before collapsing unchanged lines">
         {{#let (not (and this.originalDocument this.collapseUnchanged)) as |isDisabled|}}
           <Input @type="checkbox" @checked={{this.unchangedMargin}} disabled={{isDisabled}} />
@@ -271,10 +275,6 @@
     <label class="{{labelClasses}}" title="Enable syntax highlighting in the deleted chunks of the diff">
       <Input @type="checkbox" @checked={{this.syntaxHighlightDeletions}} disabled={{or (not this.originalDocument) (not this.syntaxHighlighting)}} />
       <span class="ml-2 {{unless (and this.originalDocument this.syntaxHighlighting) 'text-gray-300'}}">syntaxHighlightDeletions</span>
-    </label>
-    <label class="{{labelClasses}}" title="Display chunks with only limited inline changes inline in the code">
-      <Input @type="checkbox" @checked={{this.allowInlineDiffs}} disabled={{not this.originalDocument}} />
-      <span class="ml-2 {{unless this.originalDocument 'text-gray-300'}}">allowInlineDiffs</span>
     </label>
   </codemirror-options>
 

--- a/app/templates/demo/file-contents-card.hbs
+++ b/app/templates/demo/file-contents-card.hbs
@@ -29,6 +29,10 @@
         <Input @type="checkbox" @checked={{this.headerTooltipText}} disabled={{not this.isCollapsible}} />
         <span class="ml-2 {{unless this.isCollapsible 'text-gray-300'}}">headerTooltipText</span>
       </label>
+      <label class="{{labelClasses}}" title="Enable highlighting of specified line ranges">
+        <Input @type="checkbox" @checked={{this.highlightedRanges}} />
+        <span class="ml-2">highlightedRanges</span>
+      </label>
     </component-options-right>
   </component-options>
 {{/let}}
@@ -41,6 +45,7 @@
   @isCollapsible={{this.isCollapsible}}
   @scrollIntoViewOnCollapse={{this.scrollIntoViewOnCollapse}}
   @headerTooltipText={{if this.headerTooltipText "Example tooltip message"}}
+  @highlightedRanges={{if this.highlightedRanges this.selectedDocument.highlightedRanges}}
   @onExpand={{fn (mut this.isCollapsed) false}}
   @onCollapse={{fn (mut this.isCollapsed) true}}
   class="mt-4"

--- a/app/templates/demo/file-diff-card.hbs
+++ b/app/templates/demo/file-diff-card.hbs
@@ -26,6 +26,10 @@ py-2"
         <Input @type="checkbox" @checked={{this.forceDarkTheme}} />
         <span class="ml-2">forceDarkTheme</span>
       </label>
+      <label class="{{labelClasses}}" title="Enable highlighting of specified line ranges">
+        <Input @type="checkbox" @checked={{this.highlightedRanges}} />
+        <span class="ml-2">highlightedRanges</span>
+      </label>
     </component-options-right>
   </component-options>
 {{/let}}
@@ -36,6 +40,7 @@ py-2"
   @filename={{this.selectedDocument.filename}}
   @language={{this.selectedDocument.language}}
   @forceDarkTheme={{this.forceDarkTheme}}
+  @highlightedRanges={{if this.highlightedRanges this.selectedDocument.highlightedRanges}}
   class="mt-4 {{if this.forceDarkTheme 'dark'}}"
 />
 

--- a/app/utils/code-mirror-documents.ts
+++ b/app/utils/code-mirror-documents.ts
@@ -1,7 +1,6 @@
 import { tracked } from '@glimmer/tracking';
+import type { LineRange } from 'codecrafters-frontend/components/code-mirror';
 import parseDiffAsDocument from 'codecrafters-frontend/utils/parse-diff-as-document';
-
-export type LineRange = { startLine: number; endLine: number };
 
 export class ExampleDocument {
   @tracked document: string = '';

--- a/app/utils/code-mirror-documents.ts
+++ b/app/utils/code-mirror-documents.ts
@@ -1,6 +1,7 @@
 import { tracked } from '@glimmer/tracking';
 import parseDiffAsDocument from 'codecrafters-frontend/utils/parse-diff-as-document';
-import { type LinesRange } from 'codecrafters-frontend/utils/code-mirror-highlight-ranges';
+
+export type LinesRange = { startLine: number; endLine: number };
 
 export class ExampleDocument {
   @tracked document: string = '';

--- a/app/utils/code-mirror-documents.ts
+++ b/app/utils/code-mirror-documents.ts
@@ -1,7 +1,6 @@
 import { tracked } from '@glimmer/tracking';
 import parseDiffAsDocument from 'codecrafters-frontend/utils/parse-diff-as-document';
-
-export type LinesRange = { startLine: number; endLine: number };
+import { type LinesRange } from 'codecrafters-frontend/utils/code-mirror-highlight-ranges';
 
 export class ExampleDocument {
   @tracked document: string = '';

--- a/app/utils/code-mirror-documents.ts
+++ b/app/utils/code-mirror-documents.ts
@@ -1,27 +1,33 @@
 import { tracked } from '@glimmer/tracking';
 import parseDiffAsDocument from 'codecrafters-frontend/utils/parse-diff-as-document';
 
+export type LinesRange = { startLine: number; endLine: number };
+
 export class ExampleDocument {
   @tracked document: string = '';
   @tracked originalDocument: string;
   @tracked filename: string;
   @tracked language: string;
+  @tracked highlightedRanges: LinesRange[];
 
   constructor({
     document = '',
     originalDocument,
     filename,
     language,
+    highlightedRanges = [],
   }: {
     document?: string;
     originalDocument?: string;
     filename: string;
     language: string;
+    highlightedRanges?: LinesRange[];
   }) {
     this.document = document;
     this.originalDocument = originalDocument || document;
     this.filename = filename;
     this.language = language;
+    this.highlightedRanges = highlightedRanges;
   }
 
   static createEmpty() {
@@ -32,7 +38,17 @@ export class ExampleDocument {
 export class DiffBasedExampleDocument extends ExampleDocument {
   @tracked diff?: string;
 
-  constructor({ diff, filename, language }: { diff?: string; filename: string; language: string }) {
+  constructor({
+    diff,
+    filename,
+    language,
+    highlightedRanges = [],
+  }: {
+    diff?: string;
+    filename: string;
+    language: string;
+    highlightedRanges?: LinesRange[];
+  }) {
     const { current: document, original: originalDocument } = parseDiffAsDocument(diff);
 
     super({
@@ -40,6 +56,7 @@ export class DiffBasedExampleDocument extends ExampleDocument {
       originalDocument,
       filename,
       language,
+      highlightedRanges,
     });
 
     this.diff = diff;
@@ -96,6 +113,11 @@ export default [
     ].join('\n'),
     filename: 'test.txt',
     language: 'text',
+    highlightedRanges: [
+      { startLine: 2, endLine: 4 },
+      { startLine: 7, endLine: 10 },
+      { startLine: 18, endLine: 20 },
+    ],
   }),
 
   new DiffBasedExampleDocument({
@@ -142,6 +164,13 @@ export default [
     ].join('\n'),
     filename: 'test.js',
     language: 'javascript',
+    highlightedRanges: [
+      { startLine: 5, endLine: 5 },
+      { startLine: 8, endLine: 12 },
+      { startLine: 16, endLine: 17 },
+      { startLine: 21, endLine: 22 },
+      { startLine: 26, endLine: 27 },
+    ],
   }),
 
   new DiffBasedExampleDocument({
@@ -156,12 +185,16 @@ export default [
       '+\t\t\t&nbsp;',
       '+\t\t</span>',
       '+\t\tAn example HTML document',
-      '+\t\tWith an invisible  ——≫ ‎ ≪——  characer',
+      '+\t\tWith an invisible  ——≫ ‎ ≪——  character',
       '+\t</body>',
       '+</html>',
     ].join('\n'),
     filename: 'test.html',
     language: 'html',
+    highlightedRanges: [
+      { startLine: 7, endLine: 7 },
+      { startLine: 9, endLine: 9 },
+    ],
   }),
 
   new DiffBasedExampleDocument({
@@ -239,6 +272,10 @@ export default [
     ].join('\n'),
     filename: 'test.sql',
     language: 'sql',
+    highlightedRanges: [
+      { startLine: 14, endLine: 20 },
+      { startLine: 35, endLine: 39 },
+    ],
   }),
 
   new DiffBasedExampleDocument({
@@ -268,6 +305,10 @@ export default [
     ].join('\n'),
     filename: 'test.md',
     language: 'markdown',
+    highlightedRanges: [
+      { startLine: 12, endLine: 12 },
+      { startLine: 18, endLine: 18 },
+    ],
   }),
 
   new DiffBasedExampleDocument({
@@ -300,5 +341,9 @@ export default [
     ].join('\n'),
     filename: 'Dockerfile',
     language: 'dockerfile',
+    highlightedRanges: [
+      { startLine: 7, endLine: 7 },
+      { startLine: 17, endLine: 18 },
+    ],
   }),
 ];

--- a/app/utils/code-mirror-documents.ts
+++ b/app/utils/code-mirror-documents.ts
@@ -1,14 +1,14 @@
 import { tracked } from '@glimmer/tracking';
 import parseDiffAsDocument from 'codecrafters-frontend/utils/parse-diff-as-document';
 
-export type LinesRange = { startLine: number; endLine: number };
+export type LineRange = { startLine: number; endLine: number };
 
 export class ExampleDocument {
   @tracked document: string = '';
   @tracked originalDocument: string;
   @tracked filename: string;
   @tracked language: string;
-  @tracked highlightedRanges: LinesRange[];
+  @tracked highlightedRanges: LineRange[];
 
   constructor({
     document = '',
@@ -21,7 +21,7 @@ export class ExampleDocument {
     originalDocument?: string;
     filename: string;
     language: string;
-    highlightedRanges?: LinesRange[];
+    highlightedRanges?: LineRange[];
   }) {
     this.document = document;
     this.originalDocument = originalDocument || document;
@@ -47,7 +47,7 @@ export class DiffBasedExampleDocument extends ExampleDocument {
     diff?: string;
     filename: string;
     language: string;
-    highlightedRanges?: LinesRange[];
+    highlightedRanges?: LineRange[];
   }) {
     const { current: document, original: originalDocument } = parseDiffAsDocument(diff);
 

--- a/app/utils/code-mirror-highlight-ranges.ts
+++ b/app/utils/code-mirror-highlight-ranges.ts
@@ -1,6 +1,7 @@
 import { Decoration, EditorView, gutter, gutterLineClass, GutterMarker, ViewPlugin, type DecorationSet, type ViewUpdate } from '@codemirror/view';
 import { RangeSetBuilder, Facet, RangeSet } from '@codemirror/state';
-import type { LinesRange } from './code-mirror-documents';
+
+export type LinesRange = { startLine: number; endLine: number };
 
 const highlightedRangesFacet = Facet.define<LinesRange[]>({
   static: true,

--- a/app/utils/code-mirror-highlight-ranges.ts
+++ b/app/utils/code-mirror-highlight-ranges.ts
@@ -60,19 +60,19 @@ const highlightedLinesGutterHighlighter = gutterLineClass.compute(['doc', highli
   const highlightedRanges = state.facet(highlightedRangesFacet)[0] || [];
   const marks = [];
 
-  for (const range of highlightedRanges) {
-    for (let lineNumber = range.startLine; lineNumber <= range.endLine; lineNumber++) {
-      if (lineNumber <= state.doc.lines) {
-        const linePos = state.doc.line(lineNumber).from;
-        marks.push(new HighlightedLineGutterMarker().range(linePos));
+  try {
+    for (const range of highlightedRanges) {
+      for (let lineNumber = range.startLine; lineNumber <= range.endLine; lineNumber++) {
+        if (lineNumber <= state.doc.lines) {
+          const linePos = state.doc.line(lineNumber).from;
+          marks.push(new HighlightedLineGutterMarker().range(linePos));
+        }
       }
     }
-  }
 
-  try {
     return RangeSet.of(marks);
   } catch (e) {
-    console.error(`Failed to highlight lines in the gutter: ${e instanceof Error ? e.message : e}`);
+    console.error(`Failed to highlight line ranges in the gutter: ${e instanceof Error ? e.message : e}`);
 
     return RangeSet.of([]);
   }

--- a/app/utils/code-mirror-highlight-ranges.ts
+++ b/app/utils/code-mirror-highlight-ranges.ts
@@ -1,8 +1,8 @@
 import { Decoration, EditorView, gutter, gutterLineClass, GutterMarker, ViewPlugin, type DecorationSet, type ViewUpdate } from '@codemirror/view';
 import { RangeSetBuilder, Facet, RangeSet } from '@codemirror/state';
-import type { LinesRange } from 'codecrafters-frontend/utils/code-mirror-documents';
+import type { LineRange } from 'codecrafters-frontend/utils/code-mirror-documents';
 
-const highlightedRangesFacet = Facet.define<LinesRange[]>({
+const highlightedRangesFacet = Facet.define<LineRange[]>({
   static: true,
 });
 
@@ -164,7 +164,7 @@ const baseTheme = EditorView.baseTheme({
   },
 });
 
-export function highlightRanges(highlightedRanges: LinesRange[] = []) {
+export function highlightRanges(highlightedRanges: LineRange[] = []) {
   return [
     baseTheme,
     highlightedRangesFacet.of(highlightedRanges),

--- a/app/utils/code-mirror-highlight-ranges.ts
+++ b/app/utils/code-mirror-highlight-ranges.ts
@@ -1,0 +1,175 @@
+import { Decoration, EditorView, gutter, gutterLineClass, GutterMarker, ViewPlugin, type DecorationSet, type ViewUpdate } from '@codemirror/view';
+import { RangeSetBuilder, Facet, RangeSet } from '@codemirror/state';
+import type { LinesRange } from './code-mirror-documents';
+
+const highlightedRangesFacet = Facet.define<LinesRange[]>({
+  static: true,
+});
+
+const highlightedLineDecoration = Decoration.line({
+  attributes: { class: 'cm-highlightedLine' },
+});
+
+function highlightedRangesDecoration(view: EditorView) {
+  const highlightedRanges = view.state.facet(highlightedRangesFacet)[0] || [];
+  const builder = new RangeSetBuilder<Decoration>();
+
+  for (const { from, to } of view.visibleRanges) {
+    for (let pos = from; pos <= to; ) {
+      const line = view.state.doc.lineAt(pos);
+
+      if (highlightedRanges.find((range) => line.number >= range.startLine && line.number <= range.endLine)) {
+        builder.add(line.from, line.from, highlightedLineDecoration);
+      }
+
+      pos = line.to + 1;
+    }
+  }
+
+  return builder.finish();
+}
+
+const highlightRangesViewPlugin = ViewPlugin.fromClass(
+  class {
+    decorations: DecorationSet;
+
+    constructor(view: EditorView) {
+      this.decorations = highlightedRangesDecoration(view);
+    }
+
+    update(update: ViewUpdate) {
+      this.decorations = highlightedRangesDecoration(update.view);
+    }
+  },
+  {
+    decorations: (v) => v.decorations,
+  },
+);
+
+class HighlightedLineGutterMarker extends GutterMarker {
+  elementClass = 'cm-highlightedLineGutterSibling';
+}
+
+const highlightedRangesGutter = gutter({
+  class: 'cm-highlightedRangesGutter',
+  renderEmptyElements: true,
+});
+
+const highlightedLinesGutterHighlighter = gutterLineClass.compute(['doc', highlightedRangesFacet], (state) => {
+  const highlightedRanges = state.facet(highlightedRangesFacet)[0] || [];
+  const marks = [];
+
+  for (const range of highlightedRanges) {
+    for (let lineNumber = range.startLine; lineNumber <= range.endLine; lineNumber++) {
+      if (lineNumber <= state.doc.lines) {
+        const linePos = state.doc.line(lineNumber).from;
+        marks.push(new HighlightedLineGutterMarker().range(linePos));
+      }
+    }
+  }
+
+  try {
+    return RangeSet.of(marks);
+  } catch (e) {
+    console.error(`Failed to highlight lines in the gutter: ${e instanceof Error ? e.message : e}`);
+
+    return RangeSet.of([]);
+  }
+});
+
+const baseTheme = EditorView.baseTheme({
+  '& .cm-gutterElement': {
+    '&.cm-highlightedLineGutterSibling': {
+      position: 'relative',
+
+      '&:before': {
+        content: '""',
+        position: 'absolute',
+        left: 0,
+        right: 0,
+        top: 0,
+        bottom: 0,
+        backgroundColor: 'rgba(255, 248, 197, 1)',
+        opacity: 0.6,
+        zIndex: -1,
+      },
+    },
+  },
+
+  '& .cm-highlightedRangesGutter': {
+    position: 'absolute',
+    left: 0,
+    width: '2px',
+
+    '& .cm-gutterElement': {
+      '&.cm-highlightedLineGutterSibling': {
+        '&:before': {
+          boxShadow: 'inset 2px 0 0 rgba(154, 103, 0, 1)',
+          zIndex: 1,
+        },
+        '&.cm-activeLineGutter': {
+          '&:before': {
+            opacity: 0.8,
+          },
+        },
+      },
+    },
+  },
+
+  '& .cm-line': {
+    '&.cm-highlightedLine': {
+      position: 'relative',
+
+      '&:before': {
+        content: '""',
+        position: 'absolute',
+        display: 'block',
+        top: 0,
+        left: 0,
+        right: 0,
+        bottom: 0,
+        backgroundColor: 'rgba(255, 248, 197, 1)',
+        opacity: 0.6,
+        zIndex: -1,
+      },
+    },
+  },
+
+  '&dark': {
+    '& .cm-gutterElement': {
+      '&.cm-highlightedLineGutterSibling': {
+        '&:before': {
+          backgroundColor: 'rgba(187, 128, 9, 0.15)',
+        },
+      },
+    },
+
+    '& .cm-highlightedRangesGutter': {
+      '& .cm-gutterElement': {
+        '&.cm-highlightedLineGutterSibling': {
+          '&:before': {
+            boxShadow: 'inset 2px 0 0 rgba(210, 153, 34, 1)',
+          },
+        },
+      },
+    },
+
+    '& .cm-line': {
+      '&.cm-highlightedLine': {
+        '&:before': {
+          backgroundColor: 'rgba(187, 128, 9, 0.15)',
+        },
+      },
+    },
+  },
+});
+
+export function highlightRanges(highlightedRanges: LinesRange[] = []) {
+  return [
+    baseTheme,
+    highlightedRangesFacet.of(highlightedRanges),
+    highlightedRangesGutter,
+    highlightedLinesGutterHighlighter,
+    highlightRangesViewPlugin,
+  ];
+}

--- a/app/utils/code-mirror-highlight-ranges.ts
+++ b/app/utils/code-mirror-highlight-ranges.ts
@@ -1,7 +1,6 @@
 import { Decoration, EditorView, gutter, gutterLineClass, GutterMarker, ViewPlugin, type DecorationSet, type ViewUpdate } from '@codemirror/view';
 import { RangeSetBuilder, Facet, RangeSet } from '@codemirror/state';
-
-export type LinesRange = { startLine: number; endLine: number };
+import type { LinesRange } from 'codecrafters-frontend/utils/code-mirror-documents';
 
 const highlightedRangesFacet = Facet.define<LinesRange[]>({
   static: true,

--- a/app/utils/code-mirror-highlight-ranges.ts
+++ b/app/utils/code-mirror-highlight-ranges.ts
@@ -1,6 +1,6 @@
 import { Decoration, EditorView, gutter, gutterLineClass, GutterMarker, ViewPlugin, type DecorationSet, type ViewUpdate } from '@codemirror/view';
 import { RangeSetBuilder, Facet, RangeSet } from '@codemirror/state';
-import type { LineRange } from 'codecrafters-frontend/utils/code-mirror-documents';
+import type { LineRange } from 'codecrafters-frontend/components/code-mirror';
 
 const highlightedRangesFacet = Facet.define<LineRange[]>({
   static: true,

--- a/app/utils/code-mirror-themes.ts
+++ b/app/utils/code-mirror-themes.ts
@@ -203,6 +203,26 @@ export const codeCraftersDark = [
         backgroundColor: tailwindColors.gray['900'],
       },
 
+      // All gutter elements
+      '.cm-gutterElement': {
+        '&.cm-highlightedLineGutterSibling': {
+          '&:before': {
+            backgroundColor: 'rgba(187, 128, 9, 0.15)',
+          },
+        },
+      },
+
+      // Highlight ranges gutter
+      '.cm-highlightedRangesGutter': {
+        '& .cm-gutterElement': {
+          '&.cm-highlightedLineGutterSibling': {
+            '&:before': {
+              boxShadow: 'inset 2px 0 0 rgba(210, 153, 34, 1)',
+            },
+          },
+        },
+      },
+
       // Collapse unchanged lines gutter
       '.cm-collapseUnchangedGutter': {
         '& .cm-gutterElement': {
@@ -240,7 +260,17 @@ export const codeCraftersDark = [
           color: tailwindColors.sky['300'],
         },
       },
+
+      // All lines in the document
+      '.cm-line': {
+        '&.cm-highlightedLine': {
+          '&:before': {
+            backgroundColor: 'rgba(187, 128, 9, 0.15)',
+          },
+        },
+      },
     },
+
     { dark: true },
   ),
   EditorView.theme(BASE_STYLE, { dark: true }),

--- a/tests/integration/components/code-mirror-test.js
+++ b/tests/integration/components/code-mirror-test.js
@@ -230,6 +230,18 @@ module('Integration | Component | code-mirror', function (hooks) {
       skip('it does something useful with the editor');
     });
 
+    module('highlightedRanges', function () {
+      test("it doesn't break the editor when passed", async function (assert) {
+        this.set('highlightedRanges', []);
+        await render(hbs`<CodeMirror @highlightedRanges={{this.highlightedRanges}} />`);
+        assert.ok(codeMirror.hasRendered);
+        this.set('highlightedRanges', [{ startLine: 1, endLine: 1 }]);
+        assert.ok(codeMirror.hasRendered);
+      });
+
+      skip('it does something useful with the editor');
+    });
+
     module('highlightNewlines', function () {
       test("it doesn't break the editor when passed", async function (assert) {
         this.set('highlightNewlines', true);


### PR DESCRIPTION
Closes #2832

### Brief

This adds support for highlighting line ranges via `@highlightedRanges` argument to `CodeMirror`, `FileDiffCard`, and `FileContentsCard` components.

### Details

https://github.com/user-attachments/assets/18562161-40a8-4b93-9599-99c73fa6798e

### Checklist

- [x] I've thoroughly self-reviewed my changes
- [x] I've added tests for my changes, unless they affect admin-only areas (or are otherwise not worth testing)
- [x] I've verified any visual changes using Percy (add a commit with `[percy]` in the message to trigger)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - Added support for highlighting specified line ranges in the CodeMirror editor, including visual gutter markers and themed styling for light and dark modes.
  - Introduced toggle options and UI controls to enable or disable line range highlighting in demo interfaces for code editor, file contents, and file diff views.
- **Style**
  - Enhanced dark theme styling for highlighted lines and gutter markers to improve visibility and aesthetics.
- **Tests**
  - Added tests to verify stable rendering of the editor when line range highlighting is applied.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->