### PR TITLE
Revive publish to github button

### DIFF
--- a/app/components/course-page/course-stage-step/community-solution-card/changed-file-card.hbs
+++ b/app/components/course-page/course-stage-step/community-solution-card/changed-file-card.hbs
@@ -1,6 +1,6 @@
 <div
   class="bg-white dark:bg-gray-850 shadow-sm rounded border border-gray-300 dark:border-white/10"
-  data-test-community-solution-changed-file
+  data-test-community-solution-changed-file-card
   ...attributes
 >
   <div
@@ -22,7 +22,7 @@
           {{svg-jar "github" class="w-3.5 h-3.5 text-gray-600 dark:text-gray-400"}}
         </a>
       {{else if this.shouldShowPublishToGithubButton}}
-        <button type="button" {{on "click" this.handlePublishToGithubButtonClick}} class="flex gap-x-1 items-center group">
+        <button type="button" {{on "click" @onPublishToGithubButtonClick}} class="flex gap-x-1 items-center group" data-test-publish-to-github-button>
           <span class="text-[10px] text-gray-700 dark:text-gray-300 group-hover:underline">
             Publish to GitHub
           </span>

--- a/app/components/course-page/course-stage-step/community-solution-card/changed-file-card.ts
+++ b/app/components/course-page/course-stage-step/community-solution-card/changed-file-card.ts
@@ -1,5 +1,4 @@
 import Component from '@glimmer/component';
-import { action } from '@ember/object';
 import { inject as service } from '@ember/service';
 import type AuthenticatorService from 'codecrafters-frontend/services/authenticator';
 import type CommunityCourseStageSolution from 'codecrafters-frontend/models/community-course-stage-solution';

--- a/app/components/course-page/course-stage-step/community-solution-card/changed-file-card.ts
+++ b/app/components/course-page/course-stage-step/community-solution-card/changed-file-card.ts
@@ -9,6 +9,7 @@ interface Signature {
 
   Args: {
     changedFile: CommunityCourseStageSolution['changedFiles'][number];
+    onPublishToGithubButtonClick: () => void;
     solution: CommunityCourseStageSolution;
   };
 }
@@ -18,11 +19,6 @@ export default class ChangedFileCardComponent extends Component<Signature> {
 
   get shouldShowPublishToGithubButton(): boolean {
     return this.args.solution.user.id === this.authenticator.currentUser?.id && !this.args.solution.isPublishedToPublicGithubRepository;
-  }
-
-  @action
-  handlePublishToGithubButtonClick(): void {
-    // TODO: Implement publish to GitHub functionality
   }
 }
 

--- a/app/components/course-page/course-stage-step/community-solution-card/content.hbs
+++ b/app/components/course-page/course-stage-step/community-solution-card/content.hbs
@@ -13,6 +13,7 @@
 {{#each this.changedFilesForRender key="filename" as |changedFile index|}}
   <CoursePage::CourseStageStep::CommunitySolutionCard::ChangedFileCard
     @changedFile={{changedFile}}
+    @onPublishToGithubButtonClick={{this.handlePublishToGithubButtonClick}}
     @solution={{@solution}}
     class={{if (not-eq index (sub @solution.changedFiles.length 1)) "mb-4"}}
   />

--- a/tests/acceptance/course-page/code-examples/publish-to-github-test.js
+++ b/tests/acceptance/course-page/code-examples/publish-to-github-test.js
@@ -1,0 +1,42 @@
+import catalogPage from 'codecrafters-frontend/tests/pages/catalog-page';
+import codeExamplesPage from 'codecrafters-frontend/tests/pages/course/code-examples-page';
+import coursePage from 'codecrafters-frontend/tests/pages/course-page';
+import createCommunityCourseStageSolution from 'codecrafters-frontend/mirage/utils/create-community-course-stage-solution';
+import testScenario from 'codecrafters-frontend/mirage/scenarios/test';
+import { setupAnimationTest } from 'ember-animated/test-support';
+import { module, test } from 'qunit';
+import { setupApplicationTest } from 'codecrafters-frontend/tests/helpers';
+import { signIn } from 'codecrafters-frontend/tests/support/authentication-helpers';
+
+module('Acceptance | course-page | code-examples | publish-to-github', function (hooks) {
+  setupApplicationTest(hooks);
+  setupAnimationTest(hooks);
+
+  test('can publish to GitHub if unpublished', async function (assert) {
+    testScenario(this.server);
+    const currentUser = signIn(this.owner, this.server);
+
+    let redis = this.server.schema.courses.findBy({ slug: 'redis' });
+    let python = this.server.schema.languages.findBy({ slug: 'python' });
+
+    this.server.create('repository', 'withFirstStageCompleted', {
+      course: redis,
+      language: python,
+      user: currentUser,
+    });
+
+    createCommunityCourseStageSolution(this.server, redis, 2, python);
+
+    await catalogPage.visit();
+    await catalogPage.clickOnCourse('Build your own Redis');
+    await coursePage.sidebar.clickOnStepListItem('Respond to PING');
+    await coursePage.clickOnHeaderTabLink('Code Examples');
+
+    assert.notOk(coursePage.configureGithubIntegrationModal.isVisible, 'configure github integration modal should not be visible');
+
+    await codeExamplesPage.solutionCards[0].changedFileCards[0].clickOnPublishToGithubButton();
+    assert.ok(coursePage.configureGithubIntegrationModal.isVisible, 'configure github integration modal should be visible');
+
+    // The rest is tested in course-page/publish-to-github-test.js
+  });
+});

--- a/tests/acceptance/course-page/code-examples/view-test.js
+++ b/tests/acceptance/course-page/code-examples/view-test.js
@@ -182,7 +182,7 @@ module('Acceptance | course-page | code-examples | view', function (hooks) {
     await coursePage.sidebar.clickOnStepListItem('Respond to PING');
     await coursePage.yourTaskCard.clickOnActionButton('Code Examples');
 
-    assert.strictEqual(codeExamplesPage.solutionCards[0].changedFiles.length, 2, 'shows 2 changed files');
+    assert.strictEqual(codeExamplesPage.solutionCards[0].changedFileCards.length, 2, 'shows 2 changed files');
     assert.strictEqual(codeExamplesPage.solutionCards[0].unchangedFiles.length, 2, 'shows 2 unchanged files');
 
     await codeExamplesPage.solutionCards[0].unchangedFiles[0].header.click();

--- a/tests/pages/course-page.ts
+++ b/tests/pages/course-page.ts
@@ -52,7 +52,8 @@ export default create({
   configureExtensionsModal: ConfigureExtensionsModal,
 
   configureGithubIntegrationModal: {
-    get isOpen() {
+    get isOpen(): boolean {
+      // @ts-expect-error isVisible is not typed
       return this.isVisible;
     },
 
@@ -82,7 +83,8 @@ export default create({
   },
 
   deleteRepositoryModal: {
-    get isOpen() {
+    get isOpen(): boolean {
+      // @ts-expect-error isVisible is not typed
       return this.isVisible;
     },
 
@@ -183,6 +185,7 @@ export default create({
 
   testRunnerCard: {
     async clickOnMarkStageAsCompleteButton() {
+      // @ts-expect-error markStageAsCompleteButton is not typed
       await this.markStageAsCompleteButton.click();
     },
 

--- a/tests/pages/course/code-examples-page.ts
+++ b/tests/pages/course/code-examples-page.ts
@@ -9,7 +9,9 @@ export default createPage({
   scope: '[data-test-code-examples-page]',
 
   solutionCards: collection('[data-test-community-solution-card]', {
-    changedFiles: collection('[data-test-community-solution-changed-file]'),
+    changedFileCards: collection('[data-test-community-solution-changed-file-card]', {
+      clickOnPublishToGithubButton: clickable('[data-test-publish-to-github-button]'),
+    }),
     clickOnExpandButton: clickable('[data-test-expand-button]'),
     collapseButtons: collection('[data-test-collapse-button]'),
     commentCards: collection('[data-test-comment-card]', CommentCard),


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added the ability to initiate publishing a code example to GitHub directly from the course page if it is unpublished.

- **Bug Fixes**
  - Updated test selectors and button handling to improve reliability and consistency in user interactions.

- **Tests**
  - Introduced new acceptance tests to verify the "publish to GitHub" functionality for code examples.
  - Updated existing tests to align with new selectors and improve accuracy.

- **Style**
  - Improved test selector naming for clarity.

- **Chores**
  - Enhanced TypeScript type annotations and error handling in test utilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->