### PR TITLE
Fix warning flood in tests console about a second pretender instance

### DIFF
--- a/tests/acceptance/settings-page/billing-test.js
+++ b/tests/acceptance/settings-page/billing-test.js
@@ -3,13 +3,11 @@ import { setupApplicationTest } from 'codecrafters-frontend/tests/helpers';
 import { signIn, signInAsSubscriber, signInAsVipUser } from 'codecrafters-frontend/tests/support/authentication-helpers';
 import testScenario from 'codecrafters-frontend/mirage/scenarios/test';
 import billingPage from 'codecrafters-frontend/tests/pages/settings/billing-page';
-import { setupMirage } from 'ember-cli-mirage/test-support';
 import { setupWindowMock } from 'ember-window-mock/test-support';
 import percySnapshot from '@percy/ember';
 
 module('Acceptance | settings-page | billing-test', function (hooks) {
   setupApplicationTest(hooks);
-  setupMirage(hooks);
   setupWindowMock(hooks);
 
   test('membership section shows correct plan for subscriber with active subscription', async function (assert) {


### PR DESCRIPTION
### Brief

This fixes a very annoying warning flood in the tests console, caused by an unnecessary extra `setupMirage` call.

### Screenshot

<img width="875" height="783" alt="Знімок екрана 2025-08-05 о 16 18 01" src="https://github.com/user-attachments/assets/7cfd55de-11ba-4c67-b612-d28872c8956a" />

### Checklist

- [x] I've thoroughly self-reviewed my changes
- [x] I've added tests for my changes, unless they affect admin-only areas (or are otherwise not worth testing)
- [x] I've verified any visual changes using Percy (add a commit with `[percy]` in the message to trigger)
