### PR TITLE
CC-1755: Add export functionality for viewing community solutions on GitHub

### DIFF
--- a/app/adapters/community-solution-export.ts
+++ b/app/adapters/community-solution-export.ts
@@ -1,0 +1,11 @@
+import ApplicationAdapter from './application';
+
+export default class CommunitySolutionExportAdapter extends ApplicationAdapter {
+  urlForCreateRecord() {
+    return `${this.buildURL()}/community-solution-exports`;
+  }
+
+  urlForUpdateRecord(id: string) {
+    return `${this.buildURL()}/community-solution-exports/${id}/mark-as-accessed`;
+  }
+}

--- a/app/components/course-page/course-stage-step/community-solution-card/changed-file-card.hbs
+++ b/app/components/course-page/course-stage-step/community-solution-card/changed-file-card.hbs
@@ -21,8 +21,35 @@
           </span>
           {{svg-jar "github" class="w-3.5 h-3.5 text-gray-600 dark:text-gray-400"}}
         </a>
-      {{else if this.shouldShowPublishToGithubButton}}
-        <button type="button" {{on "click" @onPublishToGithubButtonClick}} class="flex gap-x-1 items-center group" data-test-publish-to-github-button>
+      {{else}}
+        <button
+          type="button"
+          {{on "click" this.handleViewOnGithubClick}}
+          class="flex gap-x-1 items-center group"
+          data-test-view-on-github-button
+          disabled={{this.isCreatingExport}}
+        >
+          {{#if this.isCreatingExport}}
+            <span class="text-[10px] text-gray-700 dark:text-gray-300">
+              Creating export...
+            </span>
+            <div class="w-3.5 h-3.5 border-2 border-gray-400 border-t-transparent rounded-full animate-spin"></div>
+          {{else}}
+            <span class="text-[10px] text-gray-700 dark:text-gray-300 group-hover:underline">
+              View on GitHub
+            </span>
+            {{svg-jar "github" class="w-3.5 h-3.5 text-gray-600 dark:text-gray-400"}}
+          {{/if}}
+        </button>
+      {{/if}}
+
+      {{#if this.shouldShowPublishToGithubButton}}
+        <button
+          type="button"
+          {{on "click" @onPublishToGithubButtonClick}}
+          class="flex gap-x-1 items-center group ml-2"
+          data-test-publish-to-github-button
+        >
           <span class="text-[10px] text-gray-700 dark:text-gray-300 group-hover:underline">
             Publish to GitHub
           </span>

--- a/app/components/course-page/course-stage-step/community-solution-card/changed-file-card.ts
+++ b/app/components/course-page/course-stage-step/community-solution-card/changed-file-card.ts
@@ -1,7 +1,10 @@
 import Component from '@glimmer/component';
 import { inject as service } from '@ember/service';
+import { tracked } from '@glimmer/tracking';
+import { action } from '@ember/object';
 import type AuthenticatorService from 'codecrafters-frontend/services/authenticator';
 import type CommunityCourseStageSolution from 'codecrafters-frontend/models/community-course-stage-solution';
+import type CommunitySolutionExportModel from 'codecrafters-frontend/models/community-solution-export';
 
 interface Signature {
   Element: HTMLDivElement;
@@ -16,8 +19,93 @@ interface Signature {
 export default class ChangedFileCardComponent extends Component<Signature> {
   @service declare authenticator: AuthenticatorService;
 
+  @tracked isCreatingExport = false;
+
   get shouldShowPublishToGithubButton(): boolean {
     return this.args.solution.user.id === this.authenticator.currentUser?.id && !this.args.solution.isPublishedToPublicGithubRepository;
+  }
+
+  @action
+  async handleViewOnGithubClick(): Promise<void> {
+    const solution = this.args.solution;
+
+    // Check if we have a current valid export
+    const currentExport = solution.currentExport;
+
+    if (currentExport && currentExport.isProvisioned && currentExport.baseUrl) {
+      // We have a provisioned export, mark as accessed and redirect
+      await solution.markExportAsAccessed(currentExport);
+      const url = `${currentExport.baseUrl}/${this.args.changedFile.filename}`;
+      window.open(url, '_blank', 'noopener,noreferrer');
+
+      return;
+    }
+
+    if (currentExport && currentExport.isProvisioning) {
+      // Export is still being created, wait for it to complete
+      this.isCreatingExport = true;
+
+      try {
+        await this.waitForExportCompletion(currentExport);
+
+        if (currentExport.isProvisioned && currentExport.baseUrl) {
+          await solution.markExportAsAccessed(currentExport);
+          const url = `${currentExport.baseUrl}/${this.args.changedFile.filename}`;
+          window.open(url, '_blank', 'noopener,noreferrer');
+        } else {
+          alert('Export is taking longer than expected. Please try again.');
+        }
+      } catch (error) {
+        console.error('Error waiting for export:', error);
+        alert('Export is taking longer than expected. Please try again.');
+      } finally {
+        this.isCreatingExport = false;
+      }
+
+      return;
+    }
+
+    // No valid export exists, create a new one
+    this.isCreatingExport = true;
+
+    try {
+      const newExport = await solution.createOrGetExport();
+
+      // Poll for completion if it's still provisioning
+      if (newExport.isProvisioning) {
+        await this.waitForExportCompletion(newExport);
+      }
+
+      if (newExport.isProvisioned && newExport.baseUrl) {
+        await solution.markExportAsAccessed(newExport);
+        const url = `${newExport.baseUrl}/${this.args.changedFile.filename}`;
+        window.open(url, '_blank', 'noopener,noreferrer');
+      } else {
+        alert('Failed to create export. Please try again.');
+      }
+    } catch (error) {
+      console.error('Error creating export:', error);
+      alert('Failed to create export. Please try again.');
+    } finally {
+      this.isCreatingExport = false;
+    }
+  }
+
+  private async waitForExportCompletion(exportModel: CommunitySolutionExportModel): Promise<void> {
+    const maxAttempts = 30; // 30 seconds timeout
+    let attempts = 0;
+
+    while (attempts < maxAttempts && exportModel.isProvisioning) {
+      await new Promise((resolve) => setTimeout(resolve, 1000)); // Wait 1 second
+
+      try {
+        await exportModel.reload();
+        attempts++;
+      } catch (error) {
+        console.error('Error reloading export:', error);
+        break;
+      }
+    }
   }
 }
 

--- a/app/components/course-page/course-stage-step/community-solution-card/highlighted-file-card.hbs
+++ b/app/components/course-page/course-stage-step/community-solution-card/highlighted-file-card.hbs
@@ -21,8 +21,35 @@
           </span>
           {{svg-jar "github" class="w-3.5 h-3.5 text-gray-600 dark:text-gray-400"}}
         </a>
-      {{else if this.shouldShowPublishToGithubButton}}
-        <button type="button" {{on "click" @onPublishToGithubButtonClick}} class="flex gap-x-1 items-center group" data-test-publish-to-github-button>
+      {{else}}
+        <button
+          type="button"
+          {{on "click" this.handleViewOnGithubClick}}
+          class="flex gap-x-1 items-center group"
+          data-test-view-on-github-button
+          disabled={{this.isCreatingExport}}
+        >
+          {{#if this.isCreatingExport}}
+            <span class="text-[10px] text-gray-700 dark:text-gray-300">
+              Creating export...
+            </span>
+            <div class="w-3.5 h-3.5 border-2 border-gray-400 border-t-transparent rounded-full animate-spin"></div>
+          {{else}}
+            <span class="text-[10px] text-gray-700 dark:text-gray-300 group-hover:underline">
+              View on GitHub
+            </span>
+            {{svg-jar "github" class="w-3.5 h-3.5 text-gray-600 dark:text-gray-400"}}
+          {{/if}}
+        </button>
+      {{/if}}
+
+      {{#if this.shouldShowPublishToGithubButton}}
+        <button
+          type="button"
+          {{on "click" @onPublishToGithubButtonClick}}
+          class="flex gap-x-1 items-center group ml-2"
+          data-test-publish-to-github-button
+        >
           <span class="text-[10px] text-gray-700 dark:text-gray-300 group-hover:underline">
             Publish to GitHub
           </span>

--- a/app/components/course-page/course-stage-step/community-solution-card/highlighted-file-card.ts
+++ b/app/components/course-page/course-stage-step/community-solution-card/highlighted-file-card.ts
@@ -1,7 +1,10 @@
 import Component from '@glimmer/component';
 import { inject as service } from '@ember/service';
+import { tracked } from '@glimmer/tracking';
+import { action } from '@ember/object';
 import type AuthenticatorService from 'codecrafters-frontend/services/authenticator';
 import type CommunityCourseStageSolution from 'codecrafters-frontend/models/community-course-stage-solution';
+import type CommunitySolutionExportModel from 'codecrafters-frontend/models/community-solution-export';
 import type DarkModeService from 'codecrafters-frontend/services/dark-mode';
 import { codeCraftersDark, codeCraftersLight } from 'codecrafters-frontend/utils/code-mirror-themes';
 import type { LineRange } from 'codecrafters-frontend/components/code-mirror';
@@ -19,6 +22,8 @@ interface Signature {
 export default class HighlightedFileCardComponent extends Component<Signature> {
   @service declare authenticator: AuthenticatorService;
   @service declare darkMode: DarkModeService;
+
+  @tracked isCreatingExport = false;
 
   get codeMirrorTheme() {
     return this.darkMode.isEnabled ? codeCraftersDark : codeCraftersLight;
@@ -91,6 +96,89 @@ export default class HighlightedFileCardComponent extends Component<Signature> {
 
         return mergedRanges;
       }, []);
+  }
+
+  @action
+  async handleViewOnGithubClick(): Promise<void> {
+    const solution = this.args.solution;
+
+    // Check if we have a current valid export
+    const currentExport = solution.currentExport;
+
+    if (currentExport && currentExport.isProvisioned && currentExport.baseUrl) {
+      // We have a provisioned export, mark as accessed and redirect
+      await solution.markExportAsAccessed(currentExport);
+      const url = `${currentExport.baseUrl}/${this.args.highlightedFile.filename}`;
+      window.open(url, '_blank', 'noopener,noreferrer');
+
+      return;
+    }
+
+    if (currentExport && currentExport.isProvisioning) {
+      // Export is still being created, wait for it to complete
+      this.isCreatingExport = true;
+
+      try {
+        await this.waitForExportCompletion(currentExport);
+
+        if (currentExport.isProvisioned) {
+          await solution.markExportAsAccessed(currentExport);
+          const url = `${currentExport.baseUrl}/${this.args.highlightedFile.filename}`;
+          window.open(url, '_blank', 'noopener,noreferrer');
+        } else {
+          alert('Export is taking longer than expected. Please try again.');
+        }
+      } catch (error) {
+        console.error('Error waiting for export:', error);
+        alert('Export is taking longer than expected. Please try again.');
+      } finally {
+        this.isCreatingExport = false;
+      }
+
+      return;
+    }
+
+    // No valid export exists, create a new one
+    this.isCreatingExport = true;
+
+    try {
+      const newExport = await solution.createOrGetExport();
+
+      // Poll for completion if it's still provisioning
+      if (newExport.isProvisioning) {
+        await this.waitForExportCompletion(newExport);
+      }
+
+      if (newExport.isProvisioned && newExport.baseUrl) {
+        await solution.markExportAsAccessed(newExport);
+        const url = `${newExport.baseUrl}/${this.args.highlightedFile.filename}`;
+        window.open(url, '_blank', 'noopener,noreferrer');
+      } else {
+        alert('Failed to create export. Please try again.');
+      }
+    } catch (error) {
+      console.error('Error creating export:', error);
+      alert('Failed to create export. Please try again.');
+    } finally {
+      this.isCreatingExport = false;
+    }
+  }
+
+  private async waitForExportCompletion(exportModel: CommunitySolutionExportModel): Promise<void> {
+    const maxAttempts = 30; // 30 seconds timeout
+    let attempts = 0;
+
+    while (attempts < maxAttempts && exportModel.isProvisioning) {
+      await new Promise((resolve) => setTimeout(resolve, 1000)); // Wait 1 second
+
+      try {
+        await exportModel.reload();
+        attempts++;
+      } catch (error) {
+        console.error('Error reloading export:', error);
+        break;
+      }
+    }
   }
 }
 

--- a/app/models/community-course-stage-solution.ts
+++ b/app/models/community-course-stage-solution.ts
@@ -128,9 +128,9 @@ export default class CommunityCourseStageSolutionModel extends Model.extend(View
 
     await adapter.ajax(`${adapter.host}/api/v1/community-solution-exports/${exportModel.id}/mark-as-accessed`, 'POST');
 
+    // Update the local model without triggering a save
     const twentyFourHoursFromNow = new Date(Date.now() + 24 * 60 * 60 * 1000);
     exportModel.set('expiresAt', twentyFourHoursFromNow);
-    await exportModel.save();
   }
 
   declare fetchFileComparisons: (this: Model, payload: unknown) => Promise<FileComparison[]>;

--- a/app/models/community-solution-export.ts
+++ b/app/models/community-solution-export.ts
@@ -1,0 +1,26 @@
+import Model, { attr, belongsTo } from '@ember-data/model';
+import type CommunityCourseStageSolutionModel from './community-course-stage-solution';
+
+export default class CommunitySolutionExportModel extends Model {
+  static modelName = 'community-solution-export';
+  @belongsTo('community-course-stage-solution', { async: false, inverse: 'exports' })
+  declare communitySolution: CommunityCourseStageSolutionModel;
+
+  @attr('string') declare baseUrl: string;
+  @attr('date') declare expiresAt: Date;
+  @attr('string') declare status: 'provisioned' | 'provisioning';
+
+  get isExpired(): boolean {
+    if (!this.expiresAt) return false;
+
+    return new Date() > this.expiresAt;
+  }
+
+  get isProvisioned(): boolean {
+    return this.status === 'provisioned';
+  }
+
+  get isProvisioning(): boolean {
+    return this.status === 'provisioning';
+  }
+}


### PR DESCRIPTION
This PR adds the ability to view community solutions on GitHub by creating temporary exports when solutions aren't already published to public repositories.

**Checklist**:

- [ ] I've thoroughly self-reviewed my changes
- [ ] I've added tests for my changes, unless they affect admin-only areas (or are otherwise not worth testing)
- [ ] I've verified any visual changes using Percy (add a commit with `[percy]` in the message to trigger)
