### PR TITLE
feat(roadmap): always show RoadmapInfoAlert on all screen sizes

### DIFF
--- a/app/components/roadmap-info-alert.hbs
+++ b/app/components/roadmap-info-alert.hbs
@@ -1,4 +1,4 @@
-<Alert @color="blue" class="p-5">
+<Alert @color="blue" class="p-5" ...attributes>
   <div class="prose prose-sm dark:prose-invert prose-blue prose-compact">
     <h4>
       <div class="flex items-center gap-1">

--- a/app/templates/roadmap/course-extension-ideas.hbs
+++ b/app/templates/roadmap/course-extension-ideas.hbs
@@ -1,14 +1,14 @@
 <div class="flex flex-col md:flex-row-reverse gap-3">
   <div class="w-full md:w-60 flex-shrink-0">
     <div class="md:sticky md:top-4 flex flex-col gap-3">
-
       <LatestReleasesCard @courseExtensionIdeas={{@model.courseExtensionIdeas}} @courseIdeas={{@model.courseIdeas}} />
     </div>
   </div>
   <div class="flex-grow flex flex-col gap-3">
-    <RoadmapInfoAlert @heading="What are challenge extensions?" class="hidden md:block">
+    <RoadmapInfoAlert @heading="What are challenge extensions?">
       Challenge extensions are groups of extra stages that extend challenges. Vote and help us decide which ones to build.
     </RoadmapInfoAlert>
+
     <div class="flex items-center mb-6">
       <CourseDropdown
         @courses={{this.orderedCourses}}

--- a/app/templates/roadmap/course-ideas.hbs
+++ b/app/templates/roadmap/course-ideas.hbs
@@ -6,7 +6,7 @@
     </div>
   </div>
   <div class="flex-grow flex flex-col gap-3">
-    <RoadmapInfoAlert @heading="What are challenges?" class="hidden md:block">
+    <RoadmapInfoAlert @heading="What are challenges?">
       Challenges are step-by-step coding exercises where you build projects from scratch. Vote and help us decide which challenges to build.
     </RoadmapInfoAlert>
 


### PR DESCRIPTION
Remove the "hidden md:block" classes from RoadmapInfoAlert components  
to ensure the informational alerts about challenges and extensions are  
visible on all screen sizes. Also, update RoadmapInfoAlert to forward  
HTML attributes to the underlying Alert component for better flexibility.  
These changes improve user awareness of roadmap concepts regardless of  
device or viewport.

<!-- GitButler Footer Boundary Top -->
---
This is **part 1 of 2 in a stack** made with GitButler:
- <kbd>&nbsp;2&nbsp;</kbd> #3102 
- <kbd>&nbsp;1&nbsp;</kbd> #3101 👈 
<!-- GitButler Footer Boundary Bottom -->

