### PR TITLE
Fix a very annoying store auto-injection deprecation warning

### DIFF
--- a/app/services/store.js
+++ b/app/services/store.js
@@ -1,0 +1,5 @@
+/**
+ * Do NOT convert this file to TypeScript, otherwise it will stop overriding the
+ * store service from ember-data, and will start causing a deprecation warning.
+ */
+export { default } from 'ember-data/store';

--- a/app/services/store.ts
+++ b/app/services/store.ts
@@ -1,1 +1,0 @@
-export { default } from 'ember-data/store';


### PR DESCRIPTION
### Brief

This fixes a VERY annoying deprecation warning about relying on ember-data auto-magically installing the `store` service.

### Details

File `app/services/store.js` must NOT be converted to TypeScript, otherwise it will stop overriding the service file ember-data, and will start causing a deprecation warning.

### Screenshot

<img width="858" height="288" alt="Знімок екрана 2025-08-05 о 18 07 32" src="https://github.com/user-attachments/assets/40471398-21e6-4a24-a5ae-840cc0c4369f" />

### Checklist

- [x] I've thoroughly self-reviewed my changes
- [x] I've added tests for my changes, unless they affect admin-only areas (or are otherwise not worth testing)
- [x] I've verified any visual changes using Percy (add a commit with `[percy]` in the message to trigger)