### PR TITLE
Code Examples admin UI doesn't show trusted evals

### DIFF
--- a/app/models/community-solution-evaluation.ts
+++ b/app/models/community-solution-evaluation.ts
@@ -23,7 +23,37 @@ export default class CommunitySolutionEvaluationModel extends Model {
   @tracked promptFileContents: string | null = null;
 
   get trustedEvaluation(): TrustedCommunitySolutionEvaluationModel | null {
-    return this.communitySolution.trustedEvaluations.findBy('evaluator', this.evaluator) || null;
+    // Since the evaluator relationship isn't being properly loaded in trusted evaluations,
+    // we need to use a different approach
+
+    // First try through the evaluator's trustedEvaluations
+    const evaluatorId = this.evaluator.id;
+    const evaluator = this.store.peekRecord('community-solution-evaluator', evaluatorId);
+
+    if (evaluator) {
+      // Look through the evaluator's trusted evaluations for one matching this solution
+      const fromEvaluator = evaluator.trustedEvaluations.find((te) => te.communitySolution?.id === this.communitySolution.id);
+
+      if (fromEvaluator) {
+        return fromEvaluator;
+      }
+    }
+
+    // Last resort: Compare by raw ID if we know which trusted evaluation we're looking for
+    // This only works if there's only one trusted evaluation for this solution
+    if (this.communitySolution.trustedEvaluations.length === 1) {
+      // If there's only one trusted evaluation for this solution, it's likely the one we want
+      const onlyTrustedEval = this.communitySolution.trustedEvaluations.toArray()[0];
+
+      // Get the raw record to access _internalModel if needed
+      const rawRecord = this.store.peekRecord('trusted-community-solution-evaluation', onlyTrustedEval.id);
+
+      if (rawRecord) {
+        return rawRecord;
+      }
+    }
+
+    return null;
   }
 
   async fetchLogsFileContentsIfNeeded(): Promise<void> {

--- a/app/routes/course-admin/code-example.ts
+++ b/app/routes/course-admin/code-example.ts
@@ -20,10 +20,12 @@ export default class CodeExampleRoute extends BaseRoute {
     // @ts-ignore
     const course = this.modelFor('course-admin').course;
 
+    const solutionIncludes = [...CommunityCourseStageSolutionModel.defaultIncludedResources, 'trusted-evaluations'];
+
     const [solution, comparisons, evaluations] = await Promise.all([
       // Solution
       this.store.findRecord('community-course-stage-solution', params.code_example_id, {
-        include: CommunityCourseStageSolutionModel.defaultIncludedResources.join(','),
+        include: solutionIncludes.join(','),
       }),
 
       // Comparisons

--- a/app/routes/course-admin/code-example.ts
+++ b/app/routes/course-admin/code-example.ts
@@ -20,12 +20,19 @@ export default class CodeExampleRoute extends BaseRoute {
     // @ts-ignore
     const course = this.modelFor('course-admin').course;
 
-    const solutionIncludes = [...CommunityCourseStageSolutionModel.defaultIncludedResources, 'trusted-evaluations'];
+    const solutionIncludes = [
+      ...CommunityCourseStageSolutionModel.defaultIncludedResources,
+      'trusted-evaluations',
+      'trusted-evaluations.evaluator',
+      'evaluations',
+      'evaluations.evaluator',
+    ];
 
     const [solution, comparisons, evaluations] = await Promise.all([
       // Solution
       this.store.findRecord('community-course-stage-solution', params.code_example_id, {
         include: solutionIncludes.join(','),
+        reload: true,
       }),
 
       // Comparisons


### PR DESCRIPTION
**Checklist**:

- [ ] I've thoroughly self-reviewed my changes
- [ ] I've added tests for my changes, unless they affect admin-only areas (or are otherwise not worth testing)
- [ ] I've verified any visual changes using Percy (add a commit with `[percy]` in the message to trigger)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced course solution details to include information about trusted evaluations when viewing records.  
  - Improved reliability in displaying trusted evaluation data linked to community solutions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->