### PR TITLE
Show completed stage indicators on Course Overview page

### DIFF
--- a/app/components/course-overview-page/introduction-and-stages.hbs
+++ b/app/components/course-overview-page/introduction-and-stages.hbs
@@ -9,6 +9,6 @@
       <span class="relative px-6 bg-white dark:bg-gray-850">Stages</span>
     </h3>
 
-    <CourseOverviewPage::StageList @course={{@course}} />
+    <CourseOverviewPage::StageList @course={{@course}} @completedStages={{@completedStages}} />
   </div>
 </div>

--- a/app/components/course-overview-page/introduction-and-stages.ts
+++ b/app/components/course-overview-page/introduction-and-stages.ts
@@ -1,11 +1,13 @@
 import Component from '@glimmer/component';
 import type CourseModel from 'codecrafters-frontend/models/course';
+import type CourseStageModel from 'codecrafters-frontend/models/course-stage';
 
 interface Signature {
   Element: HTMLDivElement;
 
   Args: {
     course: CourseModel;
+    completedStages?: CourseStageModel[];
   };
 }
 

--- a/app/components/course-overview-page/stage-list.hbs
+++ b/app/components/course-overview-page/stage-list.hbs
@@ -1,1 +1,1 @@
-<TrackPage::CourseCard::StageList @completedStages={{(array)}} @course={{@course}} />
+<TrackPage::CourseCard::StageList @completedStages={{@completedStages}} @course={{@course}} />

--- a/app/components/course-overview-page/stage-list.ts
+++ b/app/components/course-overview-page/stage-list.ts
@@ -1,9 +1,11 @@
 import Component from '@glimmer/component';
 import CourseModel from 'codecrafters-frontend/models/course';
+import type CourseStageModel from 'codecrafters-frontend/models/course-stage';
 
 interface Signature {
   Args: {
     course: CourseModel;
+    completedStages?: CourseStageModel[];
   };
 }
 

--- a/app/components/track-page/course-card/stage-list-item.hbs
+++ b/app/components/track-page/course-card/stage-list-item.hbs
@@ -18,7 +18,9 @@
     </div>
 
     {{#if @isComplete}}
-      {{svg-jar "check" class="ml-1 w-5 text-teal-500"}}
+      <div data-test-stage-complete-checkmark>
+        {{svg-jar "check" class="ml-1 w-5 text-teal-500"}}
+      </div>
     {{else}}
       <div class="pl-4 hidden sm:flex shrink-0">
         <CourseStageDifficultyLabel @stage={{@stage}} />

--- a/app/components/track-page/course-card/stage-list.ts
+++ b/app/components/track-page/course-card/stage-list.ts
@@ -6,7 +6,7 @@ interface Signature {
   Element: HTMLDivElement;
 
   Args: {
-    completedStages: CourseStageModel[];
+    completedStages?: CourseStageModel[];
     course: CourseModel;
   };
 }

--- a/app/controllers/course-overview.ts
+++ b/app/controllers/course-overview.ts
@@ -29,7 +29,7 @@ export default class CourseOverviewController extends Controller {
       return [];
     }
 
-    return this.userRepositories.filter((repository) => repository.course === this.model.course).flatMap((repository) => repository.completedStages);
+    return this.userRepositories.flatMap((repository) => repository.completedStages);
   }
 
   get currentUser() {

--- a/app/controllers/course-overview.ts
+++ b/app/controllers/course-overview.ts
@@ -25,10 +25,6 @@ export default class CourseOverviewController extends Controller {
   }
 
   get completedStages() {
-    if (!this.model.course) {
-      return [];
-    }
-
     return this.userRepositories.flatMap((repository) => repository.completedStages);
   }
 

--- a/app/controllers/course-overview.ts
+++ b/app/controllers/course-overview.ts
@@ -24,6 +24,14 @@ export default class CourseOverviewController extends Controller {
     }
   }
 
+  get completedStages() {
+    if (!this.model.course) {
+      return [];
+    }
+
+    return this.userRepositories.filter((repository) => repository.course === this.model.course).flatMap((repository) => repository.completedStages);
+  }
+
   get currentUser() {
     return this.authenticator.currentUser;
   }

--- a/app/routes/course-overview.ts
+++ b/app/routes/course-overview.ts
@@ -75,7 +75,7 @@ export default class CourseOverviewRoute extends BaseRoute {
   }
 
   #queryUserRepositories(course: CourseModel) {
-    if (course && this.authenticator.isAuthenticated) {
+    if (this.authenticator.isAuthenticated) {
       return this.store.query('repository', {
         include: RepositoryPoller.defaultIncludedResources,
         course_id: course.id,

--- a/app/routes/course-overview.ts
+++ b/app/routes/course-overview.ts
@@ -9,11 +9,9 @@ import type MetaDataService from 'codecrafters-frontend/services/meta-data';
 import type Store from '@ember-data/store';
 import type RouterService from '@ember/routing/router-service';
 import { inject as service } from '@ember/service';
-import type CourseStageModel from 'codecrafters-frontend/models/course-stage';
 
 export interface ModelType {
   course: CourseModel;
-  completedStages?: CourseStageModel[];
 }
 
 export default class CourseOverviewRoute extends BaseRoute {
@@ -55,40 +53,35 @@ export default class CourseOverviewRoute extends BaseRoute {
     ).findBy('slug', slug);
   }
 
-  #getCompletedStages(course: CourseModel) {
-    if (!course || !this.authenticator.currentUser) {
-      return [];
-    }
-
-    return this.authenticator.currentUser.repositories
-      .filter((repository) => repository.course === course)
-      .flatMap((repository) => repository.completedStages);
-  }
-
   async model({ course_slug }: { course_slug: string }): Promise<ModelType> {
     let course: CourseModel = this.#peekCourse(course_slug);
 
     if (course) {
       // Trigger a refresh anyway, without await
       this.#findCourse(course_slug);
+      this.#queryUserRepositories(course);
     } else {
       course = await this.#findCourse(course_slug);
-
-      if (course && this.authenticator.isAuthenticated) {
-        await this.store.query('repository', {
-          include: RepositoryPoller.defaultIncludedResources,
-          course_id: course.id,
-        });
-      }
+      await this.#queryUserRepositories(course);
     }
 
     return {
       course,
-      completedStages: this.#getCompletedStages(course),
     };
   }
 
   #peekCourse(slug: string) {
     return this.store.peekAll('course').findBy('slug', slug);
+  }
+
+  #queryUserRepositories(course: CourseModel) {
+    if (course && this.authenticator.isAuthenticated) {
+      return this.store.query('repository', {
+        include: RepositoryPoller.defaultIncludedResources,
+        course_id: course.id,
+      });
+    }
+
+    return;
   }
 }

--- a/app/templates/course-overview.hbs
+++ b/app/templates/course-overview.hbs
@@ -6,7 +6,7 @@
   <div class="flex items-start flex-row mb-4">
     <div class="grow">
       <CourseOverviewPage::Notices @course={{this.model.course}} class="mb-4" />
-      <CourseOverviewPage::IntroductionAndStages @course={{this.model.course}} class="w-full" />
+      <CourseOverviewPage::IntroductionAndStages @course={{this.model.course}} @completedStages={{this.model.completedStages}} class="w-full" />
     </div>
 
     <div class="hidden lg:block sticky top-2 w-80 shrink-0 pt-2 ml-2">

--- a/app/templates/course-overview.hbs
+++ b/app/templates/course-overview.hbs
@@ -6,7 +6,7 @@
   <div class="flex items-start flex-row mb-4">
     <div class="grow">
       <CourseOverviewPage::Notices @course={{this.model.course}} class="mb-4" />
-      <CourseOverviewPage::IntroductionAndStages @course={{this.model.course}} @completedStages={{this.model.completedStages}} class="w-full" />
+      <CourseOverviewPage::IntroductionAndStages @course={{this.model.course}} @completedStages={{this.completedStages}} class="w-full" />
     </div>
 
     <div class="hidden lg:block sticky top-2 w-80 shrink-0 pt-2 ml-2">

--- a/tests/acceptance/course-page/attempt-course-stage-test.js
+++ b/tests/acceptance/course-page/attempt-course-stage-test.js
@@ -33,6 +33,7 @@ module('Acceptance | course-page | attempt-course-stage', function (hooks) {
       '/api/v1/courses', // fetch courses (catalog page)
       '/api/v1/languages', // fetch languages (catalog page)
       '/api/v1/courses', // fetch course details (course overview page)
+      '/api/v1/repositories', // fetch repositories (course page)
       '/api/v1/course-leaderboard-entries', // fetch leaderboard entries (course overview page)
       '/api/v1/courses', // refresh course (course page)
       '/api/v1/repositories', // fetch repositories (course page)

--- a/tests/acceptance/course-page/resume-course-test.js
+++ b/tests/acceptance/course-page/resume-course-test.js
@@ -40,6 +40,7 @@ module('Acceptance | course-page | resume-course-test', function (hooks) {
         'fetch languages (catalog)',
         'fetch courses (course page)',
         'fetch repositories (course page)',
+        'fetch repositories (course page)',
         'fetch leaderboard entries (course page)',
         'fetch courses (course overview)',
         'fetch hints (course page)',

--- a/tests/acceptance/course-page/start-course-test.js
+++ b/tests/acceptance/course-page/start-course-test.js
@@ -62,6 +62,7 @@ module('Acceptance | course-page | start-course', function (hooks) {
       '/api/v1/courses', // fetch courses (catalog page)
       '/api/v1/languages', // fetch languages (catalog page)
       '/api/v1/courses', // fetch course details (course overview page)
+      '/api/v1/repositories', // fetch repositories (course page)
       '/api/v1/course-leaderboard-entries', // fetch leaderboard entries (course overview page)
       '/api/v1/courses', // refresh course (course page)
       '/api/v1/repositories', // fetch repositories (course page)

--- a/tests/acceptance/course-page/switch-repository-test.js
+++ b/tests/acceptance/course-page/switch-repository-test.js
@@ -46,6 +46,7 @@ module('Acceptance | course-page | switch-repository', function (hooks) {
       'fetch languages (catalog)',
       'fetch courses (course page)',
       'fetch repositories (course page)',
+      'fetch repositories (course page)',
       'fetch leaderboard entries (course page)',
       'fetch courses (course page)',
       'fetch hints (course page)',

--- a/tests/acceptance/course-page/try-other-language-test.js
+++ b/tests/acceptance/course-page/try-other-language-test.js
@@ -35,6 +35,7 @@ module('Acceptance | course-page | try-other-language', function (hooks) {
       '/api/v1/courses', // fetch courses (catalog page)
       '/api/v1/languages', // fetch languages (catalog page)
       '/api/v1/courses', // fetch course details (course overview page)
+      '/api/v1/repositories', // fetch repositories (catalog page)
       '/api/v1/course-leaderboard-entries', // fetch leaderboard entries (course overview page)
       '/api/v1/courses', // refresh course (course page)
       '/api/v1/repositories', // fetch repositories (course page)

--- a/tests/acceptance/course-page/view-course-stages-test.js
+++ b/tests/acceptance/course-page/view-course-stages-test.js
@@ -85,9 +85,26 @@ module('Acceptance | course-page | view-course-stages-test', function (hooks) {
 
     await catalogPage.visit();
     await catalogPage.clickOnCourse('Build your own Redis');
+
+    assert.true(courseOverviewPage.stageListItems[0].hasCompletionCheckmark, 'first stage has a completion checkmark');
+    assert.false(courseOverviewPage.stageListItems[0].hasDifficultyLabel, 'first stage does not have a difficulty label');
+    assert.true(courseOverviewPage.stageListItems[1].hasCompletionCheckmark, 'second stage has a completion checkmark');
+    assert.false(courseOverviewPage.stageListItems[1].hasDifficultyLabel, 'second stage does not have a difficulty label');
+    assert.true(courseOverviewPage.stageListItems[2].hasCompletionCheckmark, 'third stage has a completion checkmark');
+    assert.false(courseOverviewPage.stageListItems[2].hasDifficultyLabel, 'third stage does not have a difficulty label');
+    assert.true(courseOverviewPage.stageListItems[3].hasCompletionCheckmark, 'fourth stage has a completion checkmark');
+    assert.false(courseOverviewPage.stageListItems[3].hasDifficultyLabel, 'fourth stage does not have a difficulty label');
+
+    assert.false(courseOverviewPage.stageListItems[4].hasCompletionCheckmark, 'fifth stage does not have a completion checkmark');
+    assert.true(courseOverviewPage.stageListItems[4].hasDifficultyLabel, 'fifth stage has a difficulty label');
+    assert.false(courseOverviewPage.stageListItems[5].hasCompletionCheckmark, 'sixth stage does not have a completion checkmark');
+    assert.true(courseOverviewPage.stageListItems[6].hasDifficultyLabel, 'sixth stage has a difficulty label');
+
+    await percySnapshot('Course Stages - Stages list checkmarks');
+
     await courseOverviewPage.clickOnStartCourse();
 
-    assert.strictEqual(coursePage.header.stepName, 'Implement the ECHO command');
+    assert.strictEqual(coursePage.header.stepName, 'Implement the ECHO command', 'stage title is shown in the header');
 
     await coursePage.sidebar.clickOnStepListItem('Respond to PING');
     await animationsSettled();

--- a/tests/pages/course-overview-page.js
+++ b/tests/pages/course-overview-page.js
@@ -1,4 +1,4 @@
-import { clickable, collection, create, text, visitable } from 'ember-cli-page-object';
+import { clickable, collection, create, isPresent, text, visitable } from 'ember-cli-page-object';
 
 export default create({
   adminPanel: {
@@ -10,6 +10,9 @@ export default create({
   clickOnStartCourse: clickable('[data-test-course-overview-header] [data-test-start-course-button]'),
   deprecatedNoticeText: text('[data-test-course-deprecated-notice]'),
   freeNoticeText: text('[data-test-course-free-notice]'),
-  stageListItems: collection('[data-test-stage-list-item]'),
+  stageListItems: collection('[data-test-stage-list-item]', {
+    hasCompletionCheckmark: isPresent('[data-test-stage-complete-checkmark]'),
+    hasDifficultyLabel: isPresent('[data-test-course-difficulty-label]'),
+  }),
   visit: visitable('/courses/:course_slug/overview'),
 });


### PR DESCRIPTION
Closes #3095

### Brief

This adds complete stage indicators to the Course Overview page

### Screenshot

<img width="697" height="710" alt="Знімок екрана 2025-09-21 о 17 57 16" src="https://github.com/user-attachments/assets/12765f3e-e1e1-4328-bef6-2dcf0f07bbd4" />

### Checklist

- [x] I've thoroughly self-reviewed my changes
- [x] I've added tests for my changes, unless they affect admin-only areas (or are otherwise not worth testing)
- [x] I've verified any visual changes using Percy (add a commit with `[percy]` in the message to trigger)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Displays completion checkmarks for stages on the Course Overview page by computing completed stages in the route and passing them through component hierarchy.
> 
> - **Course Overview**
>   - Compute `completedStages` in `routes/course-overview.ts` via `#peekCompletedStages()` (from `course-stage-completion` records) and include in model.
>   - Pass `@completedStages` through `templates/course-overview.hbs` → `CourseOverviewPage::IntroductionAndStages` → `CourseOverviewPage::StageList` → `TrackPage::CourseCard::StageList`.
>   - Make `completedStages` args optional in `StageList` components (`course-overview-page` and `track-page/course-card`).
> - **UI**
>   - Add `data-test-stage-complete-checkmark` wrapper around the checkmark in `stage-list-item.hbs`.
> - **Tests**
>   - Update acceptance test to assert checkmarks/difficulty labels on overview and add Percy snapshot.
>   - Extend `tests/pages/course-overview-page.js` with `isPresent` checks for completion and difficulty labels.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 13d0e0ede1c58ecce74f3f1120e43031664fca57. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->