### PR TITLE
fix(ui): add dark mode styles to leaderboard rank section

### DIFF
--- a/app/components/course-page/current-step-complete-modal/language-leaderboard-rank-section.hbs
+++ b/app/components/course-page/current-step-complete-modal/language-leaderboard-rank-section.hbs
@@ -10,7 +10,7 @@
   <div class="flex flex-col items-center w-full">
     {{svg-jar "presentation-chart-line" class="w-8 h-8 fill-current text-teal-500/90 mb-2"}}
 
-    <span class="text-teal-700 text-xs mb-0.5 text-center">
+    <span class="text-teal-700 dark:text-teal-400 text-xs mb-0.5 text-center">
       Your
       {{@language.name}}
       leaderboard rank is
@@ -19,11 +19,13 @@
     <AnimatedContainer>
       <div class="flex items-center w-full justify-center">
         {{#animated-if (eq this.userRankCalculation null) use=this.transition duration=300}}
-          <b class="text-2xl text-teal-600 border-b border-teal-600 group-hover:text-teal-500 border-dashed animate-pulse">
+          <b
+            class="text-2xl text-teal-600 dark:text-teal-400 border-b border-teal-600 dark:border-teal-400 group-hover:text-teal-500 border-dashed animate-pulse"
+          >
             # ⋯
           </b>
         {{else}}
-          <b class="text-2xl text-teal-600 border-b border-teal-600 group-hover:text-teal-500 border-dashed">
+          <b class="text-2xl text-teal-600 dark:text-teal-400 border-b border-teal-600 dark:border-teal-400 group-hover:text-teal-500 border-dashed">
             {{! If condition prevents type errors w/ userRankCalculation being nullable }}
             {{#if this.userRankCalculation}}
               #{{format-number this.userRankCalculation.rank}}


### PR DESCRIPTION
Update language leaderboard rank section to support dark mode by
adding appropriate text and border color classes. This improves
visibility and consistency for users in dark theme settings.