### PR TITLE
Add changed line counts to metadata

### DIFF
--- a/app/components/course-admin/code-example-insights/metadata-container.ts
+++ b/app/components/course-admin/code-example-insights/metadata-container.ts
@@ -53,6 +53,7 @@ export default class CodeExampleInsightsMetadataComponent extends Component<Sign
     }
 
     lines.push(`* ± ${this.args.solution.changedLinesCount} lines changed`);
+    lines.push(`* ⚡︎ ${this.args.solution.highlightedLinesCount} lines highlighted`);
 
     return lines.join('\n');
   }

--- a/app/models/community-course-stage-solution.ts
+++ b/app/models/community-course-stage-solution.ts
@@ -37,13 +37,16 @@ export default class CommunityCourseStageSolutionModel extends Model.extend(View
   // @ts-expect-error empty '' not supported
   @attr('') highlightedFiles: { filename: string; contents: string; highlighted_ranges: { start_line: number; end_line: number }[] }[] | null; // free-form JSON
 
+  @attr('number') declare addedLinesCount: number;
   @attr('number') declare approvedCommentsCount: number;
   @attr('string') declare explanationMarkdown: string;
   @attr('string') declare commitSha: string;
   @attr('string') declare githubRepositoryName: string;
   @attr('boolean') declare githubRepositoryIsPrivate: boolean;
+  @attr('number') declare highlightedLinesCount: number;
   @attr('boolean') declare isPinned: boolean;
   @attr('number') declare ratingMean: number | null;
+  @attr('number') declare removedLinesCount: number;
   @attr('number') declare score: number | null;
   @attr('string') declare scoreReason: 'concise' | 'pinned' | null;
   @attr('date') declare submittedAt: Date;
@@ -72,17 +75,7 @@ export default class CommunityCourseStageSolutionModel extends Model.extend(View
   }
 
   get changedLinesCount() {
-    let added = 0,
-      removed = 0;
-
-    for (const changedFile of this.changedFiles) {
-      const diff = changedFile['diff'];
-      const lines = diff.split('\n');
-      added += lines.filter((line: string) => line.startsWith('+')).length;
-      removed += lines.filter((line: string) => line.startsWith('-')).length;
-    }
-
-    return added + removed;
+    return this.addedLinesCount + this.removedLinesCount;
   }
 
   // We don't render explanations at the moment


### PR DESCRIPTION
Add `highlightedLinesCount`, `addedLinesCount`, and `removedLinesCount` 
attributes to track solution changes effectively. Update the `changedLinesCount` 
getter to return the sum of added and removed lines using the new attributes. 
Include highlighted lines count in the insights display for better visibility 
of code modifications.