### PR TITLE
ci: upgrade GitHub Actions runners to Ubuntu 24.04

### DIFF
--- a/.github/workflows/publish_bundle.yml
+++ b/.github/workflows/publish_bundle.yml
@@ -11,7 +11,7 @@ concurrency:
 
 jobs:
   build_production_bundle:
-    runs-on: depot-ubuntu-22.04-16
+    runs-on: depot-ubuntu-24.04-16
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ concurrency:
 
 jobs:
   test:
-    runs-on: depot-ubuntu-22.04-16
+    runs-on: depot-ubuntu-24.04-16
     # Use cheaper machines for dependabot if we're low on namespace credits
     # runs-on: ${{ github.actor == 'dependabot[bot]' && 'namespace-profile-frontend-light' || 'namespace-profile-frontend' }}
     permissions: write-all
@@ -117,7 +117,7 @@ jobs:
           seconds_between_github_reads: 0.01
 
   lint:
-    runs-on: depot-ubuntu-22.04-16
+    runs-on: depot-ubuntu-24.04-16
     # Use cheaper machines for dependabot if we're low on namespace credits
     # runs-on: ${{ github.actor == 'dependabot[bot]' && 'namespace-profile-frontend-light' || 'namespace-profile-frontend' }}
 


### PR DESCRIPTION
Update all workflow jobs to run on depot-ubuntu-24.04-16 from 
depot-ubuntu-22.04-16. This change ensures the CI environment uses 
the latest Ubuntu LTS version, providing improved security, updated 
packages, and better performance for build, test, and lint workflows.

<!-- GitButler Footer Boundary Top -->
---
This is **part 1 of 2 in a stack** made with GitButler:
- <kbd>&nbsp;2&nbsp;</kbd> #3105 
- <kbd>&nbsp;1&nbsp;</kbd> #3104 👈 
<!-- GitButler Footer Boundary Bottom -->

