### PR TITLE
fix: hide `cm-deletedChunk` if it's directly before `cm-collapsedRangesFirst`

### DIFF
--- a/app/utils/code-mirror-themes.ts
+++ b/app/utils/code-mirror-themes.ts
@@ -287,6 +287,13 @@ const BASE_STYLE = {
         background: 'rgba(255, 0, 0, 0.2)',
       },
     },
+
+    // If the first line of the document is both deleted and collapsed — deletedChunk widget
+    // sticks above the first-child collapsedRanges bar and looks weird, we must hide it as
+    // it's supposed to be "collapsed".
+    '&:has(+ .cm-collapsedRangesFirst)': {
+      display: 'none',
+    },
   },
 };
 


### PR DESCRIPTION
### Brief

This fixes the following situation:

<img width="648" alt="Знімок екрана 2025-07-03 о 11 11 39" src="https://github.com/user-attachments/assets/b0d87794-90f3-4200-bc7e-29317f559d0b" />

### Details

When the first line of the document is both **deleted** and **collapsed** — `deletedChunk` widget sticks above the first-child `collapsedRanges` bar and looks weird, we must hide it as it's supposed to be "collapsed".

The same situation doesn't occur with `collapseUnchanged` — a line can not be both deleted and unchanged.

### Proper look

<img width="641" alt="Знімок екрана 2025-07-03 о 11 12 19" src="https://github.com/user-attachments/assets/96b0b199-c274-45f7-92e6-1c71954b1e5b" />
<img width="648" alt="Знімок екрана 2025-07-03 о 11 16 33" src="https://github.com/user-attachments/assets/53af8d99-ee93-42c6-96c8-0953c35613ea" />

### Checklist

- [x] I've thoroughly self-reviewed my changes
- [x] I've added tests for my changes, unless they affect admin-only areas (or are otherwise not worth testing)
- [x] I've verified any visual changes using Percy (add a commit with `[percy]` in the message to trigger)
