### PR TITLE
Fix a shiki deprecation warning for `getHighlighter`

### DIFF
--- a/app/utils/highlighter-cache.ts
+++ b/app/utils/highlighter-cache.ts
@@ -2,7 +2,7 @@ import config from 'codecrafters-frontend/config/environment';
 import * as shiki from 'shiki';
 
 /**
- * getHighlighter() is the most expensive step of Shiki. Instead of calling it on every page,
+ * createHighlighter() is the most expensive step of Shiki. Instead of calling it on every page,
  * cache it here as much as possible. Make sure that your highlighters can be cached, state-free.
  * We make this async, so that multiple calls to parse markdown still share the same highlighter.
  */
@@ -35,7 +35,7 @@ export default function getOrCreateCachedHighlighterPromise(
         } as unknown as shiki.Highlighter);
       });
     } else {
-      highlighterPromise = shiki.getHighlighter(options);
+      highlighterPromise = shiki.createHighlighter(options);
     }
 
     highlighterCacheAsync.set(cacheId, highlighterPromise);


### PR DESCRIPTION
### Brief

This fixes a deprecation warning coming from `shiki.getHighlighter`, which [has been replaced](https://shiki.style/blog/v2#gethighlighter-createhighlighter) with `shiki.createHighlighter`

### Details

> There is no functional changes, but more like correcting the naming to avoid confusion. It should be a straightforward find-and-replace.

### Screenshot

<img width="605" alt="Знімок екрана 2025-06-22 о 11 06 48" src="https://github.com/user-attachments/assets/3b1672b2-3b18-486c-bc4c-41d40fca95f1" />

### Checklist

- [x] I've thoroughly self-reviewed my changes
- [x] I've added tests for my changes, unless they affect admin-only areas (or are otherwise not worth testing)
- [x] I've verified any visual changes using Percy (add a commit with `[percy]` in the message to trigger)
