### PR TITLE
feat(leaderboard): add route info metadata for anonymous access

### DIFF
--- a/app/routes/leaderboard.ts
+++ b/app/routes/leaderboard.ts
@@ -7,6 +7,7 @@ import type LeaderboardModel from 'codecrafters-frontend/models/leaderboard';
 import type Store from '@ember-data/store';
 import { inject as service } from '@ember/service';
 import type LeaderboardEntryModel from 'codecrafters-frontend/models/leaderboard-entry';
+import RouteInfoMetadata from 'codecrafters-frontend/utils/route-info-metadata';
 
 export type ModelType = {
   language: LanguageModel;
@@ -15,13 +16,15 @@ export type ModelType = {
 };
 
 export default class LeaderboardRoute extends BaseRoute {
-  allowsAnonymousAccess = true;
-
   @service declare authenticator: AuthenticatorService;
   @service declare store: Store;
 
   activate(): void {
     scrollToTop();
+  }
+
+  buildRouteInfoMetadata() {
+    return new RouteInfoMetadata({ allowsAnonymousAccess: true });
   }
 
   async model(params: { language_slug: string }): Promise<ModelType> {


### PR DESCRIPTION
Replace allowsAnonymousAccess property with buildRouteInfoMetadata 
method returning RouteInfoMetadata to declare anonymous access. 
Refactor activate method to properly close function block. This update 
aligns with new route metadata conventions and improves route 
configuration clarity.