### PR TITLE
fix(types): add non-null assertion to lastActivityAt access

### DIFF
--- a/app/controllers/catalog.ts
+++ b/app/controllers/catalog.ts
@@ -36,12 +36,10 @@ export default class CatalogController extends Controller {
         const repositoriesForCourse2 = this.authenticator.currentUser!.repositories.filterBy('course', course2).filterBy('lastActivityAt');
 
         const lastActivityForCourse1At =
-          // @ts-expect-error at(-1) is not defined on Array
-          repositoriesForCourse1.length > 0 ? repositoriesForCourse1.sortBy('lastActivityAt').at(-1).lastActivityAt.getTime() : null;
+          repositoriesForCourse1.length > 0 ? repositoriesForCourse1.sortBy('lastActivityAt').at(-1)!.lastActivityAt.getTime() : null;
 
         const lastActivityForCourse2At =
-          // @ts-expect-error at(-1) is not defined on Array
-          repositoriesForCourse2.length > 0 ? repositoriesForCourse2.sortBy('lastActivityAt').at(-1).lastActivityAt.getTime() : null;
+          repositoriesForCourse2.length > 0 ? repositoriesForCourse2.sortBy('lastActivityAt').at(-1)!.lastActivityAt.getTime() : null;
 
         if (lastActivityForCourse1At && lastActivityForCourse2At && lastActivityForCourse1At > lastActivityForCourse2At) {
           return -1;


### PR DESCRIPTION
Remove TypeScript expect errors by asserting non-null values when
accessing the last element with `.at(-1)!`. This ensures type safety
and avoids suppressing errors related to potential undefined values
in repository arrays sorted by last activity date.