### PR TITLE
Remove class="max-h-[400px]" from SubmissionLogsPreview

### DIFF
--- a/app/components/course-admin/submissions-page/submission-details-container.hbs
+++ b/app/components/course-admin/submissions-page/submission-details-container.hbs
@@ -8,7 +8,7 @@
         {{#if (eq activeTabSlug "diff")}}
           <CourseAdmin::SubmissionsPage::SubmissionDetails::DiffContainer @submission={{@submission}} data-test-diff-tab />
         {{else if (eq activeTabSlug "logs")}}
-          <SubmissionLogsPreview @submission={{@submission}} class="max-h-[400px]" />
+          <SubmissionLogsPreview @submission={{@submission}} />
         {{else if (eq activeTabSlug "community_solution")}}
           <CourseAdmin::SubmissionsPage::SubmissionDetails::CommunitySolutionContainer @submission={{@submission}} />
         {{/if}}


### PR DESCRIPTION
Reason:

It's too short for practical uses. When I was viewing the logs, I found myself having to remove it in devtools constantly.

Before:
<img width="2124" height="2130" alt="image" src="https://github.com/user-attachments/assets/b1b8daab-2e75-40a0-8a2c-41700aee3b0e" />

After:

<img width="3070" height="2172" alt="image" src="https://github.com/user-attachments/assets/00ff50f1-8fa4-4907-bd58-1f7b9dd2f038" />

**Checklist**:

- [x] I've thoroughly self-reviewed my changes
- [ ] I've added tests for my changes, unless they affect admin-only areas (or are otherwise not worth testing)
- [ ] I've verified any visual changes using Percy (add a commit with `[percy]` in the message to trigger)
