### PR TITLE
feat(alert): add interactive hover state styles for alerts

### DIFF
--- a/app/components/alert.hbs
+++ b/app/components/alert.hbs
@@ -1,3 +1,3 @@
-<div class="flex p-3 border rounded-sm shadow-xs {{this.containerColorClasses}}" ...attributes>
+<div class="flex p-3 border rounded-sm shadow-xs {{this.containerColorClasses}} {{this.containerInteractivityClasses}}" ...attributes>
   {{yield}}
 </div>

--- a/app/components/alert.ts
+++ b/app/components/alert.ts
@@ -5,6 +5,7 @@ interface Signature {
 
   Args: {
     color: 'blue' | 'green' | 'red' | 'teal' | 'yellow';
+    isInteractive?: boolean;
   };
 
   Blocks: {
@@ -20,6 +21,20 @@ export default class Alert extends Component<Signature> {
       red: 'bg-red-100/20 dark:bg-red-900/20 border-red-500/60 dark:border-red-500/40',
       teal: 'bg-teal-100/20 dark:bg-teal-900/20 border-teal-500/60 dark:border-teal-500/40',
       yellow: 'bg-yellow-100/20 dark:bg-yellow-900/20 border-yellow-500/60 dark:border-yellow-500/40',
+    }[this.args.color];
+  }
+
+  get containerInteractivityClasses(): string {
+    if (!this.args.isInteractive) {
+      return '';
+    }
+
+    return {
+      green: 'hover:bg-green-100/40 dark:hover:bg-green-900/40',
+      blue: 'hover:bg-blue-100/40 dark:hover:bg-blue-900/40',
+      red: 'hover:bg-red-100/40 dark:hover:bg-red-900/40',
+      teal: 'hover:bg-teal-100/40 dark:hover:bg-teal-900/40',
+      yellow: 'hover:bg-yellow-100/40 dark:hover:bg-yellow-900/40',
     }[this.args.color];
   }
 }


### PR DESCRIPTION
Introduce an optional isInteractive argument to the alert component
that adds hover background color changes based on the alert color.
This improves user experience by providing visual feedback on
interactive alerts, enhancing clarity and engagement without affecting
non-interactive alerts.

<!-- GitButler Footer Boundary Top -->
---
This is **part 1 of 2 in a stack** made with GitButler:
- <kbd>&nbsp;2&nbsp;</kbd> #3108 
- <kbd>&nbsp;1&nbsp;</kbd> #3109 👈 
<!-- GitButler Footer Boundary Bottom -->

