### PR TITLE
Fix: Add z-index to leaderboard container for improved stacking conte…

### DIFF
--- a/app/templates/course.hbs
+++ b/app/templates/course.hbs
@@ -87,7 +87,7 @@
         class="{{if this.leaderboardIsExpanded 'w-64 xl:w-80 pr-6' 'pr-4'}}
           pt-6 shrink-0 border-l border-gray-200 dark:border-white/5 bg-gray-50 dark:bg-gray-900 hidden md:block group"
       >
-        <div class="sticky top-14">
+        <div class="sticky top-14 z-10">
           {{#if this.leaderboardIsExpanded}}
             <CoursePage::CollapseLeaderboardButton
               class="opacity-0 group-hover:opacity-100 absolute top-6 -left-3.5 z-10"


### PR DESCRIPTION
**Checklist**:

- [*] I've thoroughly self-reviewed my changes
- [*] I've added tests for my changes, unless they affect admin-only areas (or are otherwise not worth testing)
- [*] I've verified any visual changes using Percy (add a commit with `[percy]` in the message to trigger)

Changes Made: 

- Add z-index of z-10 to the leaderboard container 

<img width="1357" height="488" alt="image" src="https://github.com/user-attachments/assets/516a07d1-f9db-4234-8046-c3349758a27e" />
