### PR TITLE
feat(gifts): add gift payment flow with multi-step navigation

### DIFF
--- a/app/components/gift-payment-page/choose-plan-step-container.hbs
+++ b/app/components/gift-payment-page/choose-plan-step-container.hbs
@@ -1,0 +1,76 @@
+<GiftPaymentPage::StepContainer @title="Choose Membership Plan" data-test-choose-plan-step-container>
+  <div class="flex flex-col gap-y-3">
+    {{#each this.pricingPlans as |plan|}}
+      <div
+        class="flex items-start justify-between border
+          {{if (eq @giftPaymentFlow.pricingPlanId plan.id) 'border-teal-500' 'border-gray-200 hover:border-gray-300'}}
+          rounded p-4
+          {{if (eq @giftPaymentFlow.pricingPlanId plan.id) 'bg-teal-50' 'bg-white hover:bg-gray-50'}}"
+        role="button"
+        {{on "click" (fn this.handlePlanSelect plan)}}
+        data-test-plan-card
+      >
+        <div class="flex items-start gap-3">
+          <div
+            class="flex-shrink-0 flex items-center justify-center w-4 h-4 border rounded-full mt-0.5
+              {{if (eq @giftPaymentFlow.pricingPlanId plan.id) 'border-teal-500' 'border-gray-400'}}"
+          >
+            {{#if (eq @giftPaymentFlow.pricingPlanId plan.id)}}
+              <div class="w-2.5 h-2.5 bg-teal-500 rounded-full"></div>
+            {{/if}}
+          </div>
+
+          <div>
+            <div class="flex items-center gap-x-1.5">
+              <span class="text-gray-600 font-bold text-sm">
+                {{plan.title}}
+                pass
+              </span>
+              {{#if (eq plan.id "yearly")}}
+                <span class="inline-block bg-teal-500 text-white font-bold rounded px-1.5 py-1 text-xxs uppercase">popular</span>
+              {{/if}}
+            </div>
+
+            <div class="prose prose-xs prose-compact mt-1 text-gray-500">
+              {{#if plan.validityInMonths}}
+                <p>
+                  Access to all membership benefits for
+                  {{plan.title}}
+                </p>
+              {{else}}
+                <p>
+                  Access to all membership benefits forever
+                </p>
+              {{/if}}
+            </div>
+          </div>
+        </div>
+
+        <div class="flex flex-col items-end pl-4 flex-shrink-0">
+          <div class="text-gray-600 font-bold">
+            ${{plan.priceInDollars}}
+          </div>
+        </div>
+      </div>
+    {{/each}}
+  </div>
+
+  <div class="mt-6 flex gap-4 justify-between items-stretch sm:items-center flex-col-reverse sm:flex-row">
+    <div class="text-xs text-gray-500">
+      You'll receive a gift link that you can send to the recipient.
+    </div>
+
+    <div>
+      <PrimaryButtonWithSpinner
+        @isDisabled={{false}}
+        @shouldShowSpinner={{and @giftPaymentFlow.isSaving true}}
+        @size="large"
+        {{on "click" this.handleContinueButtonClick}}
+        class="w-full sm:w-auto justify-center"
+        data-test-continue-button
+      >
+        Continue
+      </PrimaryButtonWithSpinner>
+    </div>
+  </div>
+</GiftPaymentPage::StepContainer>

--- a/app/components/gift-payment-page/choose-plan-step-container.hbs
+++ b/app/components/gift-payment-page/choose-plan-step-container.hbs
@@ -56,8 +56,8 @@
   </div>
 
   <div class="mt-6 flex gap-4 justify-between items-stretch sm:items-center flex-col-reverse sm:flex-row">
-    <div class="text-xs text-gray-500">
-      You'll receive a gift link that you can send to the recipient.
+    <div class="text-xs text-gray-500 text-center">
+      Your total will be ${{this.selectedPlan.priceInDollars}}.
     </div>
 
     <div>

--- a/app/components/gift-payment-page/choose-plan-step-container.hbs
+++ b/app/components/gift-payment-page/choose-plan-step-container.hbs
@@ -62,14 +62,18 @@
 
     <div>
       <PrimaryButtonWithSpinner
-        @isDisabled={{false}}
-        @shouldShowSpinner={{and @giftPaymentFlow.isSaving true}}
+        @isDisabled={{this.isProcessingContinueButtonClick}}
+        @shouldShowSpinner={{this.isProcessingContinueButtonClick}}
         @size="large"
         {{on "click" this.handleContinueButtonClick}}
         class="w-full sm:w-auto justify-center"
         data-test-continue-button
       >
-        Continue
+        {{#if this.isProcessingContinueButtonClick}}
+          Saving...
+        {{else}}
+          Continue
+        {{/if}}
       </PrimaryButtonWithSpinner>
     </div>
   </div>

--- a/app/components/gift-payment-page/choose-plan-step-container.hbs
+++ b/app/components/gift-payment-page/choose-plan-step-container.hbs
@@ -26,7 +26,7 @@
                 {{plan.title}}
                 pass
               </span>
-              {{#if (eq plan.id "yearly")}}
+              {{#if (eq plan.validityInMonths 12)}}
                 <span class="inline-block bg-teal-500 text-white font-bold rounded px-1.5 py-1 text-xxs uppercase">popular</span>
               {{/if}}
             </div>

--- a/app/components/gift-payment-page/choose-plan-step-container.ts
+++ b/app/components/gift-payment-page/choose-plan-step-container.ts
@@ -42,6 +42,12 @@ export default class ChoosePlanStepContainer extends Component<Signature> {
     }
   }
 
+  get selectedPlan(): PricingPlan | null {
+    const plan = this.pricingPlans.find((p) => p.id === this.args.giftPaymentFlow.pricingPlanId);
+
+    return plan || null;
+  }
+
   get validPricingPlanIds(): string[] {
     return this.pricingPlans.map((plan) => plan.id);
   }

--- a/app/components/gift-payment-page/choose-plan-step-container.ts
+++ b/app/components/gift-payment-page/choose-plan-step-container.ts
@@ -1,0 +1,61 @@
+import Component from '@glimmer/component';
+import { action } from '@ember/object';
+import type GiftPaymentFlowModel from 'codecrafters-frontend/models/gift-payment-flow';
+import { next } from '@ember/runloop';
+
+export interface PricingPlan {
+  id: 'quarterly' | 'yearly' | 'lifetime';
+  title: string;
+  priceInDollars: number;
+  validityInMonths?: number;
+}
+
+export const GIFT_PRICING_PLANS: PricingPlan[] = [
+  { id: 'quarterly', title: '3 months', priceInDollars: 120, validityInMonths: 3 },
+  { id: 'yearly', title: '1 year', priceInDollars: 360, validityInMonths: 12 },
+  { id: 'lifetime', title: 'Lifetime', priceInDollars: 1490 },
+];
+
+interface Signature {
+  Element: HTMLDivElement;
+
+  Args: {
+    giftPaymentFlow: GiftPaymentFlowModel;
+    onContinueButtonClick: () => void;
+  };
+}
+
+export default class ChoosePlanStepContainer extends Component<Signature> {
+  pricingPlans = GIFT_PRICING_PLANS;
+
+  constructor(owner: unknown, args: Signature['Args']) {
+    super(owner, args);
+
+    if (!this.validPricingPlanIds.includes(this.args.giftPaymentFlow.pricingPlanId)) {
+      next(() => {
+        this.args.giftPaymentFlow.pricingPlanId = 'yearly';
+      });
+    }
+  }
+
+  get validPricingPlanIds(): string[] {
+    return this.pricingPlans.map((plan) => plan.id);
+  }
+
+  @action
+  async handleContinueButtonClick() {
+    // TODO: Save
+    this.args.onContinueButtonClick();
+  }
+
+  @action
+  handlePlanSelect(plan: PricingPlan) {
+    this.args.giftPaymentFlow.pricingPlanId = plan.id;
+  }
+}
+
+declare module '@glint/environment-ember-loose/registry' {
+  export default interface Registry {
+    'GiftPaymentPage::ChoosePlanStepContainer': typeof ChoosePlanStepContainer;
+  }
+}

--- a/app/components/gift-payment-page/choose-plan-step-container.ts
+++ b/app/components/gift-payment-page/choose-plan-step-container.ts
@@ -1,22 +1,11 @@
 import Component from '@glimmer/component';
-import { action } from '@ember/object';
 import type GiftPaymentFlowModel from 'codecrafters-frontend/models/gift-payment-flow';
+import type { PricingPlan } from 'codecrafters-frontend/components/pay-page/choose-membership-plan-modal';
+import { PRICING_PLANS } from 'codecrafters-frontend/components/pay-page/choose-membership-plan-modal';
+import { action } from '@ember/object';
 import { next } from '@ember/runloop';
 import { task } from 'ember-concurrency';
 import { tracked } from '@glimmer/tracking';
-
-export interface PricingPlan {
-  id: 'quarterly' | 'yearly' | 'lifetime';
-  title: string;
-  priceInDollars: number;
-  validityInMonths?: number;
-}
-
-export const GIFT_PRICING_PLANS: PricingPlan[] = [
-  { id: 'quarterly', title: '3 months', priceInDollars: 120, validityInMonths: 3 },
-  { id: 'yearly', title: '1 year', priceInDollars: 360, validityInMonths: 12 },
-  { id: 'lifetime', title: 'Lifetime', priceInDollars: 1490 },
-];
 
 interface Signature {
   Element: HTMLDivElement;
@@ -30,7 +19,7 @@ interface Signature {
 export default class ChoosePlanStepContainer extends Component<Signature> {
   @tracked isProcessingContinueButtonClick = false;
 
-  pricingPlans = GIFT_PRICING_PLANS;
+  pricingPlans = PRICING_PLANS;
 
   constructor(owner: unknown, args: Signature['Args']) {
     super(owner, args);

--- a/app/components/gift-payment-page/confirm-and-pay-step-container.hbs
+++ b/app/components/gift-payment-page/confirm-and-pay-step-container.hbs
@@ -10,12 +10,12 @@
           <li>
             You are purchasing a
             <b>{{this.selectedPlan.title}} pass</b>
-            gift (<span class="underline">change</span>)
+            gift (<button type="button" class="underline cursor-pointer" {{on "click" (fn @onNavigationItemClick 2)}}>change</button>)
           </li>
           <li>
             Your payment receipt will be sent to
             <b>{{@giftPaymentFlow.senderEmailAddress}}</b>
-            (<span class="underline">change</span>)
+            (<button type="button" class="underline cursor-pointer" {{on "click" (fn @onNavigationItemClick 1)}}>change</button>)
           </li>
         </ul>
       </div>

--- a/app/components/gift-payment-page/confirm-and-pay-step-container.hbs
+++ b/app/components/gift-payment-page/confirm-and-pay-step-container.hbs
@@ -1,0 +1,92 @@
+<GiftPaymentPage::StepContainer @title="Confirm & Pay" data-test-confirm-and-pay-step-container>
+  <Alert @color="blue" class="mb-3">
+    <div>
+      <div class="prose prose-blue prose-xs prose-compact">
+        <h4>
+          Your membership gift details
+        </h4>
+
+        <ul>
+          <li>
+            You are purchasing a
+            <b>{{this.selectedPlan.title}} pass</b>
+            gift (<span class="underline">change</span>)
+          </li>
+          <li>
+            Your payment receipt will be sent to
+            <b>{{@giftPaymentFlow.senderEmailAddress}}</b>
+            (<span class="underline">change</span>)
+          </li>
+        </ul>
+      </div>
+    </div>
+  </Alert>
+
+  <Alert @color="teal" class="mt-3">
+    <div class="prose prose-xs prose-green prose-compact">
+      <h4>
+        Next steps
+      </h4>
+
+      <ul>
+        <li>
+          Once payment is complete, we'll send you a gift link. You can share this link with the recipient at the time of your choosing.
+        </li>
+        <li>
+          If you run into any issues, please reach out to us at
+          <a href="mailto:hello@codecrafters.io">hello@codecrafters.io</a>. We usually respond within 24 hours.
+        </li>
+      </ul>
+    </div>
+  </Alert>
+
+  <div class="bg-gray-50/50 rounded-sm border border-gray-200 p-3 mt-3">
+    <div class="prose prose-xs prose-compact">
+      <h4>
+        Expiry and refunds
+      </h4>
+
+      <ul>
+        <li>
+          If a gift isn't claimed within 12 months, it will expire.
+        </li>
+        <li>
+          You are eligible for a full refund within 30 days of purchase if the gift hasn't been claimed yet.
+        </li>
+        <li>
+          Refunds are not available after 30 days of purchase, or if the gift has been claimed.
+        </li>
+      </ul>
+    </div>
+  </div>
+
+  <div class="h-px bg-gray-100 mt-6 mb-6"></div>
+
+  <div class="flex gap-4 justify-between items-stretch sm:items-center flex-col-reverse sm:flex-row">
+    {{#if this.errorMessage}}
+      <div class="text-red-600 text-sm font-semibold">
+        {{this.errorMessage}}
+      </div>
+    {{else}}
+      <div class="text-xs text-gray-500 text-center">
+        Payments are processed securely using Stripe.
+      </div>
+    {{/if}}
+
+    <PrimaryButtonWithSpinner
+      @isDisabled={{this.isProcessingPayment}}
+      @shouldShowSpinner={{this.isProcessingPayment}}
+      @size="large"
+      {{on "click" this.handlePaymentButtonClick}}
+      class="w-full sm:w-auto justify-center"
+      data-test-pay-button
+    >
+      {{#if this.isProcessingPayment}}
+        Loading...
+      {{else}}
+        Pay ${{this.totalAmount}}
+        →
+      {{/if}}
+    </PrimaryButtonWithSpinner>
+  </div>
+</GiftPaymentPage::StepContainer>

--- a/app/components/gift-payment-page/confirm-and-pay-step-container.ts
+++ b/app/components/gift-payment-page/confirm-and-pay-step-container.ts
@@ -1,0 +1,73 @@
+import Component from '@glimmer/component';
+import { action } from '@ember/object';
+import type GiftPaymentFlowModel from 'codecrafters-frontend/models/gift-payment-flow';
+import { task } from 'ember-concurrency';
+import { tracked } from '@glimmer/tracking';
+
+export interface PricingPlan {
+  id: 'quarterly' | 'yearly' | 'lifetime';
+  title: string;
+  priceInDollars: number;
+  validityInMonths?: number;
+}
+
+export const GIFT_PRICING_PLANS: PricingPlan[] = [
+  { id: 'quarterly', title: '3 months', priceInDollars: 120, validityInMonths: 3 },
+  { id: 'yearly', title: '1 year', priceInDollars: 360, validityInMonths: 12 },
+  { id: 'lifetime', title: 'Lifetime', priceInDollars: 1490 },
+];
+
+interface Signature {
+  Element: HTMLDivElement;
+
+  Args: {
+    giftPaymentFlow: GiftPaymentFlowModel;
+  };
+}
+
+export default class ConfirmAndPayStepContainer extends Component<Signature> {
+  @tracked errorMessage: string | null = null;
+  @tracked isProcessingPayment = false;
+
+  pricingPlans = GIFT_PRICING_PLANS;
+
+  get selectedPlan(): PricingPlan | null {
+    const plan = this.pricingPlans.find((p) => p.id === this.args.giftPaymentFlow.pricingPlanId);
+
+    return plan || null;
+  }
+
+  get totalAmount(): number {
+    return this.selectedPlan?.priceInDollars || 0;
+  }
+
+  @action
+  async handlePaymentButtonClick() {
+    this.errorMessage = null;
+    this.isProcessingPayment = true;
+
+    try {
+      await this.processPaymentTask.perform();
+    } catch {
+      this.errorMessage = 'Payment failed. Please try again.';
+      this.isProcessingPayment = false;
+    }
+  }
+
+  processPaymentTask = task({ keepLatest: true }, async (): Promise<void> => {
+    // TODO: Implement actual payment processing
+    // This would typically involve:
+    // 1. Creating a checkout session with Stripe
+    // 2. Redirecting to Stripe Checkout
+    // 3. Handling the success/cancel redirects
+
+    // For now, simulate a delay
+    await new Promise((resolve) => setTimeout(resolve, 2000));
+  });
+}
+
+declare module '@glint/environment-ember-loose/registry' {
+  export default interface Registry {
+    'GiftPaymentPage::ConfirmAndPayStepContainer': typeof ConfirmAndPayStepContainer;
+  }
+}

--- a/app/components/gift-payment-page/confirm-and-pay-step-container.ts
+++ b/app/components/gift-payment-page/confirm-and-pay-step-container.ts
@@ -1,21 +1,10 @@
 import Component from '@glimmer/component';
-import { action } from '@ember/object';
 import type GiftPaymentFlowModel from 'codecrafters-frontend/models/gift-payment-flow';
+import type { PricingPlan } from 'codecrafters-frontend/components/pay-page/choose-membership-plan-modal';
+import { PRICING_PLANS } from 'codecrafters-frontend/components/pay-page/choose-membership-plan-modal';
+import { action } from '@ember/object';
 import { task } from 'ember-concurrency';
 import { tracked } from '@glimmer/tracking';
-
-export interface PricingPlan {
-  id: 'quarterly' | 'yearly' | 'lifetime';
-  title: string;
-  priceInDollars: number;
-  validityInMonths?: number;
-}
-
-export const GIFT_PRICING_PLANS: PricingPlan[] = [
-  { id: 'quarterly', title: '3 months', priceInDollars: 120, validityInMonths: 3 },
-  { id: 'yearly', title: '1 year', priceInDollars: 360, validityInMonths: 12 },
-  { id: 'lifetime', title: 'Lifetime', priceInDollars: 1490 },
-];
 
 interface Signature {
   Element: HTMLDivElement;
@@ -30,7 +19,7 @@ export default class ConfirmAndPayStepContainer extends Component<Signature> {
   @tracked errorMessage: string | null = null;
   @tracked isProcessingPayment = false;
 
-  pricingPlans = GIFT_PRICING_PLANS;
+  pricingPlans = PRICING_PLANS;
 
   get selectedPlan(): PricingPlan | null {
     const plan = this.pricingPlans.find((p) => p.id === this.args.giftPaymentFlow.pricingPlanId);

--- a/app/components/gift-payment-page/confirm-and-pay-step-container.ts
+++ b/app/components/gift-payment-page/confirm-and-pay-step-container.ts
@@ -22,6 +22,7 @@ interface Signature {
 
   Args: {
     giftPaymentFlow: GiftPaymentFlowModel;
+    onNavigationItemClick: (step: number) => void;
   };
 }
 

--- a/app/components/gift-payment-page/enter-details-step-container.hbs
+++ b/app/components/gift-payment-page/enter-details-step-container.hbs
@@ -32,20 +32,25 @@
         You'll receive a gift link that you can send to the recipient.
       </div>
       <div>
+        {{! We don't use on "click" here because it's handled by the form submit event }}
         <PrimaryButtonWithSpinner
-          @isDisabled={{this.continueButtonIsDisabled}}
-          @shouldShowSpinner={{and @giftPaymentFlow.isSaving true}}
+          @isDisabled={{or (not this.formInputsAreValid) this.isProcessingContinueButtonClick}}
+          @shouldShowSpinner={{this.isProcessingContinueButtonClick}}
           @size="large"
           type="submit"
           class="w-full sm:w-auto justify-center"
           data-test-continue-button
         >
-          Continue
+          {{#if this.isProcessingContinueButtonClick}}
+            Saving...
+          {{else}}
+            Continue
+          {{/if}}
         </PrimaryButtonWithSpinner>
 
-        {{#if this.continueButtonIsDisabled}}
+        {{#unless this.formInputsAreValid}}
           <EmberTooltip @text="Enter details above to continue" />
-        {{/if}}
+        {{/unless}}
       </div>
     </div>
   </form>

--- a/app/components/gift-payment-page/enter-details-step-container.hbs
+++ b/app/components/gift-payment-page/enter-details-step-container.hbs
@@ -29,14 +29,15 @@
 
     <div class="flex gap-4 justify-between items-stretch sm:items-center flex-col-reverse sm:flex-row">
       <div class="text-xs text-gray-500">
-        We'll send you a gift link that you can send to the recipient.
+        You'll receive a gift link that you can send to the recipient.
       </div>
       <div>
         <PrimaryButtonWithSpinner
           @isDisabled={{this.continueButtonIsDisabled}}
           @shouldShowSpinner={{and @giftPaymentFlow.isSaving true}}
+          @size="large"
           type="submit"
-          class="w-full justify-center sm:w-auto"
+          class="w-full sm:w-auto justify-center"
           data-test-continue-button
         >
           Continue

--- a/app/components/gift-payment-page/enter-details-step-container.hbs
+++ b/app/components/gift-payment-page/enter-details-step-container.hbs
@@ -1,0 +1,51 @@
+<GiftPaymentPage::StepContainer @title="Gift Details" data-test-enter-details-step-container>
+  <form {{on "submit" this.handleFormSubmit}} {{did-insert this.handleDidInsertFormElement}}>
+    <GiftPaymentPage::GiftDetailsForm::Section @title="Your Email" @description="We'll send a payment receipt to this email address.">
+      <Input
+        @value={{@giftPaymentFlow.senderEmailAddress}}
+        @type="email"
+        {{on "blur" this.handleInputBlur}}
+        class="text-sm rounded-sm px-3 py-2 placeholder-gray-300 focus:outline-hidden focus:ring-2 focus:ring-teal-500 border border-gray-200 w-full"
+        id="sender_email_address_input"
+        placeholder="john@example.com"
+        required
+      />
+    </GiftPaymentPage::GiftDetailsForm::Section>
+
+    <div class="h-px bg-gray-100 mt-6 mb-6"></div>
+
+    <GiftPaymentPage::GiftDetailsForm::Section @title="Gift Message" @description="Optional. You can edit this after purchase.">
+      <Textarea
+        @value={{@giftPaymentFlow.giftMessage}}
+        {{on "blur" this.handleInputBlur}}
+        class="text-sm rounded-sm px-3 py-2 placeholder-gray-300 focus:outline-hidden focus:ring-2 focus:ring-teal-500 border border-gray-200 w-full"
+        id="gift_message_input"
+        placeholder={{this.giftMessageInputPlaceholder}}
+        rows="5"
+      />
+    </GiftPaymentPage::GiftDetailsForm::Section>
+
+    <div class="h-px bg-gray-100 mt-6 mb-6"></div>
+
+    <div class="flex gap-4 justify-between items-stretch sm:items-center flex-col-reverse sm:flex-row">
+      <div class="text-xs text-gray-500">
+        We'll send you a gift link that you can send to the recipient.
+      </div>
+      <div>
+        <PrimaryButtonWithSpinner
+          @isDisabled={{this.continueButtonIsDisabled}}
+          @shouldShowSpinner={{and @giftPaymentFlow.isSaving true}}
+          type="submit"
+          class="w-full justify-center sm:w-auto"
+          data-test-continue-button
+        >
+          Continue
+        </PrimaryButtonWithSpinner>
+
+        {{#if this.continueButtonIsDisabled}}
+          <EmberTooltip @text="Enter details above to continue" />
+        {{/if}}
+      </div>
+    </div>
+  </form>
+</GiftPaymentPage::StepContainer>

--- a/app/components/gift-payment-page/enter-details-step-container.ts
+++ b/app/components/gift-payment-page/enter-details-step-container.ts
@@ -1,0 +1,63 @@
+import Component from '@glimmer/component';
+import { action } from '@ember/object';
+import type GiftPaymentFlowModel from 'codecrafters-frontend/models/gift-payment-flow';
+import { task } from 'ember-concurrency';
+import { tracked } from '@glimmer/tracking';
+
+interface Signature {
+  Element: HTMLDivElement;
+
+  Args: {
+    giftPaymentFlow: GiftPaymentFlowModel;
+    onContinueButtonClick: () => void;
+  };
+}
+
+export default class EnterDetailsStepContainer extends Component<Signature> {
+  formElement: HTMLFormElement | null = null;
+
+  @tracked continueButtonIsDisabled = true;
+
+  get giftMessageInputPlaceholder() {
+    return `Hey Jess!
+
+Hope you enjoy learning with CodeCrafters.`;
+  }
+
+  @action
+  async handleDidInsertFormElement(formElement: HTMLFormElement) {
+    this.formElement = formElement;
+    this.continueButtonIsDisabled = !this.formElement.checkValidity();
+  }
+
+  @action
+  async handleFormSubmit(e: Event) {
+    e.preventDefault();
+
+    this.formElement!.reportValidity();
+
+    if (this.formElement!.checkValidity()) {
+      await this.saveGiftPaymentFlowTask.perform();
+      this.args.onContinueButtonClick();
+    }
+  }
+
+  @action
+  async handleInputBlur() {
+    if (this.formElement!.checkValidity()) {
+      this.saveGiftPaymentFlowTask.perform();
+    }
+
+    this.continueButtonIsDisabled = !this.formElement!.checkValidity();
+  }
+
+  saveGiftPaymentFlowTask = task({ keepLatest: true }, async (): Promise<void> => {
+    this.args.giftPaymentFlow.save();
+  });
+}
+
+declare module '@glint/environment-ember-loose/registry' {
+  export default interface Registry {
+    'GiftPaymentPage::EnterDetailsStepContainer': typeof EnterDetailsStepContainer;
+  }
+}

--- a/app/components/gift-payment-page/enter-details-step-container.ts
+++ b/app/components/gift-payment-page/enter-details-step-container.ts
@@ -16,7 +16,8 @@ interface Signature {
 export default class EnterDetailsStepContainer extends Component<Signature> {
   formElement: HTMLFormElement | null = null;
 
-  @tracked continueButtonIsDisabled = true;
+  @tracked isProcessingContinueButtonClick = false;
+  @tracked formInputsAreValid = false;
 
   get giftMessageInputPlaceholder() {
     return `Hey Jess!
@@ -27,7 +28,7 @@ Hope you enjoy learning with CodeCrafters.`;
   @action
   async handleDidInsertFormElement(formElement: HTMLFormElement) {
     this.formElement = formElement;
-    this.continueButtonIsDisabled = !this.formElement.checkValidity();
+    this.recomputeFormInputsAreValid();
   }
 
   @action
@@ -35,8 +36,10 @@ Hope you enjoy learning with CodeCrafters.`;
     e.preventDefault();
 
     this.formElement!.reportValidity();
+    this.recomputeFormInputsAreValid();
 
-    if (this.formElement!.checkValidity()) {
+    if (this.formInputsAreValid) {
+      this.isProcessingContinueButtonClick = true;
       await this.saveGiftPaymentFlowTask.perform();
       this.args.onContinueButtonClick();
     }
@@ -44,11 +47,16 @@ Hope you enjoy learning with CodeCrafters.`;
 
   @action
   async handleInputBlur() {
-    if (this.formElement!.checkValidity()) {
+    this.recomputeFormInputsAreValid();
+
+    if (this.formInputsAreValid) {
       this.saveGiftPaymentFlowTask.perform();
     }
+  }
 
-    this.continueButtonIsDisabled = !this.formElement!.checkValidity();
+  @action
+  recomputeFormInputsAreValid() {
+    this.formInputsAreValid = this.formElement!.checkValidity();
   }
 
   saveGiftPaymentFlowTask = task({ keepLatest: true }, async (): Promise<void> => {

--- a/app/components/gift-payment-page/enter-details-step-container.ts
+++ b/app/components/gift-payment-page/enter-details-step-container.ts
@@ -52,7 +52,7 @@ Hope you enjoy learning with CodeCrafters.`;
   }
 
   saveGiftPaymentFlowTask = task({ keepLatest: true }, async (): Promise<void> => {
-    this.args.giftPaymentFlow.save();
+    await this.args.giftPaymentFlow.save();
   });
 }
 

--- a/app/components/gift-payment-page/gift-details-form/section.hbs
+++ b/app/components/gift-payment-page/gift-details-form/section.hbs
@@ -1,0 +1,10 @@
+<div class="grid grid-cols-1 sm:grid-cols-2">
+  <div class="pb-6 pr-0 sm:pb-0 sm:pr-4">
+    <div class="text-gray-700 font-semibold text-lg mb-1">{{@title}}</div>
+    <div class="text-gray-400 text-xs">{{@description}}</div>
+  </div>
+
+  <div>
+    {{yield}}
+  </div>
+</div>

--- a/app/components/gift-payment-page/gift-details-form/section.ts
+++ b/app/components/gift-payment-page/gift-details-form/section.ts
@@ -1,0 +1,22 @@
+import Component from '@glimmer/component';
+
+interface Signature {
+  Element: HTMLDivElement;
+
+  Args: {
+    title: string;
+    description: string;
+  };
+
+  Blocks: {
+    default: [];
+  };
+}
+
+export default class Section extends Component<Signature> {}
+
+declare module '@glint/environment-ember-loose/registry' {
+  export default interface Registry {
+    'GiftPaymentPage::GiftDetailsForm::Section': typeof Section;
+  }
+}

--- a/app/components/gift-payment-page/navigation-container-item.hbs
+++ b/app/components/gift-payment-page/navigation-container-item.hbs
@@ -1,0 +1,20 @@
+<div class="relative hover:opacity-100 {{unless (or @isComplete @isCurrent) 'cursor-not-allowed'}}" role="button" ...attributes>
+  <div
+    class="h-4 w-4
+      {{if (or @isComplete @isCurrent) 'bg-teal-500' 'bg-gray-300'}}
+      border-2
+      {{if (or @isComplete @isCurrent) 'border-teal-500' 'border-gray-300'}}
+      rounded-full"
+  >
+    {{#if @isComplete}}
+      {{svg-jar "check" class="h-3 w-3 text-white"}}
+    {{/if}}
+  </div>
+
+  <div
+    class="absolute -left-20 -right-20 top-6 text-center uppercase font-semibold text-xs sm:text-base
+      {{if (or @isComplete @isCurrent) 'text-teal-500' 'text-gray-300'}}"
+  >
+    {{@name}}
+  </div>
+</div>

--- a/app/components/gift-payment-page/navigation-container-item.ts
+++ b/app/components/gift-payment-page/navigation-container-item.ts
@@ -1,0 +1,19 @@
+import Component from '@glimmer/component';
+
+interface Signature {
+  Element: HTMLDivElement;
+
+  Args: {
+    isComplete: boolean;
+    isCurrent: boolean;
+    name: string;
+  };
+}
+
+export default class NavigationContainerItem extends Component<Signature> {}
+
+declare module '@glint/environment-ember-loose/registry' {
+  export default interface Registry {
+    'GiftPaymentPage::NavigationContainerItem': typeof NavigationContainerItem;
+  }
+}

--- a/app/components/gift-payment-page/navigation-container.hbs
+++ b/app/components/gift-payment-page/navigation-container.hbs
@@ -20,7 +20,7 @@
   <GiftPaymentPage::NavigationContainerItem
     @isComplete={{includes 3 @completedSteps}}
     @isCurrent={{eq @currentStep 3}}
-    @name="Pay"
+    @name="Confirm & Pay"
     {{on "click" (fn @onNavigationItemClick 3)}}
   />
 </div>

--- a/app/components/gift-payment-page/navigation-container.hbs
+++ b/app/components/gift-payment-page/navigation-container.hbs
@@ -1,0 +1,26 @@
+<div class="flex items-center" ...attributes>
+  <GiftPaymentPage::NavigationContainerItem
+    @isComplete={{includes 1 @completedSteps}}
+    @isCurrent={{eq @currentStep 1}}
+    @name="Enter Details"
+    {{on "click" (fn @onNavigationItemClick 1)}}
+  />
+
+  <div class="h-0.5 w-16 sm:w-40 {{if (gt @currentStep 1) 'bg-teal-500' 'bg-gray-200'}} ml-4 mr-4"></div>
+
+  <GiftPaymentPage::NavigationContainerItem
+    @isComplete={{includes 2 @completedSteps}}
+    @isCurrent={{eq @currentStep 2}}
+    @name="Choose Plan"
+    {{on "click" (fn @onNavigationItemClick 2)}}
+  />
+
+  <div class="h-0.5 w-16 sm:w-40 {{if (gt @currentStep 2) 'bg-teal-500' 'bg-gray-200'}} ml-4 mr-4"></div>
+
+  <GiftPaymentPage::NavigationContainerItem
+    @isComplete={{includes 3 @completedSteps}}
+    @isCurrent={{eq @currentStep 3}}
+    @name="Pay"
+    {{on "click" (fn @onNavigationItemClick 3)}}
+  />
+</div>

--- a/app/components/gift-payment-page/navigation-container.ts
+++ b/app/components/gift-payment-page/navigation-container.ts
@@ -1,0 +1,19 @@
+import Component from '@glimmer/component';
+
+interface Signature {
+  Element: HTMLDivElement;
+
+  Args: {
+    completedSteps: number[];
+    currentStep: number;
+    onNavigationItemClick: (step: number) => void;
+  };
+}
+
+export default class NavigationContainer extends Component<Signature> {}
+
+declare module '@glint/environment-ember-loose/registry' {
+  export default interface Registry {
+    'GiftPaymentPage::NavigationContainer': typeof NavigationContainer;
+  }
+}

--- a/app/components/gift-payment-page/step-container.hbs
+++ b/app/components/gift-payment-page/step-container.hbs
@@ -1,0 +1,6 @@
+<div class="w-full max-w-xl bg-white border border-gray-200 rounded-sm p-6" ...attributes>
+  <div class="text-gray-700 font-bold mb-1 uppercase">{{@title}}</div>
+  <div class="h-px bg-gray-100 mt-2 mb-6"></div>
+
+  {{yield}}
+</div>

--- a/app/components/gift-payment-page/step-container.ts
+++ b/app/components/gift-payment-page/step-container.ts
@@ -1,0 +1,21 @@
+import Component from '@glimmer/component';
+
+interface Signature {
+  Element: HTMLDivElement;
+
+  Args: {
+    title: string;
+  };
+
+  Blocks: {
+    default: [];
+  };
+}
+
+export default class StepContainer extends Component<Signature> {}
+
+declare module '@glint/environment-ember-loose/registry' {
+  export default interface Registry {
+    'GiftPaymentPage::StepContainer': typeof StepContainer;
+  }
+}

--- a/app/components/pay-page/choose-membership-plan-modal.ts
+++ b/app/components/pay-page/choose-membership-plan-modal.ts
@@ -11,16 +11,17 @@ import type PromotionalDiscountModel from 'codecrafters-frontend/models/promotio
 import type AuthenticatorService from 'codecrafters-frontend/services/authenticator';
 
 export interface PricingPlan {
-  id: 'quarterly' | 'yearly' | 'lifetime';
+  id: 'v1-3mo' | 'v1-1yr' | 'v1-lifetime';
+  frequency: 'quarterly' | 'yearly' | 'lifetime'; // TODO: Remove this!
   title: string;
   priceInDollars: number;
   validityInMonths?: number; // undefined for lifetime
 }
 
 export const PRICING_PLANS: PricingPlan[] = [
-  { id: 'quarterly', title: '3 months', priceInDollars: 120, validityInMonths: 3 },
-  { id: 'yearly', title: '1 year', priceInDollars: 360, validityInMonths: 12 },
-  { id: 'lifetime', title: 'Lifetime', priceInDollars: 1490 },
+  { id: 'v1-3mo', frequency: 'quarterly', title: '3 months', priceInDollars: 120, validityInMonths: 3 },
+  { id: 'v1-1yr', frequency: 'yearly', title: '1 year', priceInDollars: 360, validityInMonths: 12 },
+  { id: 'v1-lifetime', frequency: 'lifetime', title: 'Lifetime', priceInDollars: 1490 },
 ];
 
 interface Signature {
@@ -43,7 +44,7 @@ export default class ChooseMembershipPlanModal extends Component<Signature> {
   @tracked currentStep: 'plan-selection' | 'invoice-details' = 'plan-selection';
   @tracked extraInvoiceDetailsRequested = false;
   @tracked isCreatingCheckoutSession = false;
-  @tracked selectedPlanId: PricingPlan['id'] = 'quarterly';
+  @tracked selectedPlanId: PricingPlan['id'] = 'v1-3mo';
 
   get selectedPlan(): PricingPlan {
     const plan = this.pricingPlans.find((p) => p.id === this.selectedPlanId);
@@ -90,8 +91,8 @@ export default class ChooseMembershipPlanModal extends Component<Signature> {
     const checkoutSession = this.store.createRecord('individual-checkout-session', {
       cancelUrl: `${window.location.origin}/pay`,
       extraInvoiceDetailsRequested: this.extraInvoiceDetailsRequested,
-      pricingFrequency: this.selectedPlanId,
-      promotionalDiscount: this.selectedPlanId === 'yearly' ? this.args.activeDiscountForYearlyPlan : null,
+      pricingFrequency: this.selectedPlan.frequency, // TODO: Switch to passing in actual IDs
+      promotionalDiscount: this.selectedPlanId === 'v1-1yr' ? this.args.activeDiscountForYearlyPlan : null,
       regionalDiscount: this.args.regionalDiscount || null,
       successUrl: `${window.location.origin}/catalog`,
     });

--- a/app/components/pay-page/choose-membership-plan-modal/invoice-details-step.hbs
+++ b/app/components/pay-page/choose-membership-plan-modal/invoice-details-step.hbs
@@ -4,7 +4,7 @@
       @isSelected={{true}}
       @onClick={{(noop)}}
       @plan={{@selectedPlan}}
-      @promotionalDiscount={{if (eq @selectedPlan.id "yearly") @activeDiscountForYearlyPlan null}}
+      @promotionalDiscount={{if (eq @selectedPlan.validityInMonths 12) @activeDiscountForYearlyPlan null}}
       @regionalDiscount={{@regionalDiscount}}
     />
 

--- a/app/components/pay-page/choose-membership-plan-modal/plan-card.hbs
+++ b/app/components/pay-page/choose-membership-plan-modal/plan-card.hbs
@@ -23,7 +23,7 @@
           {{@plan.title}}
           pass
         </span>
-        {{#if (eq @plan.id "yearly")}}
+        {{#if (eq @plan.validityInMonths 12)}}
           <span class="inline-block bg-teal-500 text-white font-bold rounded px-1.5 py-1 text-xxs uppercase">best value</span>
         {{/if}}
       </div>

--- a/app/components/pay-page/choose-membership-plan-modal/plan-selection-step.hbs
+++ b/app/components/pay-page/choose-membership-plan-modal/plan-selection-step.hbs
@@ -5,7 +5,7 @@
         @isSelected={{eq @selectedPlan.id plan.id}}
         @onClick={{fn @onPlanSelect plan}}
         @plan={{plan}}
-        @promotionalDiscount={{if (eq plan.id "yearly") @activeDiscountForYearlyPlan null}}
+        @promotionalDiscount={{if (eq plan.validityInMonths 12) @activeDiscountForYearlyPlan null}}
         @regionalDiscount={{@regionalDiscount}}
       />
     {{/each}}

--- a/app/controllers/gifts/buy.ts
+++ b/app/controllers/gifts/buy.ts
@@ -5,7 +5,7 @@ import { tracked } from '@glimmer/tracking';
 import scrollToTop from 'codecrafters-frontend/utils/scroll-to-top';
 import type Store from '@ember-data/store';
 import type GiftPaymentFlowModel from 'codecrafters-frontend/models/gift-payment-flow';
-import { fade } from 'ember-animated/transitions/fade';
+import fade from 'ember-animated/transitions/fade';
 
 export default class GiftsBuyController extends Controller {
   transition = fade;

--- a/app/controllers/gifts/buy.ts
+++ b/app/controllers/gifts/buy.ts
@@ -1,0 +1,36 @@
+import { inject as service } from '@ember/service';
+import Controller from '@ember/controller';
+import { action } from '@ember/object';
+import { tracked } from '@glimmer/tracking';
+import scrollToTop from 'codecrafters-frontend/utils/scroll-to-top';
+import type Store from '@ember-data/store';
+import type GiftPaymentFlowModel from 'codecrafters-frontend/models/gift-payment-flow';
+
+export default class GiftsBuyController extends Controller {
+  declare model: GiftPaymentFlowModel;
+  @service declare store: Store;
+
+  queryParams = [{ giftPaymentFlowId: 'f' }];
+
+  @tracked completedSteps: number[] = [];
+  @tracked currentStep: number = 1;
+  @tracked giftPaymentFlowId: string | undefined = undefined;
+
+  @action
+  handleContinueButtonClick() {
+    if (this.model.id) {
+      this.giftPaymentFlowId = this.model.id;
+    }
+
+    this.completedSteps = [...this.completedSteps, this.currentStep];
+    this.currentStep = this.currentStep + 1;
+    scrollToTop();
+  }
+
+  @action
+  handleNavigationItemClick(step: number) {
+    if (step === 1 || this.completedSteps.includes(step - 1)) {
+      this.currentStep = step;
+    }
+  }
+}

--- a/app/controllers/gifts/buy.ts
+++ b/app/controllers/gifts/buy.ts
@@ -5,8 +5,11 @@ import { tracked } from '@glimmer/tracking';
 import scrollToTop from 'codecrafters-frontend/utils/scroll-to-top';
 import type Store from '@ember-data/store';
 import type GiftPaymentFlowModel from 'codecrafters-frontend/models/gift-payment-flow';
+import { fade } from 'ember-animated/transitions/fade';
 
 export default class GiftsBuyController extends Controller {
+  transition = fade;
+
   declare model: GiftPaymentFlowModel;
   @service declare store: Store;
 

--- a/app/models/gift-payment-flow.ts
+++ b/app/models/gift-payment-flow.ts
@@ -1,0 +1,6 @@
+import Model, { attr } from '@ember-data/model';
+
+export default class GiftPaymentFlowModel extends Model {
+  @attr('string') declare giftMessage: string;
+  @attr('string') declare senderEmailAddress: string;
+}

--- a/app/models/gift-payment-flow.ts
+++ b/app/models/gift-payment-flow.ts
@@ -2,5 +2,6 @@ import Model, { attr } from '@ember-data/model';
 
 export default class GiftPaymentFlowModel extends Model {
   @attr('string') declare giftMessage: string;
+  @attr('string') declare pricingPlanId: string;
   @attr('string') declare senderEmailAddress: string;
 }

--- a/app/router.ts
+++ b/app/router.ts
@@ -64,6 +64,7 @@ Router.map(function () {
 
   this.route('course-overview', { path: '/courses/:course_slug/overview' }); // TODO: Add dark mode support
   this.route('debug');
+  this.route('gifts.buy', { path: '/gifts/buy' });
   this.route('institution', { path: '/campus/:institution_slug' });
   this.route('join'); // TODO: Add dark mode support
   this.route('join-course', { path: '/join/:course_slug' });

--- a/app/routes/gifts/buy.ts
+++ b/app/routes/gifts/buy.ts
@@ -17,7 +17,7 @@ export default class GiftsPayRoute extends BaseRoute {
     if (params.giftPaymentFlowId) {
       return await this.store.findRecord('gift-payment-flow', params.giftPaymentFlowId);
     } else {
-      return this.store.createRecord('gift-payment-flow', {});
+      return this.store.createRecord('gift-payment-flow', { pricingPlanId: 'v1-lifetime' });
     }
   }
 }

--- a/app/routes/gifts/buy.ts
+++ b/app/routes/gifts/buy.ts
@@ -1,0 +1,23 @@
+import BaseRoute from 'codecrafters-frontend/utils/base-route';
+import RouteInfoMetadata from 'codecrafters-frontend/utils/route-info-metadata';
+import type GiftPaymentFlowModel from 'codecrafters-frontend/models/gift-payment-flow';
+import type Store from '@ember-data/store';
+import { inject as service } from '@ember/service';
+
+export type ModelType = GiftPaymentFlowModel;
+
+export default class GiftsPayRoute extends BaseRoute {
+  @service declare store: Store;
+
+  buildRouteInfoMetadata() {
+    return new RouteInfoMetadata({ allowsAnonymousAccess: true });
+  }
+
+  async model(params: { giftPaymentFlowId?: string }): Promise<ModelType> {
+    if (params.giftPaymentFlowId) {
+      return await this.store.findRecord('gift-payment-flow', params.giftPaymentFlowId);
+    } else {
+      return this.store.createRecord('gift-payment-flow', {});
+    }
+  }
+}

--- a/app/templates/gifts/buy.hbs
+++ b/app/templates/gifts/buy.hbs
@@ -14,17 +14,13 @@
         class="mb-20"
       />
 
-      {{#if (eq this.currentStep 1)}}
-        <GiftPaymentPage::EnterDetailsStepContainer
-          @giftPaymentFlow={{this.model}}
-          @isComplete={{this.isStep1Complete}}
-          @onContinueButtonClick={{this.handleContinueButtonClick}}
-        />
-      {{else if (eq this.currentStep 2)}}
-        {{!-- <TeamPaymentPage::PaymentDetailsStepContainer @teamPaymentFlow={{this.model}} @onContinueButtonClick={{this.handleContinueButtonClick}} /> --}}
-      {{else if (eq this.currentStep 3)}}
-        {{!-- <TeamPaymentPage::ReviewPaymentStepContainer @teamPaymentFlow={{this.model}} /> --}}
-      {{/if}}
+      {{#animated-if (eq this.currentStep 1) use=this.transition}}
+        <GiftPaymentPage::EnterDetailsStepContainer @giftPaymentFlow={{this.model}} @onContinueButtonClick={{this.handleContinueButtonClick}} />
+      {{else}}{{#if (eq this.currentStep 2)}}
+          <GiftPaymentPage::ChoosePlanStepContainer @giftPaymentFlow={{this.model}} @onContinueButtonClick={{this.handleContinueButtonClick}} />
+        {{else if (eq this.currentStep 3)}}
+          <GiftPaymentPage::ConfirmAndPayStepContainer @giftPaymentFlow={{this.model}} />
+        {{/if}}{{/animated-if}}
     {{/if}}
   </div>
 </div>

--- a/app/templates/gifts/buy.hbs
+++ b/app/templates/gifts/buy.hbs
@@ -14,13 +14,22 @@
         class="mb-20"
       />
 
-      {{#animated-if (eq this.currentStep 1) use=this.transition}}
-        <GiftPaymentPage::EnterDetailsStepContainer @giftPaymentFlow={{this.model}} @onContinueButtonClick={{this.handleContinueButtonClick}} />
-      {{else}}{{#if (eq this.currentStep 2)}}
-          <GiftPaymentPage::ChoosePlanStepContainer @giftPaymentFlow={{this.model}} @onContinueButtonClick={{this.handleContinueButtonClick}} />
-        {{else if (eq this.currentStep 3)}}
-          <GiftPaymentPage::ConfirmAndPayStepContainer @giftPaymentFlow={{this.model}} />
-        {{/if}}{{/animated-if}}
+      <AnimatedContainer class="w-full max-w-xl">
+        {{#animated-if (eq this.currentStep 1) use=this.transition duration=200}}
+          <GiftPaymentPage::EnterDetailsStepContainer @giftPaymentFlow={{this.model}} @onContinueButtonClick={{this.handleContinueButtonClick}} />
+        {{else}}
+          {{#animated-if (eq this.currentStep 2) use=this.transition duration=200}}
+            <GiftPaymentPage::ChoosePlanStepContainer @giftPaymentFlow={{this.model}} @onContinueButtonClick={{this.handleContinueButtonClick}} />
+          {{else}}
+            {{#animated-if (eq this.currentStep 3) use=this.transition duration=200}}
+              <GiftPaymentPage::ConfirmAndPayStepContainer
+                @giftPaymentFlow={{this.model}}
+                @onNavigationItemClick={{this.handleNavigationItemClick}}
+              />
+            {{/animated-if}}
+          {{/animated-if}}
+        {{/animated-if}}
+      </AnimatedContainer>
     {{/if}}
   </div>
 </div>

--- a/app/templates/gifts/buy.hbs
+++ b/app/templates/gifts/buy.hbs
@@ -1,0 +1,30 @@
+{{page-title "Gift a CodeCrafters Membership"}}
+
+<div class="container mx-auto lg:max-w-(--breakpoint-lg) pt-16 pb-48 px-3 md:px-6">
+  <div class="flex flex-col items-center">
+    <h1 class="text-center text-3xl text-gray-700 font-bold tracking-tighter mb-12">Gift a CodeCrafters membership</h1>
+
+    {{#if false}}
+      {{! TODO: Add success step }}
+    {{else}}
+      <GiftPaymentPage::NavigationContainer
+        @completedSteps={{this.completedSteps}}
+        @currentStep={{this.currentStep}}
+        @onNavigationItemClick={{this.handleNavigationItemClick}}
+        class="mb-20"
+      />
+
+      {{#if (eq this.currentStep 1)}}
+        <GiftPaymentPage::EnterDetailsStepContainer
+          @giftPaymentFlow={{this.model}}
+          @isComplete={{this.isStep1Complete}}
+          @onContinueButtonClick={{this.handleContinueButtonClick}}
+        />
+      {{else if (eq this.currentStep 2)}}
+        {{!-- <TeamPaymentPage::PaymentDetailsStepContainer @teamPaymentFlow={{this.model}} @onContinueButtonClick={{this.handleContinueButtonClick}} /> --}}
+      {{else if (eq this.currentStep 3)}}
+        {{!-- <TeamPaymentPage::ReviewPaymentStepContainer @teamPaymentFlow={{this.model}} /> --}}
+      {{/if}}
+    {{/if}}
+  </div>
+</div>

--- a/mirage/config.js
+++ b/mirage/config.js
@@ -35,6 +35,7 @@ import emailAddresses from './handlers/email-addresses';
 import fakeSubmissionLogs from './handlers/fake-submission-logs';
 import featureSuggestions from './handlers/feature-suggestions';
 import freeUsageGrants from './handlers/free-usage-grants';
+import giftPaymentFlows from './handlers/gift-payment-flows';
 import githubAppInstallations from './handlers/github-app-installations';
 import githubRepositorySyncConfigurations from './handlers/github-repository-sync-configurations';
 import individualCheckoutSessions from './handlers/individual-checkout-sessions';
@@ -174,6 +175,7 @@ function routes() {
   fakeSubmissionLogs(this);
   featureSuggestions(this);
   freeUsageGrants(this);
+  giftPaymentFlows(this);
   githubAppInstallations(this);
   githubRepositorySyncConfigurations(this);
   individualCheckoutSessions(this);

--- a/mirage/handlers/gift-payment-flows.js
+++ b/mirage/handlers/gift-payment-flows.js
@@ -1,0 +1,7 @@
+export default function (server) {
+  server.post('/gift-payment-flows');
+  server.patch('/gift-payment-flows/:id');
+
+  // TODO: Add this when we implement fetching an existing payment flow
+  // server.get('/gift-payment-flows/:id');
+}

--- a/tests/acceptance/buy-gift-page/purchase-test.js
+++ b/tests/acceptance/buy-gift-page/purchase-test.js
@@ -1,0 +1,32 @@
+import { module, test } from 'qunit';
+import { setupApplicationTest } from 'codecrafters-frontend/tests/helpers';
+import { setupWindowMock } from 'ember-window-mock/test-support';
+import giftPaymentPage from 'codecrafters-frontend/tests/pages/gift-payment-page';
+import testScenario from 'codecrafters-frontend/mirage/scenarios/test';
+import percySnapshot from '@percy/ember';
+
+module('Acceptance | buy-gift-page | purchase', function (hooks) {
+  setupApplicationTest(hooks);
+  setupWindowMock(hooks);
+
+  test('user can purchase a gift', async function (assert) {
+    testScenario(this.server);
+
+    await giftPaymentPage.visit();
+    assert.ok(giftPaymentPage.enterDetailsStepContainer.isVisible, 'Enter details step is visible');
+    await percySnapshot('Gift Payment - Enter Details Step');
+
+    await giftPaymentPage.enterDetailsStepContainer.fillInSenderEmailAddress('paul@codecrafters.io');
+    await giftPaymentPage.enterDetailsStepContainer.fillInGiftMessage('Hey Jess! \n\nHope you enjoy learning with CodeCrafters.');
+
+    await giftPaymentPage.enterDetailsStepContainer.clickOnContinueButton();
+    assert.ok(giftPaymentPage.choosePlanStepContainer.isVisible, 'Choose plan step is visible');
+    await percySnapshot('Gift Payment - Choose Plan Step');
+
+    await giftPaymentPage.choosePlanStepContainer.clickOnContinueButton();
+    assert.ok(giftPaymentPage.confirmAndPayStepContainer.isVisible, 'Confirm and pay step is visible');
+    await percySnapshot('Gift Payment - Confirm and Pay Step');
+
+    await giftPaymentPage.confirmAndPayStepContainer.clickOnPayButton();
+  });
+});

--- a/tests/pages/gift-payment-page.ts
+++ b/tests/pages/gift-payment-page.ts
@@ -1,0 +1,22 @@
+import { clickable, fillable, visitable } from 'ember-cli-page-object';
+import createPage from 'codecrafters-frontend/tests/support/create-page';
+
+export default createPage({
+  enterDetailsStepContainer: {
+    clickOnContinueButton: clickable('[data-test-continue-button]'),
+    fillInSenderEmailAddress: fillable('#sender_email_address_input'),
+    fillInGiftMessage: fillable('#gift_message_input'),
+    scope: '[data-test-enter-details-step-container]',
+  },
+
+  // paymentDetailsStepContainer: {
+  //   clickOnContinueButton: clickable('[data-test-continue-button]'),
+  //   scope: '[data-test-payment-details-step-container]',
+  // },
+
+  // reviewPaymentStepContainer: {
+  //   scope: '[data-test-review-payment-step-container]',
+  // },
+
+  visit: visitable('/gifts/buy'),
+});

--- a/tests/pages/gift-payment-page.ts
+++ b/tests/pages/gift-payment-page.ts
@@ -9,14 +9,15 @@ export default createPage({
     scope: '[data-test-enter-details-step-container]',
   },
 
-  // paymentDetailsStepContainer: {
-  //   clickOnContinueButton: clickable('[data-test-continue-button]'),
-  //   scope: '[data-test-payment-details-step-container]',
-  // },
+  choosePlanStepContainer: {
+    clickOnContinueButton: clickable('[data-test-continue-button]'),
+    scope: '[data-test-choose-plan-step-container]',
+  },
 
-  // reviewPaymentStepContainer: {
-  //   scope: '[data-test-review-payment-step-container]',
-  // },
+  confirmAndPayStepContainer: {
+    clickOnPayButton: clickable('[data-test-pay-button]'),
+    scope: '[data-test-confirm-and-pay-step-container]',
+  },
 
   visit: visitable('/gifts/buy'),
 });


### PR DESCRIPTION
Introduce a new gift payment flow feature under /gifts/buy route that
supports creating or fetching a gift payment session. Implement a
multi-step navigation component to guide users through the gift
purchase process, tracking completed and current steps within the
controller. Add data model for gift payment flow to store user inputs,
and create corresponding page objects for easier testing and interaction.

These changes enable anonymous access and enhance user experience by
providing clear navigation and state management throughout the payment
steps.