### PR TITLE
feat(course-card): add dark mode styles to progress bar

### DIFF
--- a/app/components/track-page/course-card/progress-bar.hbs
+++ b/app/components/track-page/course-card/progress-bar.hbs
@@ -1,6 +1,9 @@
-<div class="flex items-center" data-test-course-progress>
+<div class="flex items-center" data-test-course-progress ...attributes>
   <div class="rounded-sm overflow-hidden mr-2">
-    <div class="{{if @lastPushedRepository.allStagesAreComplete 'bg-teal-100' 'bg-blue-100'}} h-4 w-20 flex items-stretch">
+    <div
+      class="{{if @lastPushedRepository.allStagesAreComplete 'bg-teal-100 dark:bg-teal-900' 'bg-blue-100 dark:bg-blue-900'}}
+        h-4 w-20 flex items-stretch"
+    >
       {{#if (eq @lastPushedRepository.completedStages.length 0)}}
         <div class="bg-blue-500 w-1/12"></div>
       {{else}}


### PR DESCRIPTION
Enhance progress bar in course card component to support dark mode by
adding conditional dark background colors. Also pass down extra HTML
attributes to the root div for better flexibility and integration.