### PR TITLE
Update invoice handling to use receipt URL

### DIFF
--- a/app/components/settings/billing-page/payment-history-section.hbs
+++ b/app/components/settings/billing-page/payment-history-section.hbs
@@ -42,15 +42,15 @@
             {{/if}}
           </div>
           <div class="flex items-center justify-end">
-            {{#if (and charge.invoiceId charge.statusIsSucceeded)}}
+            {{#if (and charge.receiptUrl charge.statusIsSucceeded)}}
               <a
-                href={{charge.invoiceDownloadUrl}}
+                href={{charge.receiptUrl}}
                 target="_blank"
                 class="text-teal-500 dark:text-teal-400 hover:text-teal-600 dark:hover:text-teal-300 font-semibold text-sm"
                 data-test-download-invoice-link
                 rel="noopener noreferrer"
               >
-                Download Invoice
+                View Invoice
               </a>
             {{else if charge.statusIsFailed}}
               <span class="text-gray-600 dark:text-gray-300 text-sm">Payment failed</span>

--- a/app/models/charge.ts
+++ b/app/models/charge.ts
@@ -1,5 +1,4 @@
 import Model, { attr, belongsTo } from '@ember-data/model';
-import config from 'codecrafters-frontend/config/environment';
 import type UserModel from 'codecrafters-frontend/models/user';
 import { equal } from '@ember/object/computed'; // eslint-disable-line ember/no-computed-properties-in-native-classes
 
@@ -10,7 +9,7 @@ export default class Charge extends Model {
   @attr('number') declare amountRefunded: number;
   @attr('date') declare createdAt: Date;
   @attr('string') declare currency: string;
-  @attr('string') declare invoiceId: string;
+  @attr('string') declare receiptUrl: string;
   @attr('string') declare status: 'succeeded' | 'pending' | 'failed';
 
   @belongsTo('user', { async: false, inverse: null }) declare user: UserModel;
@@ -21,14 +20,6 @@ export default class Charge extends Model {
 
   get displayString() {
     return Charge.buildDisplayString(this.amount, this.currency);
-  }
-
-  get invoiceDownloadUrl() {
-    if (!this.invoiceId) {
-      return null;
-    }
-
-    return `${config.x.backendUrl}/invoices/${this.invoiceId}/download`;
   }
 
   get isFullyRefunded() {


### PR DESCRIPTION
- Changed the invoice download link to use the receipt URL instead of the invoice ID.
- Updated the link text from "Download Invoice" to "View Invoice" for clarity.
- Removed the obsolete invoice download URL method from the Charge model.

**Checklist**:

- [ ] I've thoroughly self-reviewed my changes
- [ ] I've added tests for my changes, unless they affect admin-only areas (or are otherwise not worth testing)
- [ ] I've verified any visual changes using Percy (add a commit with `[percy]` in the message to trigger)
