### PR TITLE
refactor(faq-list): replace HTML answers with Markdown

### DIFF
--- a/app/components/faq-item.hbs
+++ b/app/components/faq-item.hbs
@@ -17,7 +17,6 @@
   {{#if @isOpen}}
     <div class="w-full h-px bg-gray-200 mt-3 mb-4">
     </div>
-    {{! template-lint-disable no-triple-curlies }}
-    <div class="prose dark:prose-invert prose-sm sm:prose-base">{{{@faq.answer}}}</div>
+    <div class="prose dark:prose-invert prose-sm sm:prose-base">{{markdown-to-html @faq.answerMarkdown}}</div>
   {{/if}}
 </div>

--- a/app/components/faq-list.ts
+++ b/app/components/faq-list.ts
@@ -4,7 +4,7 @@ import { tracked } from '@glimmer/tracking';
 
 export type Faq = {
   query: string;
-  answer: string;
+  answerMarkdown: string;
 };
 
 interface Signature {
@@ -17,51 +17,49 @@ export default class FaqListComponent extends Component<Signature> {
   faqs: Faq[] = [
     {
       query: 'How many challenges do you offer?',
-      answer: `<p>We currently offer 10 challenges comprising of 250+ stages and support 22 programming languages.</p>
+      answerMarkdown: `We currently offer 10 challenges comprising of 250+ stages and support 22 programming languages.
 
-<ul>
-<li>Build Your Own Redis</li>
-<li>Build Your Own Git</li>
-<li>Build Your Own SQLite</li>
-<li>Build Your Own grep</li>
-<li>Build Your Own BitTorrent</li>
-<li>Build Your Own HTTP Server</li>
-<li>Build Your Own DNS Server</li>
-<li>Build Your Own Shell</li>
-<li>Build Your Own Interpreter</li>
-<li>Build Your Own Kafka</li>
-</ul>
+* Build Your Own Redis
+* Build Your Own Git
+* Build Your Own SQLite
+* Build Your Own grep
+* Build Your Own BitTorrent
+* Build Your Own HTTP Server
+* Build Your Own DNS Server
+* Build Your Own Shell
+* Build Your Own Interpreter
+* Build Your Own Kafka
 
-<p>If we launch new challenges during your membership, you get access to those too. Visit <a href="https://app.codecrafters.io/catalog" target="_blank" class="underline" rel="noopener noreferrer">our catalog</a> to check each individual challenge in detail.</p>`,
+If we launch new challenges during your membership, you get access to those too. Visit [our catalog](https://app.codecrafters.io/catalog) to check each individual challenge in detail.`,
     },
     {
       query: 'Why the Team Plan over the Individual Membership?',
-      answer: 'The Team Plan gives you swappable spots to share among your team. Finished all challenges? Pass your spot to a teammate.',
+      answerMarkdown: 'The Team Plan gives you swappable spots to share among your team. Finished all challenges? Pass your spot to a teammate.',
     },
     {
       query: 'Is there a free trial?',
-      answer: `<p>We always have at least one challenge available for free. You can easily find them highlighted in <a href="https://app.codecrafters.io/catalog" target="_blank" class="underline" rel="noopener noreferrer">our catalog</a>.</p>
-    
-    <p>Additionally, you can explore the detailed breakdowns of all our challenges without signing up. You can also view the task descriptions for every challenge without hitting a paywall.</p>`,
+      answerMarkdown: `We always have at least one challenge available for free. You can easily find them highlighted in [our catalog](https://app.codecrafters.io/catalog).
+
+Additionally, you can explore the detailed breakdowns of all our challenges without signing up. You can also view the task descriptions for every challenge without hitting a paywall.`,
     },
     {
       query: 'Is there a recurring payment?',
-      answer: 'Nope, just a one-time payment for unlimited access during your membership period.',
+      answerMarkdown: 'Nope, just a one-time payment for unlimited access during your membership period.',
     },
     {
       query: 'How about refunds?',
-      answer:
+      answerMarkdown:
         "We don't offer refunds. You can freely explore our curriculum without a paywall, and also test drive a couple of stages per course, without providing any card details.",
     },
     {
       query: "This is great but it's too expensive",
-      answer: `<p>We understand the cost consideration today but investing in your technical skills is one of the highest ROI activities you can do. It has a direct impact on your earning potential.</p>
-    
-    <p>We’ve spoken with hundreds of our paid users about their experience before CodeCrafters. They’d spend weeks window-shopping for project ideas, trying to piece together resources, getting lost in “tutorial hell”, and realizing too late that their plans missed key details. Instead of wasting weeks or sometimes months’ worth of time, our users prefer to start right away with CodeCrafters, pushing code, refining their skills, and following our proven, battle-tested guidance.</p>
-    
-    <p>If you’re early in your career or still a student working with limited budgets, focusing on foundational skills might be more appropriate before investing in CodeCrafters, which is designed for those who already have a job and are ready to push their limits.</p>
-    
-    <p>Many companies allow employees to expense CodeCrafters as part of their learning and development budget, yours might too. <a href="https://codecrafters.io/expense" target="_blank" class="underline" rel="noopener noreferrer">Read more about that here</a>.</p>`,
+      answerMarkdown: `We understand the cost consideration today but investing in your technical skills is one of the highest ROI activities you can do. It has a direct impact on your earning potential.
+
+We've spoken with hundreds of our paid users about their experience before CodeCrafters. They'd spend weeks window-shopping for project ideas, trying to piece together resources, getting lost in "tutorial hell", and realizing too late that their plans missed key details. Instead of wasting weeks or sometimes months' worth of time, our users prefer to start right away with CodeCrafters, pushing code, refining their skills, and following our proven, battle-tested guidance.
+
+If you're early in your career or still a student working with limited budgets, focusing on foundational skills might be more appropriate before investing in CodeCrafters, which is designed for those who already have a job and are ready to push their limits.
+
+Many companies allow employees to expense CodeCrafters as part of their learning and development budget, yours might too. [Read more about that here](https://codecrafters.io/expense).`,
     },
   ];
 


### PR DESCRIPTION
Update FAQ answers to use Markdown instead of HTML. This change 
improves readability, enables easier formatting, and enhances 
consistency across FAQ entries. All instances of the answer field 
are replaced with answerMarkdown, allowing for better 
presentation of content.