### PR TITLE
Send `_empty.html` instead of 404 in prerender functions if FastBoot status code was not 200

### DIFF
--- a/vercel-functions/prerender/_prerender-ember-route.func/index.js
+++ b/vercel-functions/prerender/_prerender-ember-route.func/index.js
@@ -31,17 +31,14 @@ export default async function prerenderEmberRoute(request, response) {
   // Parse status code
   const statusCode = result._fastbootInfo.response.statusCode;
 
-  // Redirect to 404 page if the status code is not 200
+  // Render a generic page if the status code is not 200
   if (statusCode !== 200) {
     console.warn('FastBoot response statusCode was:', statusCode);
-    response.redirect('/404');
+    response.send(fs.readFileSync('dist/_empty.html', 'utf-8'));
 
     return;
   }
 
-  // Get the HTML content of the FastBoot response
-  const html = await result['html'](); // Weird VSCode syntax highlighting issue if written as result.html()
-
-  // Send the HTML content as result
-  response.send(html);
+  // Get the HTML content of the FastBoot response & send it as result
+  response.send(await result.html());
 }


### PR DESCRIPTION
### Brief

Instead of sending a 404 status code if FastBoot didn't return a 200 in Vercel Prerender Functions — send contents of `_empty.html`

### Checklist

- [x] I've thoroughly self-reviewed my changes
- [x] I've added tests for my changes, unless they affect admin-only areas (or are otherwise not worth testing)
- [x] I've verified any visual changes using Percy (add a commit with `[percy]` in the message to trigger)
