### PR TITLE
Move admin panel link to account dropdown

### DIFF
--- a/app/components/header/account-dropdown.hbs
+++ b/app/components/header/account-dropdown.hbs
@@ -70,6 +70,11 @@
         <DarkModeToggleWithUpgradePrompt @size="small" />
       </div>
 
+      {{#if this.currentUser.isAdmin}}
+        <div class="h-px mt-2 mb-2 ml-3 mr-3 bg-gray-200 dark:bg-white/5" />
+        <DropdownLink @text="Admin Panel" @icon="cog" {{on "click" (fn this.handleAdminPanelLinkClick dd.actions)}} />
+      {{/if}}
+
       <div class="h-px mt-2 mb-2 ml-3 mr-3 bg-gray-200 dark:bg-white/5" />
 
       <DropdownLink @text="Logout" @icon="logout" {{on "click" this.handleLogoutClick}} />

--- a/app/components/header/account-dropdown.ts
+++ b/app/components/header/account-dropdown.ts
@@ -8,6 +8,7 @@ import type Store from '@ember-data/store';
 import type TeamModel from 'codecrafters-frontend/models/team';
 import type FeatureFlagsService from 'codecrafters-frontend/services/feature-flags';
 import type DarkModeService from 'codecrafters-frontend/services/dark-mode';
+import config from 'codecrafters-frontend/config/environment';
 
 export default class AccountDropdown extends Component {
   @service declare authenticator: AuthenticatorService;
@@ -18,6 +19,12 @@ export default class AccountDropdown extends Component {
 
   get currentUser() {
     return this.authenticator.currentUser;
+  }
+
+  @action
+  handleAdminPanelLinkClick(dropdownActions: { close: () => void }) {
+    dropdownActions.close();
+    window.open(`${config.x.backendUrl}/admin`, '_blank');
   }
 
   @action

--- a/app/components/header/index.ts
+++ b/app/components/header/index.ts
@@ -1,18 +1,17 @@
 import Component from '@glimmer/component';
-import { action } from '@ember/object';
-import { tracked } from '@glimmer/tracking';
-import { inject as service } from '@ember/service';
-import { htmlSafe } from '@ember/template';
-import { next } from '@ember/runloop';
+import PromotionalDiscountModel from 'codecrafters-frontend/models/promotional-discount';
 import logoImage from '/assets/images/logo/logomark-color.svg';
-import config from 'codecrafters-frontend/config/environment';
 import type AuthenticatorService from 'codecrafters-frontend/services/authenticator';
 import type ContainerWidthService from 'codecrafters-frontend/services/container-width';
 import type FeatureFlagsService from 'codecrafters-frontend/services/feature-flags';
 import type RouterService from '@ember/routing/router-service';
 import type VersionTrackerService from 'codecrafters-frontend/services/version-tracker';
-import PromotionalDiscountModel from 'codecrafters-frontend/models/promotional-discount';
 import type { SafeString } from '@ember/template/-private/handlebars';
+import { action } from '@ember/object';
+import { htmlSafe } from '@ember/template';
+import { inject as service } from '@ember/service';
+import { next } from '@ember/runloop';
+import { tracked } from '@glimmer/tracking';
 
 interface Signature {
   Element: HTMLDivElement;
@@ -33,10 +32,6 @@ export default class Header extends Component<Signature> {
 
   get activeDiscountForYearlyPlan(): PromotionalDiscountModel | null {
     return this.currentUser?.activeDiscountForYearlyPlan || null;
-  }
-
-  get adminPanelLink() {
-    return `${config.x.backendUrl}/admin`;
   }
 
   get currentUser() {
@@ -64,10 +59,6 @@ export default class Header extends Component<Signature> {
       { text: 'Catalog', route: 'catalog', type: 'route' },
       { text: 'Roadmap', route: 'roadmap', type: 'route' },
     ];
-
-    if (this.currentUser && this.currentUser.isAdmin) {
-      links.push({ text: 'Admin', route: this.adminPanelLink, type: 'link' });
-    }
 
     return links;
   }


### PR DESCRIPTION
Add an "Admin Panel" link to the account dropdown menu visible only to
admin users. The link opens the backend admin page in a new tab, using
the backend URL from the environment config. This improves access and
usability for admin users to quickly reach the admin interface.

Also clean up unused admin-related code from the header index component,
removing the admin link generation and adminPanelLink getter that were
previously unused. This simplifies the codebase and consolidates admin
link logic into the account dropdown component.