### PR TITLE
feat(tracking): add Google Tag Manager to index.html

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -31,6 +31,14 @@
 
     <script async src="https://metabase.codecrafters.io/app/iframeResizer.js"></script>
 
+    <!-- Google Tag Manager -->
+    <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+    new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+    j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+    'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+    })(window,document,'script','dataLayer','GTM-P75248HQ');</script>
+    <!-- End Google Tag Manager -->
+
     <!-- Facebook Pixel Code -->
     <script>
       !function(f,b,e,v,n,t,s)
@@ -57,6 +65,11 @@
     </script> -->
   </head>
   <body style="margin: 0; background-color: rgb(248 250 252)">
+    <!-- Google Tag Manager (noscript) -->
+    <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-P75248HQ"
+    height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+    <!-- End Google Tag Manager (noscript) -->
+
     <div class="ember-load-indicator">
       <div class="indicator-container">
         <svg class="indicator-icon" width="100" height="100" viewBox="0 0 500 500" fill="none" xmlns="http://www.w3.org/2000/svg">


### PR DESCRIPTION
Integrate Google Tag Manager scripts and noscript iframe into the main
HTML to enable improved analytics and tag management. This change allows
for better tracking of user interactions and easier management of tags
without modifying code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds Google Tag Manager (GTM-P75248HQ) to `app/index.html` with head script and body noscript iframe.
> 
> - **Tracking/Analytics**:
>   - Add Google Tag Manager to `app/index.html`:
>     - Insert GTM bootstrap script in `<head>`.
>     - Add corresponding `noscript` iframe in `<body>`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7452a2d0e9acf60433ac8abf9995296c08807bde. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->