### PR TITLE
feat(course-page): show language leaderboard rank on stage completion

### DIFF
--- a/app/components/course-page/current-step-complete-modal.hbs
+++ b/app/components/course-page/current-step-complete-modal.hbs
@@ -8,11 +8,24 @@
       {{if (eq this.currentStep.type "CourseStageStep") "Stage Completed!" "Step Completed!"}}
     </div>
 
-    <div class="prose dark:prose-invert mb-5" data-test-completion-message>
-      <p>
-        {{this.currentStep.completionNoticeMessage}}
-      </p>
-    </div>
+    {{! We don't have much to show for non-stage steps, so let's tack on the notice's short message }}
+    {{#unless (eq this.currentStep.type "CourseStageStep")}}
+      <div class="prose dark:prose-invert mb-5" data-test-completion-message>
+        <p>
+          {{this.currentStep.completionNoticeMessage}}
+        </p>
+      </div>
+    {{/unless}}
+
+    {{#if (eq this.currentStep.type "CourseStageStep")}}
+      {{! If condition prevents type errors w/ Repository#language being nullable }}
+      {{#if this.currentStepAsCourseStageStep.repository.language}}
+        <CoursePage::CurrentStepCompleteModal::LanguageLeaderboardRankSection
+          @language={{this.currentStepAsCourseStageStep.repository.language}}
+          class="mt-3 mb-3"
+        />
+      {{/if}}
+    {{/if}}
 
     <PrimaryLinkButton
       @route={{this.stepForNextOrActiveStepButton.routeParams.route}}

--- a/app/components/course-page/current-step-complete-modal.hbs
+++ b/app/components/course-page/current-step-complete-modal.hbs
@@ -8,16 +8,7 @@
       {{if (eq this.currentStep.type "CourseStageStep") "Stage Completed!" "Step Completed!"}}
     </div>
 
-    {{! We don't have much to show for non-stage steps, so let's tack on the notice's short message }}
-    {{#unless (eq this.currentStep.type "CourseStageStep")}}
-      <div class="prose dark:prose-invert mb-5" data-test-completion-message>
-        <p>
-          {{this.currentStep.completionNoticeMessage}}
-        </p>
-      </div>
-    {{/unless}}
-
-    {{#if (eq this.currentStep.type "CourseStageStep")}}
+    {{#if this.shouldShowLanguageLeaderboardRankSection}}
       {{! If condition prevents type errors w/ Repository#language being nullable }}
       {{#if this.currentStepAsCourseStageStep.repository.language}}
         <CoursePage::CurrentStepCompleteModal::LanguageLeaderboardRankSection
@@ -25,6 +16,12 @@
           class="mt-3 mb-3"
         />
       {{/if}}
+    {{else}}
+      <div class="prose dark:prose-invert mb-5" data-test-completion-message>
+        <p>
+          {{this.currentStep.completionNoticeMessage}}
+        </p>
+      </div>
     {{/if}}
 
     <PrimaryLinkButton

--- a/app/components/course-page/current-step-complete-modal.ts
+++ b/app/components/course-page/current-step-complete-modal.ts
@@ -1,7 +1,8 @@
-import { service } from '@ember/service';
 import Component from '@glimmer/component';
-import type StepDefinition from 'codecrafters-frontend/utils/course-page-step-list/step';
 import CoursePageStateService from 'codecrafters-frontend/services/course-page-state';
+import type StepDefinition from 'codecrafters-frontend/utils/course-page-step-list/step';
+import { service } from '@ember/service';
+
 interface Signature {
   Element: HTMLDivElement;
 
@@ -16,6 +17,10 @@ export default class CurrentStepCompleteModal extends Component<Signature> {
 
   get currentStep() {
     return this.coursePageState.currentStep;
+  }
+
+  get currentStepAsCourseStageStep() {
+    return this.coursePageState.currentStepAsCourseStageStep;
   }
 
   get nextStep() {

--- a/app/components/course-page/current-step-complete-modal.ts
+++ b/app/components/course-page/current-step-complete-modal.ts
@@ -2,6 +2,7 @@ import Component from '@glimmer/component';
 import CoursePageStateService from 'codecrafters-frontend/services/course-page-state';
 import type StepDefinition from 'codecrafters-frontend/utils/course-page-step-list/step';
 import { service } from '@ember/service';
+import type FeatureFlagsService from 'codecrafters-frontend/services/feature-flags';
 
 interface Signature {
   Element: HTMLDivElement;
@@ -14,6 +15,7 @@ interface Signature {
 
 export default class CurrentStepCompleteModal extends Component<Signature> {
   @service declare coursePageState: CoursePageStateService;
+  @service declare featureFlags: FeatureFlagsService;
 
   get currentStep() {
     return this.coursePageState.currentStep;
@@ -25,6 +27,10 @@ export default class CurrentStepCompleteModal extends Component<Signature> {
 
   get nextStep() {
     return this.coursePageState.nextStep;
+  }
+
+  get shouldShowLanguageLeaderboardRankSection() {
+    return this.currentStep.type === 'CourseStageStep' && this.featureFlags.shouldSeeLeaderboard;
   }
 
   get stepForNextOrActiveStepButton() {

--- a/app/components/course-page/current-step-complete-modal/language-leaderboard-rank-section.hbs
+++ b/app/components/course-page/current-step-complete-modal/language-leaderboard-rank-section.hbs
@@ -1,0 +1,28 @@
+<Alert @color="teal" class="w-full p-5 pb-6" ...attributes>
+  <div class="flex flex-col items-center w-full">
+    {{svg-jar "presentation-chart-line" class="w-8 h-8 fill-current text-teal-500/90 mb-2"}}
+
+    <span class="text-teal-700 text-xs mb-0.5 text-center">
+      Your
+      {{@language.name}}
+      leaderboard rank is
+    </span>
+
+    <AnimatedContainer>
+      <div class="flex items-center w-full justify-center">
+        {{#animated-if (eq this.userRankCalculation null) use=this.transition duration=300}}
+          <b class="text-2xl text-teal-600 border-b border-teal-600 group-hover:text-teal-500 border-dashed animate-pulse">
+            # ⋯
+          </b>
+        {{else}}
+          <b class="text-2xl text-teal-600 border-b border-teal-600 group-hover:text-teal-500 border-dashed">
+            {{! If condition prevents type errors w/ userRankCalculation being nullable }}
+            {{#if this.userRankCalculation}}
+              #{{format-number this.userRankCalculation.rank}}
+            {{/if}}
+          </b>
+        {{/animated-if}}
+      </div>
+    </AnimatedContainer>
+  </div>
+</Alert>

--- a/app/components/course-page/current-step-complete-modal/language-leaderboard-rank-section.hbs
+++ b/app/components/course-page/current-step-complete-modal/language-leaderboard-rank-section.hbs
@@ -1,4 +1,4 @@
-<Alert @color="teal" class="w-full p-5 pb-6" ...attributes>
+<Alert @color="teal" class="w-full p-5 pb-6" ...attributes data-test-language-leaderboard-rank-section>
   <div class="flex flex-col items-center w-full">
     {{svg-jar "presentation-chart-line" class="w-8 h-8 fill-current text-teal-500/90 mb-2"}}
 

--- a/app/components/course-page/current-step-complete-modal/language-leaderboard-rank-section.hbs
+++ b/app/components/course-page/current-step-complete-modal/language-leaderboard-rank-section.hbs
@@ -1,4 +1,12 @@
-<Alert @color="teal" class="w-full p-5 pb-6" ...attributes data-test-language-leaderboard-rank-section>
+<Alert
+  @color="teal"
+  @isInteractive={{true}}
+  class="w-full p-5 pb-6"
+  role="button"
+  {{on "click" this.handleClick}}
+  ...attributes
+  data-test-language-leaderboard-rank-section
+>
   <div class="flex flex-col items-center w-full">
     {{svg-jar "presentation-chart-line" class="w-8 h-8 fill-current text-teal-500/90 mb-2"}}
 

--- a/app/components/course-page/current-step-complete-modal/language-leaderboard-rank-section.ts
+++ b/app/components/course-page/current-step-complete-modal/language-leaderboard-rank-section.ts
@@ -1,11 +1,13 @@
-import { service } from '@ember/service';
 import Component from '@glimmer/component';
+import fade from 'ember-animated/transitions/fade';
 import type LanguageModel from 'codecrafters-frontend/models/language';
-import type Store from '@ember-data/store';
 import type LeaderboardRankCalculationModel from 'codecrafters-frontend/models/leaderboard-rank-calculation';
+import type RouterService from '@ember/routing/router-service';
+import type Store from '@ember-data/store';
+import { action } from '@ember/object';
+import { service } from '@ember/service';
 import { task } from 'ember-concurrency';
 import { tracked } from '@glimmer/tracking';
-import fade from 'ember-animated/transitions/fade';
 
 interface Signature {
   Element: HTMLDivElement;
@@ -19,6 +21,7 @@ export default class LanguageLeaderboardRankSection extends Component<Signature>
   transition = fade;
 
   @service declare store: Store;
+  @service declare router: RouterService;
 
   @tracked userRankCalculation: LeaderboardRankCalculationModel | null = null;
 
@@ -26,6 +29,11 @@ export default class LanguageLeaderboardRankSection extends Component<Signature>
     super(owner, args);
 
     this.loadUserRankCalculationTask.perform();
+  }
+
+  @action
+  handleClick() {
+    window.open(this.router.urlFor('leaderboard', this.args.language.slug), '_blank');
   }
 
   loadUserRankCalculationTask = task({ restartable: true }, async () => {

--- a/app/components/course-page/current-step-complete-modal/language-leaderboard-rank-section.ts
+++ b/app/components/course-page/current-step-complete-modal/language-leaderboard-rank-section.ts
@@ -1,0 +1,44 @@
+import { service } from '@ember/service';
+import Component from '@glimmer/component';
+import type LanguageModel from 'codecrafters-frontend/models/language';
+import type Store from '@ember-data/store';
+import type LeaderboardRankCalculationModel from 'codecrafters-frontend/models/leaderboard-rank-calculation';
+import { task } from 'ember-concurrency';
+import { tracked } from '@glimmer/tracking';
+import fade from 'ember-animated/transitions/fade';
+
+interface Signature {
+  Element: HTMLDivElement;
+
+  Args: {
+    language: LanguageModel;
+  };
+}
+
+export default class LanguageLeaderboardRankSection extends Component<Signature> {
+  transition = fade;
+
+  @service declare store: Store;
+
+  @tracked userRankCalculation: LeaderboardRankCalculationModel | null = null;
+
+  constructor(owner: unknown, args: Signature['Args']) {
+    super(owner, args);
+
+    this.loadUserRankCalculationTask.perform();
+  }
+
+  loadUserRankCalculationTask = task({ restartable: true }, async () => {
+    this.userRankCalculation = await this.store
+      .createRecord('leaderboard-rank-calculation', {
+        leaderboard: this.args.language.leaderboard!,
+      })
+      .save();
+  });
+}
+
+declare module '@glint/environment-ember-loose/registry' {
+  export default interface Registry {
+    'CoursePage::CurrentStepCompleteModal::LanguageLeaderboardRankSection': typeof LanguageLeaderboardRankSection;
+  }
+}

--- a/app/utils/repository-poller.ts
+++ b/app/utils/repository-poller.ts
@@ -6,6 +6,7 @@ export default class RepositoryPoller extends Poller {
 
   static defaultIncludedResources = [
     'language',
+    'language.leaderboard',
     'extension-activations',
     'extension-activations.extension',
     'extension-activations.repository',

--- a/tests/acceptance/course-page/attempt-course-stage-test.js
+++ b/tests/acceptance/course-page/attempt-course-stage-test.js
@@ -97,7 +97,10 @@ module('Acceptance | course-page | attempt-course-stage', function (hooks) {
     await Promise.all(window.pollerInstances.map((poller) => poller.forcePoll()));
     await animationsSettled();
 
-    assert.contains(coursePage.currentStepCompleteModal.completionMessage, 'You completed this stage today.');
+    assert.ok(coursePage.currentStepCompleteModal.languageLeaderboardRankSection.isVisible, 'language leaderboard rank section is visible');
+
+    await coursePage.currentStepCompleteModal.clickOnViewInstructionsButton();
+    assert.contains(coursePage.completedStepNotice.text, 'You completed this stage today.');
   });
 
   test('can pass tests using CLI', async function (assert) {

--- a/tests/acceptance/course-page/attempt-course-stage-test.js
+++ b/tests/acceptance/course-page/attempt-course-stage-test.js
@@ -70,13 +70,15 @@ module('Acceptance | course-page | attempt-course-stage', function (hooks) {
 
   test('can pass course stage', async function (assert) {
     testScenario(this.server);
-    signInAsSubscriber(this.owner, this.server);
+    const currentUser = signInAsSubscriber(this.owner, this.server);
 
-    let currentUser = this.server.schema.users.first();
-    let go = this.server.schema.languages.findBy({ slug: 'go' });
-    let redis = this.server.schema.courses.findBy({ slug: 'redis' });
+    // TODO: Remove this once leaderboard isn't behind a feature flag
+    currentUser.update({ featureFlags: { 'should-see-leaderboard': 'test' } });
 
-    let repository = this.server.create('repository', 'withFirstStageCompleted', {
+    const go = this.server.schema.languages.findBy({ slug: 'go' });
+    const redis = this.server.schema.courses.findBy({ slug: 'redis' });
+
+    const repository = this.server.create('repository', 'withFirstStageCompleted', {
       course: redis,
       language: go,
       user: currentUser,

--- a/tests/acceptance/course-page/submit-course-stage-feedback-test.js
+++ b/tests/acceptance/course-page/submit-course-stage-feedback-test.js
@@ -14,13 +14,15 @@ module('Acceptance | course-page | submit-course-stage-feedback', function (hook
 
   test('can submit course stage feedback after passing course stage', async function (assert) {
     testScenario(this.server);
-    signInAsSubscriber(this.owner, this.server);
+    const currentUser = signInAsSubscriber(this.owner, this.server);
 
-    let currentUser = this.server.schema.users.first();
-    let go = this.server.schema.languages.findBy({ slug: 'go' });
-    let redis = this.server.schema.courses.findBy({ slug: 'redis' });
+    // TODO: Remove this once leaderboard isn't behind a feature flag
+    currentUser.update('featureFlags', { 'should-see-leaderboard': 'test' });
 
-    let repository = this.server.create('repository', 'withFirstStageCompleted', {
+    const go = this.server.schema.languages.findBy({ slug: 'go' });
+    const redis = this.server.schema.courses.findBy({ slug: 'redis' });
+
+    const repository = this.server.create('repository', 'withFirstStageCompleted', {
       course: redis,
       language: go,
       user: currentUser,

--- a/tests/acceptance/course-page/submit-course-stage-feedback-test.js
+++ b/tests/acceptance/course-page/submit-course-stage-feedback-test.js
@@ -43,14 +43,14 @@ module('Acceptance | course-page | submit-course-stage-feedback', function (hook
     await coursePage.sidebar.clickOnStepListItem('Respond to multiple PINGs');
     assert.strictEqual(coursePage.header.stepName, 'Respond to multiple PINGs', 'stage 3 is active');
 
-    assert.contains(coursePage.currentStepCompleteModal.text, 'You completed this stage today.', 'completion text is stage completed');
+    assert.ok(coursePage.currentStepCompleteModal.languageLeaderboardRankSection.isVisible, 'language leaderboard rank section is visible');
     assert.ok(coursePage.feedbackPrompt.isVisible, 'has feedback prompt');
 
     await coursePage.sidebar.clickOnStepListItem('Respond to PING');
     await animationsSettled();
 
     assert.strictEqual(coursePage.header.stepName, 'Respond to PING', '2nd stage is expanded');
-    assert.contains(coursePage.currentStepCompleteModal.text, 'You completed this stage today.', 'completion text is stage completed');
+    assert.ok(coursePage.currentStepCompleteModal.languageLeaderboardRankSection.isVisible, 'language leaderboard rank section is visible');
     assert.ok(coursePage.feedbackPrompt.isVisible, 'has feedback prompt');
 
     await coursePage.sidebar.clickOnStepListItem('Respond to multiple PINGs');

--- a/tests/acceptance/course-page/view-course-stages-test.js
+++ b/tests/acceptance/course-page/view-course-stages-test.js
@@ -44,11 +44,13 @@ module('Acceptance | course-page | view-course-stages-test', function (hooks) {
 
   test('can view previous stages after completing them', async function (assert) {
     testScenario(this.server);
-    signIn(this.owner, this.server);
+    const currentUser = signIn(this.owner, this.server);
 
-    let currentUser = this.server.schema.users.first();
-    let python = this.server.schema.languages.findBy({ name: 'Python' });
-    let redis = this.server.schema.courses.findBy({ slug: 'redis' });
+    // TODO: Remove this once leaderboard isn't behind a feature flag
+    currentUser.update('featureFlags', { 'should-see-leaderboard': 'test' });
+
+    const python = this.server.schema.languages.findBy({ name: 'Python' });
+    const redis = this.server.schema.courses.findBy({ slug: 'redis' });
 
     let pythonRepository = this.server.create('repository', 'withFirstStageCompleted', {
       course: redis,

--- a/tests/acceptance/course-page/view-course-stages-test.js
+++ b/tests/acceptance/course-page/view-course-stages-test.js
@@ -91,7 +91,9 @@ module('Acceptance | course-page | view-course-stages-test', function (hooks) {
     await animationsSettled();
 
     assert.strictEqual(coursePage.header.stepName, 'Respond to PING', 'course stage item is active if clicked on');
-    assert.contains(coursePage.currentStepCompleteModal.completionMessage, 'You completed this stage 5 days ago.');
+    assert.ok(coursePage.currentStepCompleteModal.languageLeaderboardRankSection.isVisible);
+    await coursePage.currentStepCompleteModal.clickOnViewInstructionsButton();
+    assert.contains(coursePage.completedStepNotice.text, 'You completed this stage 5 days ago.');
 
     await percySnapshot('Course Stages - Completed stage');
 
@@ -99,13 +101,15 @@ module('Acceptance | course-page | view-course-stages-test', function (hooks) {
     await animationsSettled();
 
     assert.strictEqual(coursePage.header.stepName, 'Respond to multiple PINGs', 'course stage item is active if clicked on');
-    assert.contains(coursePage.currentStepCompleteModal.completionMessage, 'You completed this stage yesterday.');
+    await coursePage.currentStepCompleteModal.clickOnViewInstructionsButton();
+    assert.contains(coursePage.completedStepNotice.text, 'You completed this stage yesterday.');
 
     await coursePage.sidebar.clickOnStepListItem('Handle concurrent clients');
     await animationsSettled();
 
     assert.strictEqual(coursePage.header.stepName, 'Handle concurrent clients', 'course stage item is active if clicked on');
-    assert.contains(coursePage.currentStepCompleteModal.completionMessage, 'You completed this stage today.');
+    await coursePage.currentStepCompleteModal.clickOnViewInstructionsButton();
+    assert.contains(coursePage.completedStepNotice.text, 'You completed this stage today.');
   });
 
   test('can navigate directly to stage even if previous stages are not completed', async function (assert) {

--- a/tests/acceptance/course-page/view-course-stages-test.js
+++ b/tests/acceptance/course-page/view-course-stages-test.js
@@ -91,7 +91,7 @@ module('Acceptance | course-page | view-course-stages-test', function (hooks) {
     await animationsSettled();
 
     assert.strictEqual(coursePage.header.stepName, 'Respond to PING', 'course stage item is active if clicked on');
-    assert.ok(coursePage.currentStepCompleteModal.languageLeaderboardRankSection.isVisible);
+    assert.ok(coursePage.currentStepCompleteModal.languageLeaderboardRankSection.isVisible, 'language leaderboard rank section is visible');
     await coursePage.currentStepCompleteModal.clickOnViewInstructionsButton();
     assert.contains(coursePage.completedStepNotice.text, 'You completed this stage 5 days ago.');
 
@@ -101,14 +101,12 @@ module('Acceptance | course-page | view-course-stages-test', function (hooks) {
     await animationsSettled();
 
     assert.strictEqual(coursePage.header.stepName, 'Respond to multiple PINGs', 'course stage item is active if clicked on');
-    await coursePage.currentStepCompleteModal.clickOnViewInstructionsButton();
     assert.contains(coursePage.completedStepNotice.text, 'You completed this stage yesterday.');
 
     await coursePage.sidebar.clickOnStepListItem('Handle concurrent clients');
     await animationsSettled();
 
     assert.strictEqual(coursePage.header.stepName, 'Handle concurrent clients', 'course stage item is active if clicked on');
-    await coursePage.currentStepCompleteModal.clickOnViewInstructionsButton();
     assert.contains(coursePage.completedStepNotice.text, 'You completed this stage today.');
   });
 

--- a/tests/pages/course-page.ts
+++ b/tests/pages/course-page.ts
@@ -74,11 +74,8 @@ export default create({
     clickOnNextOrActiveStepButton: clickable('[data-test-next-or-active-step-button]'),
     clickOnViewInstructionsButton: clickable('[data-test-view-instructions-button]'),
     completionMessage: text('[data-test-completion-message]'),
-
-    nextOrActiveStepButton: {
-      scope: '[data-test-next-or-active-step-button]',
-    },
-
+    languageLeaderboardRankSection: { scope: '[data-test-language-leaderboard-rank-section]' },
+    nextOrActiveStepButton: { scope: '[data-test-next-or-active-step-button]' },
     scope: '[data-test-current-step-complete-modal]',
   },
 


### PR DESCRIPTION
Display the user's leaderboard rank for the repository language when completing
a CourseStageStep. Hide the generic completion notice for stage steps and
replace it with a detailed LanguageLeaderboardRankSection.

Update the Mirage handler to use the current authenticated user and calculate
the correct leaderboard rank dynamically. Include the language leaderboard
relationship during repository polling to support these enhancements.

This provides users with immediate feedback on their ranking progress after
completing significant course stages, improving engagement and motivation.

<!-- GitButler Footer Boundary Top -->
---
This is **part 2 of 2 in a stack** made with GitButler:
- <kbd>&nbsp;2&nbsp;</kbd> #3108 👈 
- <kbd>&nbsp;1&nbsp;</kbd> #3109 
<!-- GitButler Footer Boundary Bottom -->

