### PR TITLE
test: fix header leaderboard feature flag tests and add waitUntil

### DIFF
--- a/tests/acceptance/header-test.js
+++ b/tests/acceptance/header-test.js
@@ -32,7 +32,7 @@ module('Acceptance | header-test', function (hooks) {
 
   test('header should show generic leaderboard link if user has feature flag enabled and leaderboard entries', async function (assert) {
     const user = signIn(this.owner, this.server);
-    user.update('featureFlags', { 'should-see-leaderboard': 'true' });
+    user.update('featureFlags', { 'should-see-leaderboard': 'test' });
 
     await catalogPage.visit();
     assert.true(catalogPage.header.hasLink('Leaderboard'), 'expect leaderboard link to be visible');
@@ -43,7 +43,7 @@ module('Acceptance | header-test', function (hooks) {
 
   test('header should show custom leaderboard link if user has feature flag enabled', async function (assert) {
     const user = signIn(this.owner, this.server);
-    user.update('featureFlags', { 'should-see-leaderboard': 'true' });
+    user.update('featureFlags', { 'should-see-leaderboard': 'test' });
 
     const python = this.server.schema.languages.findBy({ name: 'Python' });
 


### PR DESCRIPTION
Update feature flag values from 'true' to 'test' to correctly simulate user
permissions for showing leaderboard links. Add waitUntil in tests to wait for
the leaderboard link to appear before asserting, improving test reliability.
Also include a pauseTest call to aid debugging during test runs.