### PR TITLE
feat(alert): add teal color variant to alert component

### DIFF
--- a/app/components/alert.ts
+++ b/app/components/alert.ts
@@ -4,7 +4,7 @@ interface Signature {
   Element: HTMLDivElement;
 
   Args: {
-    color: 'green' | 'blue' | 'red' | 'yellow';
+    color: 'blue' | 'green' | 'red' | 'teal' | 'yellow';
   };
 
   Blocks: {
@@ -18,6 +18,7 @@ export default class Alert extends Component<Signature> {
       green: 'bg-green-100/20 dark:bg-green-900/20 border-green-500/60 dark:border-green-500/40',
       blue: 'bg-blue-100/20 dark:bg-blue-900/20 border-blue-500/60 dark:border-blue-500/40',
       red: 'bg-red-100/20 dark:bg-red-900/20 border-red-500/60 dark:border-red-500/40',
+      teal: 'bg-teal-100/20 dark:bg-teal-900/20 border-teal-500/60 dark:border-teal-500/40',
       yellow: 'bg-yellow-100/20 dark:bg-yellow-900/20 border-yellow-500/60 dark:border-yellow-500/40',
     }[this.args.color];
   }


### PR DESCRIPTION
Add support for a new 'teal' color option in the Alert component by
updating the accepted color types and defining corresponding background
and border styles. This enhancement broadens the color palette,
providing more flexibility for UI design and better alignment with
branding requirements.