### PR TITLE
fix: update community solution card logic for highlighted files

### DIFF
--- a/app/components/course-page/course-stage-step/community-solution-card/index.ts
+++ b/app/components/course-page/course-stage-step/community-solution-card/index.ts
@@ -49,7 +49,8 @@ export default class CommunitySolutionCardComponent extends Component<Signature>
       this.loadAsyncResources.perform();
     }
 
-    if (this.authenticator.currentUser?.isStaff && this.args.solution.highlightedFiles && this.args.solution.highlightedFiles.length > 0) {
+    // We still haven't migrated all solutions to have highlighted files, some only have changed files
+    if (this.args.solution.highlightedFiles && this.args.solution.highlightedFiles.length > 0) {
       this.diffSource = 'highlighted-files';
     }
   }

--- a/app/components/course-page/course-stage-step/community-solution-card/more-dropdown.hbs
+++ b/app/components/course-page/course-stage-step/community-solution-card/more-dropdown.hbs
@@ -6,7 +6,7 @@
   </dd.Trigger>
   <dd.Content>
     <div class="py-2 border dark:border-white/10 rounded shadow bg-white dark:bg-gray-850" data-test-more-dropdown-content>
-      {{#if (and (current-user-is-staff) @solution.highlightedFiles)}}
+      {{#if (gt @solution.highlightedFiles.length 0)}}
         {{#if (eq @diffSource "highlighted-files")}}
           <DropdownLink @text="View full diff" @icon="switch-horizontal" {{on "click" (fn this.handleViewFullDiffLinkClick dd.actions)}} />
         {{else}}

--- a/tests/acceptance/course-page/code-examples/publish-to-github-test.js
+++ b/tests/acceptance/course-page/code-examples/publish-to-github-test.js
@@ -34,7 +34,7 @@ module('Acceptance | course-page | code-examples | publish-to-github', function 
 
     assert.notOk(coursePage.configureGithubIntegrationModal.isVisible, 'configure github integration modal should not be visible');
 
-    await codeExamplesPage.solutionCards[0].changedFileCards[0].clickOnPublishToGithubButton();
+    await codeExamplesPage.solutionCards[0].highlightedFileCards[0].clickOnPublishToGithubButton();
     assert.ok(coursePage.configureGithubIntegrationModal.isVisible, 'configure github integration modal should be visible');
 
     // The rest is tested in course-page/publish-to-github-test.js

--- a/tests/acceptance/course-page/code-examples/view-test.js
+++ b/tests/acceptance/course-page/code-examples/view-test.js
@@ -182,6 +182,9 @@ module('Acceptance | course-page | code-examples | view', function (hooks) {
     await coursePage.sidebar.clickOnStepListItem('Respond to PING');
     await coursePage.yourTaskCard.clickOnActionButton('Code Examples');
 
+    await codeExamplesPage.solutionCards[0].toggleMoreDropdown();
+    await codeExamplesPage.solutionCards[0].moreDropdown.clickOnLink('View full diff');
+
     assert.strictEqual(codeExamplesPage.solutionCards[0].changedFileCards.length, 2, 'shows 2 changed files');
     assert.strictEqual(codeExamplesPage.solutionCards[0].unchangedFiles.length, 2, 'shows 2 unchanged files');
 

--- a/tests/pages/course/code-examples-page.ts
+++ b/tests/pages/course/code-examples-page.ts
@@ -21,6 +21,10 @@ export default createPage({
     collapseButtons: collection('[data-test-collapse-button]'),
     commentCards: collection('[data-test-comment-card]', CommentCard),
 
+    highlightedFileCards: collection('[data-test-community-solution-highlighted-file-card]', {
+      clickOnPublishToGithubButton: clickable('[data-test-publish-to-github-button]'),
+    }),
+
     downvoteButton: {
       hover: triggerable('mouseenter'),
       isInactive: hasClass('opacity-50'),


### PR DESCRIPTION
Refactor the logic for displaying highlighted files in the community 
solution card. Remove the dependency on the current user being staff 
for the presence of highlighted files to ensure compatibility with 
solutions that may not have been migrated yet. Update the template 
to directly check the length of highlightedFiles, improving code 
clarity and maintaining proper functionality across variations of 
solutions.