### PR TITLE
fix(versioning): bump app version and update leaderboard flag

### DIFF
--- a/app/services/feature-flags.ts
+++ b/app/services/feature-flags.ts
@@ -19,7 +19,7 @@ export default class FeatureFlagsService extends Service {
   }
 
   get shouldSeeLeaderboard(): boolean {
-    return this.currentUser?.isStaff || this.getFeatureFlagValue('should-see-leaderboard') === 'true';
+    return this.currentUser?.isStaff || this.getFeatureFlagValue('should-see-leaderboard') === 'test';
   }
 
   getFeatureFlagValue(flagName: string): string | null | undefined {

--- a/config/environment.js
+++ b/config/environment.js
@@ -49,7 +49,7 @@ module.exports = function (environment) {
 
       // Update the major version number to force all clients to update.
       // The minor version doesn't do anything at the moment, might use in the future.
-      version: `34.0.${process.env.VERCEL_GIT_COMMIT_SHA?.slice(0, 7) || 'dev'}`,
+      version: `35.0.${process.env.VERCEL_GIT_COMMIT_SHA?.slice(0, 7) || 'dev'}`,
     },
     fastboot: {
       hostWhitelist: [/^localhost:\d+$/],


### PR DESCRIPTION
Increase the major version from 34.0 to 35.0 to force all clients
to update with the latest release. Change the leaderboard feature flag
check from 'true' to 'test' to refine access control logic for staff and
feature flag evaluation.