### PR TITLE
Update language dropdown to use sorted languages on code examples insights index page

### DIFF
--- a/app/controllers/course-admin/code-example-insights-index.ts
+++ b/app/controllers/course-admin/code-example-insights-index.ts
@@ -12,6 +12,10 @@ export default class CodeExampleInsightsIndexController extends Controller {
 
   declare model: ModelType;
 
+  get sortedLanguagesForDropdown() {
+    return this.model.course.betaOrLiveLanguages.sortBy('name');
+  }
+
   @action
   onLanguageChange(language: LanguageModel) {
     this.router.transitionTo({

--- a/app/controllers/course-admin/code-example-insights.ts
+++ b/app/controllers/course-admin/code-example-insights.ts
@@ -50,6 +50,10 @@ export default class CodeExampleInsightsController extends Controller {
     }
   }
 
+  get sortedLanguagesForDropdown() {
+    return this.model.courseStage.course.betaOrLiveLanguages.sortBy('name');
+  }
+
   get sortedSolutions(): CommunityCourseStageSolutionModel[] {
     // The API handles the sorting order
     return this.model.solutions;

--- a/app/templates/course-admin/code-example-insights-index.hbs
+++ b/app/templates/course-admin/code-example-insights-index.hbs
@@ -11,7 +11,7 @@
       </div>
       <div>
         <LanguageDropdown
-          @languages={{@model.languages}}
+          @languages={{this.sortedLanguagesForDropdown}}
           @onRequestedLanguageChange={{this.onLanguageChange}}
           @requestedLanguage={{@model.selectedLanguage}}
           @selectedLanguage={{@model.selectedLanguage}}

--- a/app/templates/course-admin/code-example-insights.hbs
+++ b/app/templates/course-admin/code-example-insights.hbs
@@ -26,7 +26,7 @@
           @onSelectedCourseStageChange={{this.handleCourseStageChange}}
         />
         <LanguageDropdown
-          @languages={{@model.courseStage.course.betaOrLiveLanguages}}
+          @languages={{this.sortedLanguagesForDropdown}}
           @onRequestedLanguageChange={{this.handleRequestedLanguageChange}}
           @requestedLanguage={{@model.language}}
           @selectedLanguage={{@model.language}}


### PR DESCRIPTION
**Checklist**:

- [x] I've thoroughly self-reviewed my changes
- [ ] I've added tests for my changes, unless they affect admin-only areas (or are otherwise not worth testing)
- [ ] I've verified any visual changes using Percy (add a commit with `[percy]` in the message to trigger)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - The language dropdown in the course code example insights page now displays languages sorted by name for easier selection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->