### PR TITLE
Add `collapsedRanges` support to CodeMirror

### DIFF
--- a/app/components/code-mirror.hbs
+++ b/app/components/code-mirror.hbs
@@ -5,6 +5,7 @@
   {{did-update this.optionDidChange "autocompletion" @autocompletion}}
   {{did-update this.optionDidChange "bracketMatching" @bracketMatching}}
   {{did-update this.optionDidChange "closeBrackets" @closeBrackets}}
+  {{did-update this.optionDidChange "collapsedRanges" @collapsedRanges}}
   {{did-update this.optionDidChange "crosshairCursor" @crosshairCursor}}
   {{did-update this.optionDidChange "drawSelection" @drawSelection}}
   {{did-update this.optionDidChange "dropCursor" @dropCursor}}

--- a/app/components/code-mirror.hbs
+++ b/app/components/code-mirror.hbs
@@ -33,6 +33,7 @@
     (array
       @originalDocument
       @mergeControls
+      @collapsedRanges
       @collapseUnchanged
       @highlightChanges
       @syntaxHighlightDeletions

--- a/app/components/code-mirror.ts
+++ b/app/components/code-mirror.ts
@@ -40,6 +40,7 @@ import { highlightNewlines } from 'codecrafters-frontend/utils/code-mirror-highl
 import { collapseUnchangedGutter } from 'codecrafters-frontend/utils/code-mirror-collapse-unchanged-gutter';
 import { highlightActiveLineGutter as highlightActiveLineGutterRS } from 'codecrafters-frontend/utils/code-mirror-gutter-rs';
 import { highlightRanges } from 'codecrafters-frontend/utils/code-mirror-highlight-ranges';
+import { collapseRanges } from 'codecrafters-frontend/utils/code-mirror-collapse-ranges';
 
 function generateHTMLElement(src: string): HTMLElement {
   const div = document.createElement('div');
@@ -69,6 +70,7 @@ const OPTION_HANDLERS: { [key: string]: OptionHandler } = {
   autocompletion: ({ autocompletion: enabled }) => (enabled ? [autocompletion(), keymap.of(completionKeymap)] : []),
   bracketMatching: ({ bracketMatching: enabled }) => (enabled ? [bracketMatching()] : []),
   closeBrackets: ({ closeBrackets: enabled }) => (enabled ? [closeBrackets(), keymap.of(closeBracketsKeymap)] : []),
+  collapsedRanges: ({ collapsedRanges }) => (collapsedRanges ? collapseRanges(collapsedRanges) : []),
   crosshairCursor: ({ crosshairCursor: enabled }) => (enabled ? [crosshairCursor()] : []),
   drawSelection: ({ drawSelection: enabled }) => (enabled ? [drawSelection()] : []),
   dropCursor: ({ dropCursor: enabled }) => (enabled ? [dropCursor()] : []),
@@ -219,6 +221,10 @@ export interface Signature {
        * Automatically close brackets when typing
        */
       closeBrackets?: boolean;
+      /**
+       * Enable collapsing of specified line ranges
+       */
+      collapsedRanges?: LineRange[];
       /**
        * Use a crosshair cursor over the editor when ALT key is pressed
        */

--- a/app/components/code-mirror.ts
+++ b/app/components/code-mirror.ts
@@ -41,6 +41,7 @@ import { collapseUnchangedGutter } from 'codecrafters-frontend/utils/code-mirror
 import { highlightActiveLineGutter as highlightActiveLineGutterRS } from 'codecrafters-frontend/utils/code-mirror-gutter-rs';
 import { highlightRanges } from 'codecrafters-frontend/utils/code-mirror-highlight-ranges';
 import { collapseRanges } from 'codecrafters-frontend/utils/code-mirror-collapse-ranges';
+import { collapseRangesGutter } from 'codecrafters-frontend/utils/code-mirror-collapse-ranges-gutter';
 
 function generateHTMLElement(src: string): HTMLElement {
   const div = document.createElement('div');
@@ -149,11 +150,11 @@ const OPTION_HANDLERS: { [key: string]: OptionHandler } = {
             syntaxHighlightDeletions: !!syntaxHighlighting && !!syntaxHighlightDeletions,
             allowInlineDiffs: !!allowInlineDiffs,
           }),
-          collapseUnchanged ? collapseUnchangedGutter() : [],
+          collapseUnchanged && !collapsedRanges ? collapseUnchangedGutter() : [],
         ]
       : [];
   },
-  collapsedRanges: ({ collapsedRanges }) => (collapsedRanges ? collapseRanges(collapsedRanges) : []),
+  collapsedRanges: ({ collapsedRanges }) => (collapsedRanges ? [collapseRanges(collapsedRanges), collapseRangesGutter()] : []),
 };
 
 export interface Signature {

--- a/app/components/file-contents-card.hbs
+++ b/app/components/file-contents-card.hbs
@@ -47,6 +47,7 @@
       @lineNumbers={{true}}
       @allowMultipleSelections={{true}}
       @bracketMatching={{true}}
+      @collapsedRanges={{@collapsedRanges}}
       @crosshairCursor={{true}}
       @drawSelection={{true}}
       @rectangularSelection={{true}}

--- a/app/components/file-contents-card.ts
+++ b/app/components/file-contents-card.ts
@@ -36,6 +36,10 @@ interface Signature {
      */
     headerTooltipText?: string;
     /**
+     * Enable collapsing of specified line ranges
+     */
+    collapsedRanges?: LinesRange[];
+    /**
      * Enable highlighting of specified line ranges
      */
     highlightedRanges?: LineRange[];

--- a/app/components/file-contents-card.ts
+++ b/app/components/file-contents-card.ts
@@ -38,7 +38,7 @@ interface Signature {
     /**
      * Enable collapsing of specified line ranges
      */
-    collapsedRanges?: LinesRange[];
+    collapsedRanges?: LineRange[];
     /**
      * Enable highlighting of specified line ranges
      */

--- a/app/components/file-diff-card.hbs
+++ b/app/components/file-diff-card.hbs
@@ -12,6 +12,7 @@
         @language={{@language}}
         @allowMultipleSelections={{true}}
         @bracketMatching={{true}}
+        @collapsedRanges={{@collapsedRanges}}
         @collapseUnchanged={{true}}
         @crosshairCursor={{true}}
         @drawSelection={{true}}

--- a/app/components/file-diff-card.ts
+++ b/app/components/file-diff-card.ts
@@ -24,7 +24,7 @@ interface Signature {
     /**
      * Enable collapsing of specified line ranges
      */
-    collapsedRanges?: LinesRange[];
+    collapsedRanges?: LineRange[];
     /**
      * Enable highlighting of specified line ranges
      */

--- a/app/components/file-diff-card.ts
+++ b/app/components/file-diff-card.ts
@@ -22,6 +22,10 @@ interface Signature {
      */
     forceDarkTheme?: boolean;
     /**
+     * Enable collapsing of specified line ranges
+     */
+    collapsedRanges?: LinesRange[];
+    /**
      * Enable highlighting of specified line ranges
      */
     highlightedRanges?: LineRange[];

--- a/app/controllers/demo/code-mirror.ts
+++ b/app/controllers/demo/code-mirror.ts
@@ -34,6 +34,7 @@ const OPTION_DEFAULTS = {
   autocompletion: true,
   bracketMatching: true,
   closeBrackets: true,
+  collapsedRanges: false,
   collapseUnchanged: true,
   crosshairCursor: true,
   document: true,
@@ -91,6 +92,7 @@ export default class DemoCodeMirrorController extends Controller {
     'autocompletion',
     'bracketMatching',
     'closeBrackets',
+    'collapsedRanges',
     'collapseUnchanged',
     'crosshairCursor',
     'document',
@@ -144,6 +146,7 @@ export default class DemoCodeMirrorController extends Controller {
   @tracked autocompletion = OPTION_DEFAULTS.autocompletion;
   @tracked bracketMatching = OPTION_DEFAULTS.bracketMatching;
   @tracked closeBrackets = OPTION_DEFAULTS.closeBrackets;
+  @tracked collapsedRanges = OPTION_DEFAULTS.collapsedRanges;
   @tracked crosshairCursor = OPTION_DEFAULTS.crosshairCursor;
   @tracked document = OPTION_DEFAULTS.document;
   @tracked documents: ExampleDocument[] = EXAMPLE_DOCUMENTS;

--- a/app/controllers/demo/file-contents-card.ts
+++ b/app/controllers/demo/file-contents-card.ts
@@ -5,6 +5,7 @@ import EXAMPLE_DOCUMENTS, { ExampleDocument } from 'codecrafters-frontend/utils/
 
 const OPTION_DEFAULTS = {
   headerTooltipText: false,
+  collapsedRanges: false,
   highlightedRanges: false,
   isCollapsed: false,
   isCollapsible: false,
@@ -17,6 +18,7 @@ export default class DemoFileContentsCardController extends Controller {
 
   @tracked documents: ExampleDocument[] = EXAMPLE_DOCUMENTS;
   @tracked headerTooltipText: boolean = OPTION_DEFAULTS.headerTooltipText;
+  @tracked collapsedRanges: boolean = OPTION_DEFAULTS.collapsedRanges;
   @tracked highlightedRanges: boolean = OPTION_DEFAULTS.highlightedRanges;
   @tracked isCollapsed: boolean = OPTION_DEFAULTS.isCollapsed;
   @tracked isCollapsible: boolean = OPTION_DEFAULTS.isCollapsible;

--- a/app/controllers/demo/file-diff-card.ts
+++ b/app/controllers/demo/file-diff-card.ts
@@ -5,6 +5,7 @@ import EXAMPLE_DOCUMENTS, { DiffBasedExampleDocument } from 'codecrafters-fronte
 
 const OPTION_DEFAULTS = {
   forceDarkTheme: false,
+  collapsedRanges: false,
   highlightedRanges: false,
   selectedDocumentIndex: 1,
   useCodeMirror: true,
@@ -14,6 +15,7 @@ export default class DemoFileDiffCardController extends Controller {
   @tracked documents: DiffBasedExampleDocument[] = EXAMPLE_DOCUMENTS;
 
   @tracked forceDarkTheme: boolean = OPTION_DEFAULTS.forceDarkTheme;
+  @tracked collapsedRanges: boolean = OPTION_DEFAULTS.collapsedRanges;
   @tracked highlightedRanges: boolean = OPTION_DEFAULTS.highlightedRanges;
   @tracked selectedDocumentIndex: number = OPTION_DEFAULTS.selectedDocumentIndex;
   @tracked useCodeMirror: boolean = OPTION_DEFAULTS.useCodeMirror;

--- a/app/routes/demo/code-mirror.ts
+++ b/app/routes/demo/code-mirror.ts
@@ -6,6 +6,7 @@ const QUERY_PARAMS = [
   'autocompletion',
   'bracketMatching',
   'closeBrackets',
+  'collapsedRanges',
   'collapseUnchanged',
   'crosshairCursor',
   'document',

--- a/app/routes/demo/file-contents-card.ts
+++ b/app/routes/demo/file-contents-card.ts
@@ -1,6 +1,7 @@
 import Route from '@ember/routing/route';
 
 const QUERY_PARAMS = [
+  'collapsedRanges',
   'foldGutter',
   'headerTooltipText',
   'highlightedRanges',

--- a/app/routes/demo/file-diff-card.ts
+++ b/app/routes/demo/file-diff-card.ts
@@ -1,6 +1,6 @@
 import Route from '@ember/routing/route';
 
-const QUERY_PARAMS = ['forceDarkTheme', 'highlightedRanges', 'selectedDocumentIndex', 'useCodeMirror'];
+const QUERY_PARAMS = ['collapsedRanges', 'forceDarkTheme', 'highlightedRanges', 'selectedDocumentIndex', 'useCodeMirror'];
 
 interface QueryParamOptions {
   [key: string]: {

--- a/app/templates/demo/code-mirror.hbs
+++ b/app/templates/demo/code-mirror.hbs
@@ -127,8 +127,8 @@
         <span class="ml-2 {{unless this.originalDocument 'text-gray-300'}}">mergeControls</span>
       </label>
       <label class="{{labelClasses}}" title="Enable collapsing unchanged lines in the diff editor">
-        <Input @type="checkbox" @checked={{this.collapseUnchanged}} disabled={{not this.originalDocument}} />
-        <span class="ml-2 {{unless this.originalDocument 'text-gray-300'}}">collapseUnchanged</span>
+        <Input @type="checkbox" @checked={{this.collapseUnchanged}} disabled={{or (not this.originalDocument) this.collapsedRanges}} />
+        <span class="ml-2 {{if (or (not this.originalDocument) this.collapsedRanges) 'text-gray-300'}}">collapseUnchanged</span>
       </label>
       <label class="{{labelClasses}}" title="Display chunks with only limited inline changes inline in the code">
         <Input @type="checkbox" @checked={{this.allowInlineDiffs}} disabled={{not this.originalDocument}} />

--- a/app/templates/demo/code-mirror.hbs
+++ b/app/templates/demo/code-mirror.hbs
@@ -103,6 +103,10 @@
         <Input @type="checkbox" @checked={{this.highlightedRanges}} />
         <span class="ml-2">highlightedRanges</span>
       </label>
+      <label class="{{labelClasses}}" title="Enable collapsing of specified line ranges">
+        <Input @type="checkbox" @checked={{this.collapsedRanges}} />
+        <span class="ml-2">collapsedRanges</span>
+      </label>
     </codemirror-options-left>
     <codemirror-options-right class="flex flex-wrap">
       <label class="{{labelClasses}}" title="Placeholder text to show when document is empty or not passed">
@@ -333,6 +337,7 @@
   @allowMultipleSelections={{this.allowMultipleSelections}}
   @autocompletion={{this.autocompletion}}
   @bracketMatching={{this.bracketMatching}}
+  @collapsedRanges={{if this.collapsedRanges this.selectedDocument.collapsedRanges}}
   @closeBrackets={{this.closeBrackets}}
   @crosshairCursor={{this.crosshairCursor}}
   @drawSelection={{this.drawSelection}}

--- a/app/templates/demo/file-contents-card.hbs
+++ b/app/templates/demo/file-contents-card.hbs
@@ -2,10 +2,10 @@
 
 {{#let
   "flex flex-wrap text-sm font-semibold text-gray-600 dark:text-gray-200 border-b border-gray-200 dark:border-gray-700 py-2"
-  "flex cursor-default select-none text-nowrap mx-2"
+  "flex cursor-default select-none text-nowrap mx-2 h-[20px]"
   as |groupClasses labelClasses|
 }}
-  <component-options class="{{groupClasses}} -mt-8">
+  <component-options class="{{groupClasses}} border-dotted flex-nowrap -mt-8">
     <component-options-left class="flex flex-grow flex-wrap">
       <label class="{{labelClasses}}" title="File for the component to render (select a preset)">
         <span class="mr-2">File:</span>
@@ -16,11 +16,26 @@
         </select>
       </label>
     </component-options-left>
-    <component-options-right class="flex flex-wrap">
+    <component-options-right class="flex flex-wrap justify-end">
+      <label class="{{labelClasses}}" title="Enable highlighting of specified line ranges">
+        <Input @type="checkbox" @checked={{this.highlightedRanges}} />
+        <span class="ml-2">highlightedRanges</span>
+      </label>
+      <label class="{{labelClasses}}" title="Enable collapsing of specified line ranges">
+        <Input @type="checkbox" @checked={{this.collapsedRanges}} />
+        <span class="ml-2">collapsedRanges</span>
+      </label>
+    </component-options-right>
+  </component-options>
+
+  <component-options class="{{groupClasses}} flex-nowrap">
+    <component-options-left class="flex flex-grow flex-wrap">
       <label class="{{labelClasses}}" title="Enable collapsing of the file card to just the header">
         <Input @type="checkbox" @checked={{this.isCollapsible}} />
         <span class="ml-2">isCollapsible</span>
       </label>
+    </component-options-left>
+    <component-options-right class="flex flex-wrap justify-end">
       <label class="{{labelClasses}}" title="Scroll the component into view after it's collapsed">
         <Input @type="checkbox" @checked={{this.scrollIntoViewOnCollapse}} disabled={{not this.isCollapsible}} />
         <span class="ml-2 {{unless this.isCollapsible 'text-gray-300'}}">scrollIntoViewOnCollapse</span>
@@ -28,10 +43,6 @@
       <label class="{{labelClasses}}" title="Show a tooltip in the header when collapsible & collapsed">
         <Input @type="checkbox" @checked={{this.headerTooltipText}} disabled={{not this.isCollapsible}} />
         <span class="ml-2 {{unless this.isCollapsible 'text-gray-300'}}">headerTooltipText</span>
-      </label>
-      <label class="{{labelClasses}}" title="Enable highlighting of specified line ranges">
-        <Input @type="checkbox" @checked={{this.highlightedRanges}} />
-        <span class="ml-2">highlightedRanges</span>
       </label>
     </component-options-right>
   </component-options>
@@ -45,6 +56,7 @@
   @isCollapsible={{this.isCollapsible}}
   @scrollIntoViewOnCollapse={{this.scrollIntoViewOnCollapse}}
   @headerTooltipText={{if this.headerTooltipText "Example tooltip message"}}
+  @collapsedRanges={{if this.collapsedRanges this.selectedDocument.collapsedRanges}}
   @highlightedRanges={{if this.highlightedRanges this.selectedDocument.highlightedRanges}}
   @onExpand={{fn (mut this.isCollapsed) false}}
   @onCollapse={{fn (mut this.isCollapsed) true}}

--- a/app/templates/demo/file-diff-card.hbs
+++ b/app/templates/demo/file-diff-card.hbs
@@ -1,12 +1,11 @@
 {{page-title "FileDiffCard"}}
 
 {{#let
-  "flex flex-wrap text-sm font-semibold text-gray-600 dark:text-gray-200 border-b border-gray-200 dark:border-gray-700
-py-2"
-  "flex cursor-default select-none text-nowrap mx-2"
+  "flex flex-wrap text-sm font-semibold text-gray-600 dark:text-gray-200 border-b border-gray-200 dark:border-gray-700 py-2"
+  "flex cursor-default select-none text-nowrap mx-2 h-[20px]"
   as |groupClasses labelClasses|
 }}
-  <component-options class="{{groupClasses}} -mt-8">
+  <component-options class="{{groupClasses}} border-dotted flex-nowrap -mt-8">
     <component-options-left class="flex flex-grow flex-wrap">
       <label class="{{labelClasses}}" title="File for the component to render (select a preset)">
         <span class="mr-2">File:</span>
@@ -17,18 +16,29 @@ py-2"
         </select>
       </label>
     </component-options-left>
-    <component-options-right class="flex flex-wrap">
+    <component-options-right class="flex flex-wrap justify-end">
+      <label class="{{labelClasses}}" title="Enable highlighting of specified line ranges">
+        <Input @type="checkbox" @checked={{this.highlightedRanges}} />
+        <span class="ml-2">highlightedRanges</span>
+      </label>
+      <label class="{{labelClasses}}" title="Enable collapsing of specified line ranges">
+        <Input @type="checkbox" @checked={{this.collapsedRanges}} />
+        <span class="ml-2">collapsedRanges</span>
+      </label>
+    </component-options-right>
+  </component-options>
+
+  <component-options class="{{groupClasses}} flex-nowrap">
+    <component-options-left class="flex flex-grow flex-wrap">
       <label class="{{labelClasses}}" title="Use CodeMirror instead of SyntaxHighlightedDiff for rendering the diff">
         <Input @type="checkbox" @checked={{this.useCodeMirror}} />
         <span class="ml-2">useCodeMirror</span>
       </label>
+    </component-options-left>
+    <component-options-right class="flex flex-wrap justify-end">
       <label class="{{labelClasses}}" title="Always render CodeMirror using Dark Theme">
         <Input @type="checkbox" @checked={{this.forceDarkTheme}} />
         <span class="ml-2">forceDarkTheme</span>
-      </label>
-      <label class="{{labelClasses}}" title="Enable highlighting of specified line ranges">
-        <Input @type="checkbox" @checked={{this.highlightedRanges}} />
-        <span class="ml-2">highlightedRanges</span>
       </label>
     </component-options-right>
   </component-options>
@@ -40,6 +50,7 @@ py-2"
   @filename={{this.selectedDocument.filename}}
   @language={{this.selectedDocument.language}}
   @forceDarkTheme={{this.forceDarkTheme}}
+  @collapsedRanges={{if this.collapsedRanges this.selectedDocument.collapsedRanges}}
   @highlightedRanges={{if this.highlightedRanges this.selectedDocument.highlightedRanges}}
   class="mt-4 {{if this.forceDarkTheme 'dark'}}"
 />

--- a/app/utils/code-mirror-collapse-ranges-gutter.ts
+++ b/app/utils/code-mirror-collapse-ranges-gutter.ts
@@ -1,0 +1,82 @@
+import { BlockInfo, EditorView, gutter, GutterMarker, type WidgetType } from '@codemirror/view';
+import { gutter as gutterRS, GutterMarker as GutterMarkerRS } from 'codecrafters-frontend/utils/code-mirror-gutter-rs';
+import { CollapsedRangesWidget, uncollapseRangesStateEffect } from 'codecrafters-frontend/utils/code-mirror-collapse-ranges';
+
+function isCollapseRangesWidget(widget: WidgetType) {
+  return widget instanceof CollapsedRangesWidget;
+}
+
+function renderGutterElement(view: EditorView, widget: WidgetType, line: BlockInfo) {
+  const totalLines = view.state.doc.lines;
+  const lineNumber = view.state.doc.lineAt(line.from).number;
+  const collapsedLinesCount = 'lines' in widget ? (widget.lines as number) : 1;
+  const extraClassNames = [];
+
+  if (lineNumber === 1) {
+    extraClassNames.push('cm-collapseRangesGutterElementFirst');
+  } else if (lineNumber + collapsedLinesCount - 1 >= totalLines) {
+    extraClassNames.push('cm-collapseRangesGutterElementLast');
+  }
+
+  const el = document.createElement('div');
+  el.className = ['cm-collapseRangesGutterElement', ...extraClassNames].join(' ');
+  el.addEventListener('click', function dispatchUncollapseRangesStateEffect() {
+    view.dispatch({ effects: uncollapseRangesStateEffect.of(line.from) });
+  });
+
+  return el;
+}
+
+export class CollapseRangesGutterMarker extends GutterMarker {
+  line: BlockInfo;
+  view: EditorView;
+  widget: WidgetType;
+
+  constructor(view: EditorView, widget: WidgetType, line: BlockInfo) {
+    super();
+    this.line = line;
+    this.view = view;
+    this.widget = widget;
+  }
+
+  toDOM(view: EditorView) {
+    return renderGutterElement(view, this.widget, this.line);
+  }
+}
+
+export class CollapseRangesGutterMarkerRS extends GutterMarkerRS {
+  line: BlockInfo;
+  view: EditorView;
+  widget: WidgetType;
+
+  constructor(view: EditorView, widget: WidgetType, line: BlockInfo) {
+    super();
+    this.line = line;
+    this.view = view;
+    this.widget = widget;
+  }
+
+  toDOM(view: EditorView) {
+    return renderGutterElement(view, this.widget, this.line);
+  }
+}
+
+export function collapseRangesGutter() {
+  return [
+    gutter({
+      class: 'cm-collapseRangesGutter',
+
+      widgetMarker(view, widget, line) {
+        return isCollapseRangesWidget(widget) ? new CollapseRangesGutterMarker(view, widget, line) : null;
+      },
+    }),
+
+    gutterRS({
+      class: 'cm-collapseRangesGutter',
+
+      widgetMarker(view, widget, line) {
+        return isCollapseRangesWidget(widget) ? new CollapseRangesGutterMarkerRS(view, widget, line) : null;
+      },
+    }),
+  ];
+}

--- a/app/utils/code-mirror-collapse-ranges.ts
+++ b/app/utils/code-mirror-collapse-ranges.ts
@@ -1,0 +1,5 @@
+import type { LineRange } from 'codecrafters-frontend/components/code-mirror';
+
+export function collapseRanges(collapsedRanges: LineRange[] = []) {
+  return collapsedRanges ? [] : [];
+}

--- a/app/utils/code-mirror-collapse-ranges.ts
+++ b/app/utils/code-mirror-collapse-ranges.ts
@@ -1,5 +1,122 @@
+import { Decoration, EditorView, WidgetType, type DecorationSet } from '@codemirror/view';
+import { EditorState, RangeSetBuilder, StateEffect, StateField } from '@codemirror/state';
 import type { LineRange } from 'codecrafters-frontend/components/code-mirror';
 
+export const uncollapseRangesStateEffect = StateEffect.define<number>({
+  map: (value, change) => change.mapPos(value),
+});
+
+const CollapsedRangesStateField = StateField.define<DecorationSet>({
+  create(_state) {
+    return Decoration.none;
+  },
+
+  update(deco, tr) {
+    deco = deco.map(tr.changes);
+
+    for (const e of tr.effects) {
+      if (e.is(uncollapseRangesStateEffect)) {
+        deco = deco.update({ filter: (from) => from != e.value });
+      }
+    }
+
+    return deco;
+  },
+
+  provide: (f) => EditorView.decorations.from(f),
+});
+
+export class CollapsedRangesWidget extends WidgetType {
+  constructor(
+    readonly startLine: number,
+    readonly endLine: number,
+  ) {
+    super();
+  }
+
+  get estimatedHeight() {
+    return 27;
+  }
+
+  get lines() {
+    return this.endLine - this.startLine + 1;
+  }
+
+  eq(other: CollapsedRangesWidget) {
+    return this.startLine == other.startLine && this.endLine == other.endLine;
+  }
+
+  ignoreEvent(e: Event) {
+    return e instanceof MouseEvent;
+  }
+
+  toDOM(view: EditorView) {
+    const outer = document.createElement('div');
+    outer.className = 'cm-collapsedRanges';
+    outer.textContent = view.state.phrase('Expand $ lines', this.lines);
+
+    outer.addEventListener('click', (e) => {
+      const pos = view.posAtDOM(e.target as HTMLElement);
+      view.dispatch({ effects: uncollapseRangesStateEffect.of(pos) });
+    });
+
+    return outer;
+  }
+}
+
+function buildCollapsedRangesDecorations(state: EditorState, collapsedRanges: LineRange[]) {
+  const builder = new RangeSetBuilder<Decoration>();
+
+  for (const { startLine, endLine } of collapsedRanges) {
+    builder.add(
+      state.doc.line(startLine).from,
+      state.doc.line(endLine).to,
+      Decoration.replace({
+        widget: new CollapsedRangesWidget(startLine, endLine),
+        block: true,
+      }),
+    );
+  }
+
+  return builder.finish();
+}
+
+function initCollapsedRangesStateField(collapsedRanges: LineRange[] = []) {
+  return CollapsedRangesStateField.init((state) => buildCollapsedRangesDecorations(state, collapsedRanges));
+}
+
+const baseTheme = EditorView.baseTheme({
+  '& .cm-collapsedRanges': {
+    padding: '5px 5px 5px 10px',
+    background: 'linear-gradient(to bottom, transparent 0, #f3f3f3 30%, #f3f3f3 70%, transparent 100%)',
+    color: '#444',
+    cursor: 'pointer',
+    '&:before': {
+      content: '"⦚"',
+      marginInlineEnd: '7px',
+    },
+    '&:after': {
+      content: '"⦚"',
+      marginInlineStart: '7px',
+    },
+  },
+
+  '&dark': {
+    '& .cm-collapsedRanges': {
+      color: '#ddd',
+      background: 'linear-gradient(to bottom, transparent 0, #222 30%, #222 70%, transparent 100%)',
+    },
+  },
+});
+
 export function collapseRanges(collapsedRanges: LineRange[] = []) {
-  return collapsedRanges ? [] : [];
+  return collapsedRanges
+    ? [
+        EditorState.phrases.of({
+          'Expand $ lines': 'Expand $ lines',
+        }),
+        baseTheme,
+        initCollapsedRangesStateField(collapsedRanges),
+      ]
+    : [];
 }

--- a/app/utils/code-mirror-collapse-ranges.ts
+++ b/app/utils/code-mirror-collapse-ranges.ts
@@ -68,14 +68,16 @@ function buildCollapsedRangesDecorations(state: EditorState, collapsedRanges: Li
   const builder = new RangeSetBuilder<Decoration>();
 
   for (const { startLine, endLine } of collapsedRanges) {
-    builder.add(
-      state.doc.line(startLine).from,
-      state.doc.line(endLine).to,
-      Decoration.replace({
-        widget: new CollapsedRangesWidget(startLine, endLine),
-        block: true,
-      }),
-    );
+    if (startLine <= state.doc.lines && endLine <= state.doc.lines) {
+      builder.add(
+        state.doc.line(startLine).from,
+        state.doc.line(endLine).to,
+        Decoration.replace({
+          widget: new CollapsedRangesWidget(startLine, endLine),
+          block: true,
+        }),
+      );
+    }
   }
 
   return builder.finish();

--- a/app/utils/code-mirror-documents.ts
+++ b/app/utils/code-mirror-documents.ts
@@ -212,6 +212,10 @@ export default [
       { startLine: 7, endLine: 7 },
       { startLine: 9, endLine: 9 },
     ],
+    collapsedRanges: [
+      { startLine: 2, endLine: 4 },
+      { startLine: 6, endLine: 8 },
+    ],
   }),
 
   new DiffBasedExampleDocument({
@@ -231,6 +235,10 @@ export default [
     ].join('\n'),
     filename: 'test.py',
     language: 'python',
+    collapsedRanges: [
+      { startLine: 1, endLine: 1 },
+      { startLine: 3, endLine: 9 },
+    ],
   }),
 
   new DiffBasedExampleDocument({
@@ -293,6 +301,10 @@ export default [
       { startLine: 14, endLine: 20 },
       { startLine: 35, endLine: 39 },
     ],
+    collapsedRanges: [
+      { startLine: 15, endLine: 19 },
+      { startLine: 24, endLine: 26 },
+    ],
   }),
 
   new DiffBasedExampleDocument({
@@ -325,6 +337,10 @@ export default [
     highlightedRanges: [
       { startLine: 12, endLine: 12 },
       { startLine: 18, endLine: 18 },
+    ],
+    collapsedRanges: [
+      { startLine: 1, endLine: 6 },
+      { startLine: 21, endLine: 21 },
     ],
   }),
 
@@ -361,6 +377,10 @@ export default [
     highlightedRanges: [
       { startLine: 7, endLine: 7 },
       { startLine: 17, endLine: 18 },
+    ],
+    collapsedRanges: [
+      { startLine: 12, endLine: 15 },
+      { startLine: 22, endLine: 23 },
     ],
   }),
 ];

--- a/app/utils/code-mirror-documents.ts
+++ b/app/utils/code-mirror-documents.ts
@@ -125,8 +125,11 @@ export default [
       { startLine: 18, endLine: 20 },
     ],
     collapsedRanges: [
+      { startLine: 1, endLine: 7 },
       { startLine: 12, endLine: 15 },
       { startLine: 25, endLine: 27 },
+      { startLine: 30, endLine: 31 },
+      { startLine: 38, endLine: 39 },
     ],
   }),
 
@@ -180,6 +183,10 @@ export default [
       { startLine: 16, endLine: 17 },
       { startLine: 21, endLine: 22 },
       { startLine: 26, endLine: 27 },
+    ],
+    collapsedRanges: [
+      { startLine: 7, endLine: 13 },
+      { startLine: 20, endLine: 28 },
     ],
   }),
 

--- a/app/utils/code-mirror-documents.ts
+++ b/app/utils/code-mirror-documents.ts
@@ -8,6 +8,7 @@ export class ExampleDocument {
   @tracked filename: string;
   @tracked language: string;
   @tracked highlightedRanges: LineRange[];
+  @tracked collapsedRanges: LineRange[];
 
   constructor({
     document = '',
@@ -15,18 +16,21 @@ export class ExampleDocument {
     filename,
     language,
     highlightedRanges = [],
+    collapsedRanges = [],
   }: {
     document?: string;
     originalDocument?: string;
     filename: string;
     language: string;
     highlightedRanges?: LineRange[];
+    collapsedRanges?: LineRange[];
   }) {
     this.document = document;
     this.originalDocument = originalDocument || document;
     this.filename = filename;
     this.language = language;
     this.highlightedRanges = highlightedRanges;
+    this.collapsedRanges = collapsedRanges;
   }
 
   static createEmpty() {
@@ -42,11 +46,13 @@ export class DiffBasedExampleDocument extends ExampleDocument {
     filename,
     language,
     highlightedRanges = [],
+    collapsedRanges = [],
   }: {
     diff?: string;
     filename: string;
     language: string;
     highlightedRanges?: LineRange[];
+    collapsedRanges?: LineRange[];
   }) {
     const { current: document, original: originalDocument } = parseDiffAsDocument(diff);
 
@@ -56,6 +62,7 @@ export class DiffBasedExampleDocument extends ExampleDocument {
       filename,
       language,
       highlightedRanges,
+      collapsedRanges,
     });
 
     this.diff = diff;
@@ -116,6 +123,10 @@ export default [
       { startLine: 2, endLine: 4 },
       { startLine: 7, endLine: 10 },
       { startLine: 18, endLine: 20 },
+    ],
+    collapsedRanges: [
+      { startLine: 12, endLine: 15 },
+      { startLine: 25, endLine: 27 },
     ],
   }),
 

--- a/app/utils/code-mirror-themes.ts
+++ b/app/utils/code-mirror-themes.ts
@@ -159,6 +159,44 @@ const BASE_STYLE = {
     },
   },
 
+  // Expand collapsed ranges bar
+  '.cm-collapsedRanges': {
+    height: '1.75rem', // h7
+    borderTopWidth: '1px',
+    borderBottomWidth: '1px',
+    fontSize: '0.75rem', // text-xs
+    fontFamily: 'Montserrat, sans-serif',
+    lineHeight: '1rem', // text-xs
+    background: tailwindColors.sky['50'],
+    color: tailwindColors.sky['700'],
+    borderColor: tailwindColors.sky['100'],
+
+    '&:hover': {
+      background: tailwindColors.sky['100'],
+      color: tailwindColors.sky['800'],
+    },
+
+    '&:before': {
+      content: 'none',
+    },
+
+    '&:after': {
+      content: 'none',
+    },
+
+    '&:first-child': {
+      borderTop: 'none',
+      marginTop: '-0.5rem',
+      marginBottom: '0.5rem',
+    },
+
+    '&:last-child': {
+      borderBottom: 'none',
+      marginTop: '0.5rem',
+      marginBottom: '-0.5rem',
+    },
+  },
+
   // All lines in the document
   '.cm-line': {
     lineHeight: '1.5rem',
@@ -251,6 +289,18 @@ export const codeCraftersDark = [
 
       // Expand unchanged lines bar
       '.cm-collapsedLines': {
+        background: blendColors(tailwindColors.sky['900'], 0.4, tailwindColors.slate['800']),
+        color: tailwindColors.sky['400'],
+        borderColor: blendColors(tailwindColors.white, 0.075, blendColors(tailwindColors.sky['900'], 0.4, tailwindColors.slate['800'])),
+
+        '&:hover': {
+          background: blendColors(tailwindColors.sky['800'], 0.4, tailwindColors.slate['800']),
+          color: tailwindColors.sky['300'],
+        },
+      },
+
+      // Expand collapsed ranges bar
+      '.cm-collapsedRanges': {
         background: blendColors(tailwindColors.sky['900'], 0.4, tailwindColors.slate['800']),
         color: tailwindColors.sky['400'],
         borderColor: blendColors(tailwindColors.white, 0.075, blendColors(tailwindColors.sky['900'], 0.4, tailwindColors.slate['800'])),

--- a/app/utils/code-mirror-themes.ts
+++ b/app/utils/code-mirror-themes.ts
@@ -116,6 +116,46 @@ const BASE_STYLE = {
     },
   },
 
+  // Collapse ranges gutter
+  '.cm-collapseRangesGutter': {
+    '& .cm-gutterElement': {
+      '& .cm-collapseRangesGutterElement': {
+        position: 'absolute',
+        left: 0,
+        right: 0,
+        height: '1.75rem',
+        borderTopWidth: '1px',
+        borderBottomWidth: '1px',
+        borderColor: tailwindColors.sky['100'],
+        backgroundColor: tailwindColors.sky['50'],
+        backgroundImage: 'url("/assets/images/codemirror/expand-diff-middle.svg")',
+        backgroundRepeat: 'no-repeat',
+        backgroundPosition: 'center',
+        backgroundSize: '12px 12px',
+        cursor: 'pointer',
+
+        '&.cm-collapseRangesGutterElementFirst': {
+          borderTop: 'none',
+          marginTop: '-0.5rem',
+          backgroundImage: 'url("/assets/images/codemirror/expand-diff-top.svg")',
+        },
+
+        '&.cm-collapseRangesGutterElementLast': {
+          borderBottom: 'none',
+          marginTop: '0.5rem',
+          backgroundImage: 'url("/assets/images/codemirror/expand-diff-bottom.svg")',
+        },
+      },
+
+      '&:hover': {
+        '& .cm-collapseRangesGutterElement': {
+          backgroundColor: tailwindColors.sky['100'],
+          color: tailwindColors.sky['800'],
+        },
+      },
+    },
+  },
+
   // Document content area
   '.cm-content': {
     padding: '0.5rem 0',
@@ -280,6 +320,32 @@ export const codeCraftersDark = [
 
           '&:hover': {
             '& .cm-collapseUnchangedGutterElement': {
+              backgroundColor: blendColors(tailwindColors.sky['800'], 0.4, tailwindColors.slate['800']),
+              color: tailwindColors.sky['300'],
+            },
+          },
+        },
+      },
+
+      // Collapse ranges gutter
+      '.cm-collapseRangesGutter': {
+        '& .cm-gutterElement': {
+          '& .cm-collapseRangesGutterElement': {
+            borderColor: blendColors(tailwindColors.white, 0.075, blendColors(tailwindColors.sky['900'], 0.4, tailwindColors.slate['800'])),
+            backgroundColor: blendColors(tailwindColors.sky['900'], 0.4, tailwindColors.slate['800']),
+            backgroundImage: 'url("/assets/images/codemirror/expand-diff-middle-dark.svg")',
+
+            '&.cm-collapseRangesGutterElementFirst': {
+              backgroundImage: 'url("/assets/images/codemirror/expand-diff-top-dark.svg")',
+            },
+
+            '&.cm-collapseRangesGutterElementLast': {
+              backgroundImage: 'url("/assets/images/codemirror/expand-diff-bottom-dark.svg")',
+            },
+          },
+
+          '&:hover': {
+            '& .cm-collapseRangesGutterElement': {
               backgroundColor: blendColors(tailwindColors.sky['800'], 0.4, tailwindColors.slate['800']),
               color: tailwindColors.sky['300'],
             },

--- a/tests/integration/components/code-mirror-test.js
+++ b/tests/integration/components/code-mirror-test.js
@@ -242,6 +242,18 @@ module('Integration | Component | code-mirror', function (hooks) {
       skip('it does something useful with the editor');
     });
 
+    module('collapsedRanges', function () {
+      test("it doesn't break the editor when passed", async function (assert) {
+        this.set('collapsedRanges', []);
+        await render(hbs`<CodeMirror @collapsedRanges={{this.collapsedRanges}} />`);
+        assert.ok(codeMirror.hasRendered);
+        this.set('collapsedRanges', [{ startLine: 1, endLine: 1 }]);
+        assert.ok(codeMirror.hasRendered);
+      });
+
+      skip('it does something useful with the editor');
+    });
+
     module('highlightNewlines', function () {
       test("it doesn't break the editor when passed", async function (assert) {
         this.set('highlightNewlines', true);


### PR DESCRIPTION
Depends on https://github.com/codecrafters-io/frontend/pull/2838
Closes #2833 

### Brief

This adds support for collapsing line ranges via `@collapsedRanges` argument to `CodeMirror`, `FileDiffCard`, and `FileContentsCard` components.

### Details

https://github.com/user-attachments/assets/b050ca32-7b2c-4442-b99d-0b6cb6478202

### Checklist

- [x] I've thoroughly self-reviewed my changes
- [x] I've added tests for my changes, unless they affect admin-only areas (or are otherwise not worth testing)
- [x] I've verified any visual changes using Percy (add a commit with `[percy]` in the message to trigger)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for collapsing specified line ranges in code editors and diff views, with interactive gutter controls for expanding collapsed sections.
  - Introduced UI options to toggle collapsed ranges in demo and file views.
- **Style**
  - Added new visual styles for collapsed range gutters and expand bars, supporting both light and dark themes.
- **Tests**
  - Added integration tests to verify the stability of the collapsed ranges feature.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- GitButler Footer Boundary Top -->
---
This is **part 1 of 2 in a stack** made with GitButler:
- <kbd>&nbsp;2&nbsp;</kbd> #2859 
- <kbd>&nbsp;1&nbsp;</kbd> #2850 👈 
<!-- GitButler Footer Boundary Bottom -->

