### PR TITLE
Remove unnecessary language selection message from insights page

### DIFF
--- a/app/templates/course-admin/code-example-insights-index.hbs
+++ b/app/templates/course-admin/code-example-insights-index.hbs
@@ -10,15 +10,6 @@
         </div>
       </div>
       <div>
-        {{#if @model.selectedLanguage}}
-          <div class="flex items-center gap-2">
-            <div class="text-sm text-gray-400">
-              Showing insights for
-              <span class="font-semibold text-gray-600">{{@model.selectedLanguage.name}}</span>
-            </div>
-          </div>
-        {{/if}}
-
         <LanguageDropdown
           @languages={{@model.languages}}
           @onRequestedLanguageChange={{this.onLanguageChange}}


### PR DESCRIPTION
Eliminate the language selection message from the insights page to streamline the user interface.

**Checklist**:

- [x] I've thoroughly self-reviewed my changes
- [ ] I've added tests for my changes, unless they affect admin-only areas (or are otherwise not worth testing)
- [ ] I've verified any visual changes using Percy (add a commit with `[percy]` in the message to trigger)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Removed the display of the currently selected language above the language dropdown on the insights page. The dropdown functionality remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->