### PR TITLE
Implement feedback section visibility logic based on scoring and ownership

### DIFF
--- a/app/components/course-page/course-stage-step/community-solution-card/content.hbs
+++ b/app/components/course-page/course-stage-step/community-solution-card/content.hbs
@@ -61,12 +61,12 @@
     </FileContentsCard>
   {{/each}}
 
-  {{#unless (eq @solution.user this.authenticator.currentUser)}}
+  {{#if this.shouldShowFeedbackSection}}
     <CoursePage::CourseStageStep::CommunitySolutionCard::FeedbackSection
       @metadataForDownvote={{@metadataForDownvote}}
       @metadataForUpvote={{@metadataForUpvote}}
       @solution={{@solution}}
       class="pt-6 pb-3"
     />
-  {{/unless}}
+  {{/if}}
 </div>

--- a/app/components/course-page/course-stage-step/community-solution-card/content.ts
+++ b/app/components/course-page/course-stage-step/community-solution-card/content.ts
@@ -49,6 +49,13 @@ export default class CommunitySolutionCardContentComponent extends Component<Sig
     return false;
   }
 
+  get shouldShowFeedbackSection() {
+    const isScored = (this.args.solution.score ?? 0) > 0;
+    const isNotOwner = this.currentUser.id !== this.args.solution.user.id;
+
+    return isScored && isNotOwner;
+  }
+
   get shouldShowPublishToGithubButton() {
     return this.isCurrentUserSolution && !this.args.solution.isPublishedToGithub;
   }


### PR DESCRIPTION
Introduce logic to control the visibility of the feedback section based on the solution's score and the ownership status of the current user.

**Checklist**:

- [ ] I've thoroughly self-reviewed my changes
- [ ] I've added tests for my changes, unless they affect admin-only areas (or are otherwise not worth testing)
- [ ] I've verified any visual changes using Percy (add a commit with `[percy]` in the message to trigger)
