### PR TITLE
Include evaluations and trustedEvaluations when fetching CommunitySolutions

### DIFF
--- a/app/routes/course-admin/code-example.ts
+++ b/app/routes/course-admin/code-example.ts
@@ -20,10 +20,19 @@ export default class CodeExampleRoute extends BaseRoute {
     // @ts-ignore
     const course = this.modelFor('course-admin').course;
 
+    const solutionIncludes = [
+      ...CommunityCourseStageSolutionModel.defaultIncludedResources,
+      'evaluations',
+      'evaluations.evaluator',
+      'trusted-evaluations',
+      'trusted-evaluations.evaluator',
+    ];
+
     const [solution, comparisons, evaluations] = await Promise.all([
       // Solution
       this.store.findRecord('community-course-stage-solution', params.code_example_id, {
-        include: CommunityCourseStageSolutionModel.defaultIncludedResources.join(','),
+        include: solutionIncludes.join(','),
+        reload: true,
       }),
 
       // Comparisons

--- a/app/routes/course-admin/code-example.ts
+++ b/app/routes/course-admin/code-example.ts
@@ -20,11 +20,7 @@ export default class CodeExampleRoute extends BaseRoute {
     // @ts-ignore
     const course = this.modelFor('course-admin').course;
 
-    const solutionIncludes = [
-      ...CommunityCourseStageSolutionModel.defaultIncludedResources,
-      'trusted-evaluations',
-      'trusted-evaluations.evaluator',
-    ];
+    const solutionIncludes = [...CommunityCourseStageSolutionModel.defaultIncludedResources, 'trusted-evaluations', 'trusted-evaluations.evaluator'];
 
     const [solution, comparisons, evaluations] = await Promise.all([
       // Solution

--- a/app/routes/course-admin/code-example.ts
+++ b/app/routes/course-admin/code-example.ts
@@ -22,8 +22,6 @@ export default class CodeExampleRoute extends BaseRoute {
 
     const solutionIncludes = [
       ...CommunityCourseStageSolutionModel.defaultIncludedResources,
-      'evaluations',
-      'evaluations.evaluator',
       'trusted-evaluations',
       'trusted-evaluations.evaluator',
     ];

--- a/mirage/config.js
+++ b/mirage/config.js
@@ -74,8 +74,10 @@ export default function (config) {
           courseStage: belongsTo('course-stage', { inverse: 'communitySolutions' }),
           currentUserDownvotes: hasMany('downvote', { inverse: 'downvotable' }),
           currentUserUpvotes: hasMany('upvote', { inverse: 'upvotable' }),
+          evaluations: hasMany('community-solution-evaluation', { inverse: 'communitySolution' }),
           language: belongsTo('language', { inverse: null }),
           screencasts: hasMany('course-stage-screencast', { inverse: 'solution' }),
+          trustedEvaluations: hasMany('trusted-community-solution-evaluation', { inverse: 'communitySolution' }),
           user: belongsTo('user', { inverse: null }),
         }),
         communityCourseStageSolutionComment: Model.extend({


### PR DESCRIPTION
**Checklist**:

- [x] I've thoroughly self-reviewed my changes
- [ ] I've added tests for my changes, unless they affect admin-only areas (or are otherwise not worth testing)
- [ ] I've verified any visual changes using Percy (add a commit with `[percy]` in the message to trigger)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced data loading for code example solutions to include additional evaluation details and evaluator information.
- **Bug Fixes**
	- Ensured the latest solution data is always loaded from the server.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->