### PR TITLE
refactor(test): move leaderboard setup to scenario for consistency

### DIFF
--- a/mirage/scenarios/test.js
+++ b/mirage/scenarios/test.js
@@ -22,6 +22,10 @@ export default function (server, courses = ['redis', 'docker', 'dummy', 'git', '
 
   createLanguages(server);
 
+  server.schema.languages.all().models.forEach((language) => {
+    language.update({ leaderboard: server.schema.leaderboards.create({ language: language, highestPossibleScore: 237 }) });
+  });
+
   const courseToDataMap = {
     docker: dockerCourseData,
     dummy: dummyCourseData,

--- a/tests/acceptance/header-test.js
+++ b/tests/acceptance/header-test.js
@@ -14,10 +14,6 @@ module('Acceptance | header-test', function (hooks) {
 
   hooks.beforeEach(function () {
     testScenario(this.server);
-
-    for (const language of this.server.schema.languages.all().models) {
-      language.update({ leaderboard: this.server.create('leaderboard', { highestPossibleScore: 237 }) });
-    }
   });
 
   test('header should show sign-in & pricing link if user is unauthenticated', async function (assert) {

--- a/tests/acceptance/leaderboard-page/view-test.js
+++ b/tests/acceptance/leaderboard-page/view-test.js
@@ -15,10 +15,6 @@ module('Acceptance | leaderboard-page | view', function (hooks) {
 
   hooks.beforeEach(function () {
     testScenario(this.server);
-
-    for (const language of this.server.schema.languages.all().models) {
-      language.update({ leaderboard: this.server.create('leaderboard', { highestPossibleScore: 237 }) });
-    }
   });
 
   test('can view as anonymous user', async function (assert) {


### PR DESCRIPTION
Remove leaderboard creation from acceptance test beforeEach hooks and
centralize it in the Mirage test scenario. This ensures all tests share
the same leaderboard setup, reduces duplication, and improves test
maintainability.