### PR TITLE
Improve `start` and `start:fastboot` NPM tasks

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,13 @@
+{
+	"version": "2.0.0",
+	"tasks": [
+    {
+      "label": "npm: lint:js",
+      "type": "npm",
+      "script": "lint:js",
+      "problemMatcher": [
+        "$eslint-stylish"
+      ]
+    }
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -27,8 +27,8 @@
     "lint:types": "tsc --noEmit",
     "lint:glint": "glint",
     "lint:glint:fix": "glint",
-    "start": "FASTBOOT_DISABLED=true ember serve",
-    "start:fastboot": "FASTBOOT_DISABLED=\"\" ember serve",
+    "start": "FASTBOOT_DISABLED=true npm run start:fastboot",
+    "start:fastboot": "ember serve",
     "test": "concurrently \"npm:lint\" \"npm:test:*\" --names \"lint,test:\"",
     "test:ember": "ember test"
   },

--- a/package.json
+++ b/package.json
@@ -28,8 +28,9 @@
     "lint:types": "tsc --noEmit",
     "lint:glint": "glint",
     "lint:glint:fix": "glint",
+    "restart:watchman": "command -v watchman >/dev/null 2>&1 && (watchman watch-del . && watchman watch-project .) || echo 'watchman not installed, skipping'",
     "start": "FASTBOOT_DISABLED=true npm run start:fastboot",
-    "start:fastboot": "npm run install:silent && ember serve",
+    "start:fastboot": "npm run install:silent && npm run restart:watchman && ember serve",
     "test": "concurrently \"npm:lint\" \"npm:test:*\" --names \"lint,test:\"",
     "test:ember": "ember test"
   },

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "build": "npm run build:versions && npm run build:ember",
     "build:versions": "echo \"npm: $(npm --version)\" && ember --version",
     "build:ember": "ember build --environment=production",
+    "install:silent": "npm install --no-fund --no-audit",
     "lint": "concurrently \"npm:lint:*(!fix)\" --names \"lint:\"",
     "lint:css": "stylelint \"**/*.css\"",
     "lint:css:fix": "concurrently \"npm:lint:css -- --fix\"",
@@ -28,7 +29,7 @@
     "lint:glint": "glint",
     "lint:glint:fix": "glint",
     "start": "FASTBOOT_DISABLED=true npm run start:fastboot",
-    "start:fastboot": "ember serve",
+    "start:fastboot": "npm run install:silent && ember serve",
     "test": "concurrently \"npm:lint\" \"npm:test:*\" --names \"lint,test:\"",
     "test:ember": "ember test"
   },

--- a/vercel.json
+++ b/vercel.json
@@ -1,6 +1,6 @@
 {
   "buildCommand": "scripts/build-vercel-output.sh",
-  "installCommand": "npm install --no-fund --no-audit",
+  "installCommand": "npm run install:silent",
   "redirects": [
     { "source": "/_empty.html", "destination": "/404" },
     { "source": "/_empty_notags.html", "destination": "/404" },


### PR DESCRIPTION
Follow-up to https://github.com/codecrafters-io/frontend/pull/2949

### Brief

This improves our `start` and `start:fastboot` NPM tasks, and adds several other minor improvements

### Details

- Task `start` now calls `start:fastboot` instead of `ember serve` directly
  - `FASTBOOT_DISABLED=true` now needs to be set only in `start`
- Added `install:silent` task for running `npm install --no-fund --no-audit`
- Added `restart:watchman` task for restarting watchman
- Task `start:fastboot` now runs `install:silent` and `restart:watchman` before running `ember serve`
  - it doesn't take any significant time if `node_modules` is up to date, and running these two manually every time is an unnecessary PITA
- Added a **VSCode** task with problem matcher for `lint:js` NPM task
  - This allows VSCode to collect errors into "Problems" tab when running `lint:js`

### Checklist

- [x] I've thoroughly self-reviewed my changes
- [x] I've added tests for my changes, unless they affect admin-only areas (or are otherwise not worth testing)
- [x] I've verified any visual changes using Percy (add a commit with `[percy]` in the message to trigger)
