### PR TITLE
Remove leaderboard feature flag

### DIFF
--- a/app/components/course-page/current-step-complete-modal.ts
+++ b/app/components/course-page/current-step-complete-modal.ts
@@ -2,7 +2,6 @@ import Component from '@glimmer/component';
 import CoursePageStateService from 'codecrafters-frontend/services/course-page-state';
 import type StepDefinition from 'codecrafters-frontend/utils/course-page-step-list/step';
 import { service } from '@ember/service';
-import type FeatureFlagsService from 'codecrafters-frontend/services/feature-flags';
 
 interface Signature {
   Element: HTMLDivElement;
@@ -15,7 +14,6 @@ interface Signature {
 
 export default class CurrentStepCompleteModal extends Component<Signature> {
   @service declare coursePageState: CoursePageStateService;
-  @service declare featureFlags: FeatureFlagsService;
 
   get currentStep() {
     return this.coursePageState.currentStep;
@@ -30,7 +28,7 @@ export default class CurrentStepCompleteModal extends Component<Signature> {
   }
 
   get shouldShowLanguageLeaderboardRankSection() {
-    return this.currentStep.type === 'CourseStageStep' && this.featureFlags.shouldSeeLeaderboard;
+    return this.currentStep.type === 'CourseStageStep';
   }
 
   get stepForNextOrActiveStepButton() {

--- a/app/components/header/index.ts
+++ b/app/components/header/index.ts
@@ -3,7 +3,6 @@ import PromotionalDiscountModel from 'codecrafters-frontend/models/promotional-d
 import logoImage from '/assets/images/logo/logomark-color.svg';
 import type AuthenticatorService from 'codecrafters-frontend/services/authenticator';
 import type ContainerWidthService from 'codecrafters-frontend/services/container-width';
-import type FeatureFlagsService from 'codecrafters-frontend/services/feature-flags';
 import type PreferredLanguageLeaderboardService from 'codecrafters-frontend/services/preferred-language-leaderboard';
 import type RouterService from '@ember/routing/router-service';
 import type VersionTrackerService from 'codecrafters-frontend/services/version-tracker';
@@ -23,7 +22,6 @@ export default class Header extends Component<Signature> {
 
   @service declare authenticator: AuthenticatorService;
   @service declare containerWidth: ContainerWidthService;
-  @service declare featureFlags: FeatureFlagsService;
   @service declare preferredLanguageLeaderboard: PreferredLanguageLeaderboardService;
   @service declare router: RouterService;
   @service declare versionTracker: VersionTrackerService;
@@ -67,16 +65,13 @@ export default class Header extends Component<Signature> {
     const links: { text: string; route: string; type: 'route' | 'link'; routeParams?: string[] }[] = [
       { text: 'Catalog', route: 'catalog', type: 'route' },
       { text: 'Roadmap', route: 'roadmap', type: 'route' },
-    ];
-
-    if (this.featureFlags.shouldSeeLeaderboard) {
-      links.push({
+      {
         text: 'Leaderboard',
         route: 'leaderboard',
         type: 'route',
         routeParams: [this.preferredLanguageLeaderboard.defaultLanguageSlug],
-      });
-    }
+      },
+    ];
 
     return links;
   }

--- a/app/services/feature-flags.ts
+++ b/app/services/feature-flags.ts
@@ -18,9 +18,6 @@ export default class FeatureFlagsService extends Service {
     return this.authenticator.currentUser;
   }
 
-  get shouldSeeLeaderboard(): boolean {
-    return this.currentUser?.isStaff || this.getFeatureFlagValue('should-see-leaderboard') === 'test';
-  }
 
   getFeatureFlagValue(flagName: string): string | null | undefined {
     const value = this.currentUser?.featureFlags?.[flagName];

--- a/tests/acceptance/course-page/attempt-course-stage-test.js
+++ b/tests/acceptance/course-page/attempt-course-stage-test.js
@@ -72,8 +72,6 @@ module('Acceptance | course-page | attempt-course-stage', function (hooks) {
     testScenario(this.server);
     const currentUser = signInAsSubscriber(this.owner, this.server);
 
-    // TODO: Remove this once leaderboard isn't behind a feature flag
-    currentUser.update({ featureFlags: { 'should-see-leaderboard': 'test' } });
 
     const go = this.server.schema.languages.findBy({ slug: 'go' });
     const redis = this.server.schema.courses.findBy({ slug: 'redis' });

--- a/tests/acceptance/course-page/submit-course-stage-feedback-test.js
+++ b/tests/acceptance/course-page/submit-course-stage-feedback-test.js
@@ -16,8 +16,6 @@ module('Acceptance | course-page | submit-course-stage-feedback', function (hook
     testScenario(this.server);
     const currentUser = signInAsSubscriber(this.owner, this.server);
 
-    // TODO: Remove this once leaderboard isn't behind a feature flag
-    currentUser.update('featureFlags', { 'should-see-leaderboard': 'test' });
 
     const go = this.server.schema.languages.findBy({ slug: 'go' });
     const redis = this.server.schema.courses.findBy({ slug: 'redis' });

--- a/tests/acceptance/course-page/view-course-stages-test.js
+++ b/tests/acceptance/course-page/view-course-stages-test.js
@@ -46,8 +46,6 @@ module('Acceptance | course-page | view-course-stages-test', function (hooks) {
     testScenario(this.server);
     const currentUser = signIn(this.owner, this.server);
 
-    // TODO: Remove this once leaderboard isn't behind a feature flag
-    currentUser.update('featureFlags', { 'should-see-leaderboard': 'test' });
 
     const python = this.server.schema.languages.findBy({ name: 'Python' });
     const redis = this.server.schema.courses.findBy({ slug: 'redis' });

--- a/tests/acceptance/header-test.js
+++ b/tests/acceptance/header-test.js
@@ -26,9 +26,8 @@ module('Acceptance | header-test', function (hooks) {
     assert.strictEqual(currentURL(), '/pay', 'expect to be redirected to pay page');
   });
 
-  test('header should show generic leaderboard link if user has feature flag enabled and leaderboard entries', async function (assert) {
+  test('header should show generic leaderboard link if user is authenticated and leaderboard entries', async function (assert) {
     const user = signIn(this.owner, this.server);
-    user.update('featureFlags', { 'should-see-leaderboard': 'test' });
 
     await catalogPage.visit();
     assert.true(catalogPage.header.hasLink('Leaderboard'), 'expect leaderboard link to be visible');
@@ -37,9 +36,8 @@ module('Acceptance | header-test', function (hooks) {
     assert.strictEqual(currentURL(), '/leaderboards/rust', 'expect to be redirected to rust leaderboard page');
   });
 
-  test('header should show custom leaderboard link if user has feature flag enabled', async function (assert) {
+  test('header should show custom leaderboard link if user is authenticated', async function (assert) {
     const user = signIn(this.owner, this.server);
-    user.update('featureFlags', { 'should-see-leaderboard': 'test' });
 
     const python = this.server.schema.languages.findBy({ name: 'Python' });
 


### PR DESCRIPTION
**Checklist**:

- [x] I've thoroughly self-reviewed my changes
- [x] I've added tests for my changes, unless they affect admin-only areas (or are otherwise not worth testing)
- [ ] I've verified any visual changes using Percy (add a commit with `[percy]` in the message to trigger)

This PR removes the `should-see-leaderboard` feature flag and all its associated usages.

The leaderboard is now a default feature and is exposed to all users. This involved:

*   Removing the `shouldSeeLeaderboard` getter from `FeatureFlagsService`.
*   Updating the `Header` component to always display the leaderboard link for authenticated users.
*   Updating the `CurrentStepCompleteModal` to always show the language leaderboard rank section for `CourseStageStep`.
*   Cleaning up unused `FeatureFlagsService` imports and declarations.
*   Removing feature flag setup from relevant test files and updating test descriptions.

---
[Slack Thread](https://codecrafters-io.slack.com/archives/C09EC1ULV61/p1758650083411119?thread_ts=1758650083.411119&cid=C09EC1ULV61)

<a href="https://cursor.com/background-agent?bcId=bc-6cc47141-3b8f-408b-8b68-9aeb3249d0af"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-6cc47141-3b8f-408b-8b68-9aeb3249d0af"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

