### PR TITLE
fix(config): bump app major version to 36.0

### DIFF
--- a/config/environment.js
+++ b/config/environment.js
@@ -49,7 +49,7 @@ module.exports = function (environment) {
 
       // Update the major version number to force all clients to update.
       // The minor version doesn't do anything at the moment, might use in the future.
-      version: `35.0.${process.env.VERCEL_GIT_COMMIT_SHA?.slice(0, 7) || 'dev'}`,
+      version: `36.0.${process.env.VERCEL_GIT_COMMIT_SHA?.slice(0, 7) || 'dev'}`,
     },
     fastboot: {
       hostWhitelist: [/^localhost:\d+$/],


### PR DESCRIPTION
Update the major version number from 35.0 to 36.0 in the environment
configuration to force all clients to update. This ensures that users
are running the latest version after recent significant changes.