### PR TITLE
ci: upgrade Node.js version to 24 in workflows and configs

### DIFF
--- a/.github/workflows/publish_bundle.yml
+++ b/.github/workflows/publish_bundle.yml
@@ -17,7 +17,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v4
         with:
-          node-version: '22'
+          node-version: '24'
           cache: 'npm'
       - run: npm ci --prefer-offline --ignore-scripts --no-audit --no-fund
       - run: npm run build

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,7 +25,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: '22'
+          node-version: '24'
 
       # Caching node_modules is faster than using setup-node's cache: 'npm' (https://www.voorhoede.nl/en/blog/super-fast-npm-install-on-github-actions/)
       - id: cache
@@ -126,7 +126,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: '22'
+          node-version: '24'
 
       # Caching node_modules is faster than using setup-node's cache: 'npm' (https://www.voorhoede.nl/en/blog/super-fast-npm-install-on-github-actions/)
       - id: cache

--- a/package-lock.json
+++ b/package-lock.json
@@ -190,7 +190,7 @@
         "webpack-bundle-analyzer": "^4.10.2"
       },
       "engines": {
-        "node": "22.*"
+        "node": "24.*"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {

--- a/package.json
+++ b/package.json
@@ -196,7 +196,7 @@
     "webpack-bundle-analyzer": "^4.10.2"
   },
   "engines": {
-    "node": "22.*"
+    "node": "24.*"
   },
   "ember": {
     "edition": "octane"


### PR DESCRIPTION
Update GitHub Actions workflows and package.json to use Node.js 24
instead of 22. This change aligns the project with the latest Node.js
LTS version, ensuring improved performance, security, and compatibility 
with dependencies.

<!-- GitButler Footer Boundary Top -->
---
This is **part 2 of 2 in a stack** made with GitButler:
- <kbd>&nbsp;2&nbsp;</kbd> #3105 👈 
- <kbd>&nbsp;1&nbsp;</kbd> #3104 
<!-- GitButler Footer Boundary Bottom -->

