### PR TITLE
Update leaderboard entries table for dark mode support and styling im…

### DIFF
--- a/app/components/leaderboard-page/entries-table.hbs
+++ b/app/components/leaderboard-page/entries-table.hbs
@@ -1,7 +1,7 @@
 <div ...attributes>
   {{#if (or this.hasEntries @isLoadingEntries)}}
     <div>
-      <table class="min-w-full bg-white">
+      <table class="min-w-full bg-white dark:bg-gray-850">
         <thead>
           <LeaderboardPage::EntriesTable::HeaderRow @language={{@language}} />
         </thead>
@@ -28,7 +28,7 @@
     </div>
   {{else}}
     <div class="text-center py-12">
-      <div class="text-gray-500 text-sm">
+      <div class="text-gray-500 dark:text-gray-400 text-sm">
         No entries found for this leaderboard.
       </div>
     </div>

--- a/app/components/leaderboard-page/entries-table/filler-row.hbs
+++ b/app/components/leaderboard-page/entries-table/filler-row.hbs
@@ -1,6 +1,6 @@
-<tr class="bg-gray-50">
-  <td colspan="4" class="px-4 py-3 whitespace-nowrap border border-gray-200 text-center">
-    <div class="text-xs text-gray-500">
+<tr class="bg-gray-50 dark:bg-gray-800">
+  <td colspan="4" class="px-4 py-3 whitespace-nowrap border border-gray-200 dark:border-gray-700 text-center">
+    <div class="text-xs text-gray-500 dark:text-gray-400">
       {{@text}}
     </div>
   </td>

--- a/app/components/leaderboard-page/entries-table/header-row-cell.hbs
+++ b/app/components/leaderboard-page/entries-table/header-row-cell.hbs
@@ -1,12 +1,12 @@
-<th scope="col" class="font-normal px-4 py-3 border border-gray-200" ...attributes>
+<th scope="col" class="font-normal px-4 py-3 border border-gray-200 dark:border-gray-700" ...attributes>
   <div class="flex items-center gap-1 {{if (eq @alignment 'left') 'justify-start' 'justify-end'}}">
-    <span class="text-xs font-medium text-gray-500 uppercase tracking-wider">
+    <span class="text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">
       {{@title}}
     </span>
 
     {{#if @explanationMarkdown}}
       <span>
-        {{svg-jar "information-circle" class="w-4 h-4 fill-current text-gray-200 hover:text-gray-300"}}
+        {{svg-jar "information-circle" class="w-4 h-4 fill-current text-gray-200 dark:text-gray-600 hover:text-gray-300 dark:hover:text-gray-500"}}
 
         <EmberTooltip>
           <div class="prose prose-sm prose-compact prose-invert text-white">

--- a/app/components/leaderboard-page/entries-table/row-cell.hbs
+++ b/app/components/leaderboard-page/entries-table/row-cell.hbs
@@ -1,3 +1,3 @@
-<td class="px-4 py-2 whitespace-nowrap border border-gray-200" ...attributes>
+<td class="px-4 py-2 whitespace-nowrap border border-gray-200 dark:border-gray-700" ...attributes>
   {{yield}}
 </td>

--- a/app/components/leaderboard-page/entries-table/row.hbs
+++ b/app/components/leaderboard-page/entries-table/row.hbs
@@ -1,6 +1,14 @@
-<tr class="{{if this.isCurrentUser 'bg-teal-50 ring ring-teal-500 relative' 'hover:bg-gray-50'}} group/table-row" data-test-leaderboard-entry-row>
+<tr
+  class="{{if
+      this.isCurrentUser
+      'bg-teal-50 dark:bg-teal-900/30 ring ring-teal-500 dark:ring-teal-700 relative'
+      'hover:bg-gray-50 dark:hover:bg-gray-800'
+    }}
+    group/table-row"
+  data-test-leaderboard-entry-row
+>
   <LeaderboardPage::EntriesTable::RowCell class="text-right w-[8%]">
-    <span class="text-xs font-medium {{if this.isCurrentUser 'text-teal-600' 'text-gray-400'}}">
+    <span class="text-xs font-medium {{if this.isCurrentUser 'text-teal-600 dark:text-teal-400' 'text-gray-400 dark:text-gray-500'}}">
       {{@rankText}}
     </span>
   </LeaderboardPage::EntriesTable::RowCell>
@@ -9,13 +17,16 @@
     <div class="flex items-center justify-between gap-x-6">
       <div class="flex items-center gap-1.5">
         <div class="flex-shrink-0 h-6 w-6">
-          <AvatarImage @user={{@entry.user}} class="h-6 w-6 rounded-full border border-gray-300" />
+          <AvatarImage @user={{@entry.user}} class="h-6 w-6 rounded-full border border-gray-300 dark:border-gray-600" />
         </div>
-        <div class="text-xs font-mono max-w-[12ch] sm:max-w-[16ch] truncate {{if this.isCurrentUser 'text-teal-600' 'text-gray-600'}}">
+        <div
+          class="text-xs font-mono max-w-[12ch] sm:max-w-[16ch] truncate
+            {{if this.isCurrentUser 'text-teal-600 dark:text-teal-400' 'text-gray-600 dark:text-gray-400'}}"
+        >
           <a
             href={{@entry.user.codecraftersProfileUrl}}
             target="_blank"
-            class="hover:underline hover:text-gray-800"
+            class="hover:underline hover:text-gray-800 dark:hover:text-gray-200"
             rel="noopener noreferrer"
             data-test-username
           >
@@ -25,7 +36,7 @@
       </div>
       <div class="hidden md:flex items-center gap-1.5 flex-shrink-0 {{unless this.isCurrentUser 'opacity-25 group-hover/table-row:opacity-100'}}">
         {{#if (gt this.hiddenCourses.length 0)}}
-          <div class="text-gray-500">
+          <div class="text-gray-500 dark:text-gray-400">
             ...
 
             <EmberTooltip @text={{concat this.hiddenCourses.length " other " (pluralize "challenge" count=this.hiddenCourses.length)}} />
@@ -45,8 +56,10 @@
   <LeaderboardPage::EntriesTable::RowCell class="hidden md:table-cell">
     <div class="flex items-center justify-end">
       <div class="text-xs font-mono">
-        <span class="{{if this.isCurrentUser 'text-teal-600' 'text-gray-700'}}">{{@entry.scoreUpdatesCount}}</span>
-        <span class="{{if this.isCurrentUser 'text-teal-600' 'text-gray-400'}}">stages</span>
+        <span
+          class="{{if this.isCurrentUser 'text-teal-600 dark:text-teal-400' 'text-gray-700 dark:text-gray-200'}}"
+        >{{@entry.scoreUpdatesCount}}</span>
+        <span class="{{if this.isCurrentUser 'text-teal-600 dark:text-teal-400' 'text-gray-400 dark:text-gray-500'}}">stages</span>
       </div>
     </div>
   </LeaderboardPage::EntriesTable::RowCell>
@@ -66,8 +79,8 @@
       {{/if}} --}}
 
       <div class="text-xs font-mono">
-        <span class="{{if this.isCurrentUser 'text-teal-600' 'text-gray-700'}}">{{@entry.score}}</span>
-        <span class="{{if this.isCurrentUser 'text-teal-600' 'text-gray-400'}}">pts</span>
+        <span class="{{if this.isCurrentUser 'text-teal-600 dark:text-teal-400' 'text-gray-700 dark:text-gray-200'}}">{{@entry.score}}</span>
+        <span class="{{if this.isCurrentUser 'text-teal-600 dark:text-teal-400' 'text-gray-400 dark:text-gray-500'}}">pts</span>
       </div>
     </div>
   </LeaderboardPage::EntriesTable::RowCell>

--- a/app/components/leaderboard-page/entries-table/skeleton-row.hbs
+++ b/app/components/leaderboard-page/entries-table/skeleton-row.hbs
@@ -1,6 +1,6 @@
-<tr class="hover:bg-gray-50 group/table-row" data-test-leaderboard-entry-skeleton-row>
+<tr class="hover:bg-gray-50 dark:hover:bg-gray-800 group/table-row" data-test-leaderboard-entry-skeleton-row>
   <LeaderboardPage::EntriesTable::RowCell class="text-right w-[8%]">
-    <span class="text-xs font-medium text-gray-400">
+    <span class="text-xs font-medium text-gray-400 dark:text-gray-500">
       {{@rankText}}
     </span>
   </LeaderboardPage::EntriesTable::RowCell>
@@ -28,7 +28,7 @@
   <LeaderboardPage::EntriesTable::RowCell class="hidden md:table-cell">
     <div class="flex items-center justify-end gap-2">
       <LoadingSkeleton @width={{20}} />
-      <span class="text-gray-400 text-xs font-mono">
+      <span class="text-gray-400 dark:text-gray-500 text-xs font-mono">
         stages
       </span>
     </div>
@@ -37,7 +37,7 @@
   <LeaderboardPage::EntriesTable::RowCell>
     <div class="flex items-center justify-end gap-2">
       <LoadingSkeleton @width={{20}} />
-      <span class="text-gray-400 text-xs font-mono">
+      <span class="text-gray-400 dark:text-gray-500 text-xs font-mono">
         pts
       </span>
     </div>

--- a/app/components/leaderboard-page/header.hbs
+++ b/app/components/leaderboard-page/header.hbs
@@ -1,7 +1,7 @@
 <div class="flex items-center justify-between gap-x-6 gap-y-4 flex-wrap" ...attributes>
   <div class="flex-shrink-0">
     <div class="flex items-center gap-x-2">
-      <h3 class="text-2xl font-bold text-gray-800" data-test-leaderboard-title>
+      <h3 class="text-2xl font-bold text-gray-800 dark:text-gray-200" data-test-leaderboard-title>
         {{@selectedLanguage.name}}
         Leaderboard
       </h3>

--- a/app/routes/leaderboard.ts
+++ b/app/routes/leaderboard.ts
@@ -5,7 +5,7 @@ import type CourseModel from 'codecrafters-frontend/models/course';
 import type LanguageModel from 'codecrafters-frontend/models/language';
 import type Store from '@ember-data/store';
 import { inject as service } from '@ember/service';
-import RouteInfoMetadata from 'codecrafters-frontend/utils/route-info-metadata';
+import RouteInfoMetadata, { RouteColorScheme } from 'codecrafters-frontend/utils/route-info-metadata';
 
 export type ModelType = {
   language: LanguageModel;
@@ -20,7 +20,7 @@ export default class LeaderboardRoute extends BaseRoute {
   }
 
   buildRouteInfoMetadata() {
-    return new RouteInfoMetadata({ allowsAnonymousAccess: true });
+    return new RouteInfoMetadata({ allowsAnonymousAccess: true, colorScheme: RouteColorScheme.Both });
   }
 
   async model(params: { language_slug: string }): Promise<ModelType> {


### PR DESCRIPTION
…provements.

**Checklist**:

- [x] I've thoroughly self-reviewed my changes
- [x] I've added tests for my changes, unless they affect admin-only areas (or are otherwise not worth testing)
- [x] I've verified any visual changes using Percy (add a commit with `[percy]` in the message to trigger)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Add dark mode styles across leaderboard table components and header, and configure the leaderboard route to support both color schemes.
> 
> - **UI (Leaderboard Page)**
>   - **Entries Table**: Add `dark:` variants for table/backgrounds, borders, text, and hover states in `entries-table.hbs`, `row.hbs`, `row-cell.hbs`, `header-row-cell.hbs`, `skeleton-row.hbs`, and `filler-row.hbs`.
>   - **Header**: Add dark mode text color to title in `header.hbs`.
>   - **Icons/Tooltips**: Adjust info icon colors and hover states for dark mode.
> - **Routing**:
>   - Import `RouteColorScheme` and set `colorScheme: RouteColorScheme.Both` in `buildRouteInfoMetadata()` for `app/routes/leaderboard.ts`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 28b932dcf3b015f1673bf208f5345faa34d3d0b9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->