### PR TITLE
feat(gifts): enhance redeem button functionality and add tests

### DIFF
--- a/app/controllers/gifts/redeem.ts
+++ b/app/controllers/gifts/redeem.ts
@@ -24,7 +24,7 @@ export default class GiftsRedeemController extends Controller {
 
   get redeemButtonIsDisabled() {
     // Button is disabled if user already has membership benefits
-    return this.currentUserCanAccessMembershipBenefits;
+    return this.currentUserCanAccessMembershipBenefits || this.isRedeemingGift;
   }
 
   @action
@@ -42,13 +42,12 @@ export default class GiftsRedeemController extends Controller {
     this.isRedeemingGift = true;
 
     try {
-      // TODO: Implement actual gift redeeming logic
-      // This would typically involve calling an API endpoint to redeem the gift
-      // For now, we'll just redirect to the catalog page as a placeholder
+      await this.model.redeem({});
       this.router.transitionTo('catalog');
-    } catch {
+    } catch (error) {
       // TODO: Handle error appropriately
       this.isRedeemingGift = false;
+      throw error;
     }
   }
 }

--- a/app/controllers/gifts/redeem.ts
+++ b/app/controllers/gifts/redeem.ts
@@ -1,6 +1,54 @@
 import Controller from '@ember/controller';
 import type { ModelType } from 'codecrafters-frontend/routes/gifts/redeem';
+import { inject as service } from '@ember/service';
+import { action } from '@ember/object';
+import { tracked } from '@glimmer/tracking';
+import type RouterService from '@ember/routing/router-service';
+import type AuthenticatorService from 'codecrafters-frontend/services/authenticator';
 
 export default class GiftsRedeemController extends Controller {
   declare model: ModelType;
+
+  @service declare router: RouterService;
+  @service declare authenticator: AuthenticatorService;
+
+  @tracked isRedeemingGift = false;
+
+  get currentUserCanAccessMembershipBenefits() {
+    return this.authenticator.currentUser && this.authenticator.currentUser.canAccessMembershipBenefits;
+  }
+
+  get currentUserIsAnonymous() {
+    return this.authenticator.isAnonymous;
+  }
+
+  get redeemButtonIsDisabled() {
+    // Button is disabled if user already has membership benefits
+    return this.currentUserCanAccessMembershipBenefits;
+  }
+
+  @action
+  async handleRedeemButtonClick() {
+    if (this.currentUserIsAnonymous) {
+      this.authenticator.initiateLogin();
+
+      return;
+    }
+
+    if (this.redeemButtonIsDisabled) {
+      return;
+    }
+
+    this.isRedeemingGift = true;
+
+    try {
+      // TODO: Implement actual gift redeeming logic
+      // This would typically involve calling an API endpoint to redeem the gift
+      // For now, we'll just redirect to the catalog page as a placeholder
+      this.router.transitionTo('catalog');
+    } catch {
+      // TODO: Handle error appropriately
+      this.isRedeemingGift = false;
+    }
+  }
 }

--- a/app/models/membership-gift.ts
+++ b/app/models/membership-gift.ts
@@ -1,4 +1,5 @@
 import Model, { attr, belongsTo } from '@ember-data/model';
+import { memberAction } from 'ember-api-actions';
 import type UserModel from 'codecrafters-frontend/models/user';
 
 export default class MembershipGiftModel extends Model {
@@ -10,4 +11,11 @@ export default class MembershipGiftModel extends Model {
   @attr('string') declare giftMessage: string;
   @attr('number') declare validityInDays: number;
   @attr('string') declare secretToken: string;
+
+  declare redeem: (this: MembershipGiftModel, payload: unknown) => Promise<void>;
 }
+
+MembershipGiftModel.prototype.redeem = memberAction({
+  path: 'redeem',
+  type: 'post',
+});

--- a/app/templates/gifts/redeem.hbs
+++ b/app/templates/gifts/redeem.hbs
@@ -20,8 +20,22 @@
       </p>
     </div>
 
-    <PrimaryButton data-test-claim-button {{on "click" (noop)}}>
-      Claim Gift
+    <PrimaryButton data-test-redeem-button @isDisabled={{this.redeemButtonIsDisabled}} {{on "click" this.handleRedeemButtonClick}}>
+      {{#if this.currentUserIsAnonymous}}
+        {{svg-jar "github" class="fill-current w-6 transform transition-all mr-3"}}
+      {{/if}}
+
+      {{#if this.isRedeemingGift}}
+        Redeeming...
+      {{else}}
+        Redeem Gift
+      {{/if}}
+
+      {{#if this.currentUserIsAnonymous}}
+        <EmberTooltip @text="Click to login via GitHub" />
+      {{else if this.currentUserCanAccessMembershipBenefits}}
+        <EmberTooltip @text="You already have full access to CodeCrafters. You can claim this gift once your membership expires." />
+      {{/if}}
     </PrimaryButton>
   </div>
 </div>

--- a/tests/acceptance/concepts-test.js
+++ b/tests/acceptance/concepts-test.js
@@ -876,10 +876,7 @@ module('Acceptance | concepts-test', function (hooks) {
     assert.ok(conceptsPage.conceptCards[3].draftLabel.isVisible, 'Draft label is visible for draft concepts');
 
     await conceptsPage.conceptCards[3].draftLabel.hover();
-
-    assertTooltipContent(assert, {
-      contentString: 'This concept is only visible to staff',
-    });
+    assertTooltipContent(assert, { contentString: 'This concept is only visible to staff' });
   });
 
   test('draft concepts are visible to concept author', async function (assert) {

--- a/tests/acceptance/redeem-gift-page/redeem-test.js
+++ b/tests/acceptance/redeem-gift-page/redeem-test.js
@@ -1,0 +1,51 @@
+import redeemGiftPage from 'codecrafters-frontend/tests/pages/redeem-gift-page';
+import testScenario from 'codecrafters-frontend/mirage/scenarios/test';
+import { module, test } from 'qunit';
+import { setupApplicationTest } from 'codecrafters-frontend/tests/helpers';
+import { signInAsSubscriber } from 'codecrafters-frontend/tests/support/authentication-helpers';
+import { assertTooltipContent } from 'ember-tooltips/test-support';
+
+module('Acceptance | redeem-gift-page | redeem', function (hooks) {
+  setupApplicationTest(hooks);
+
+  test('user cannot redeem a gift if they are not logged in', async function (assert) {
+    testScenario(this.server);
+
+    this.server.schema.membershipGifts.create({
+      secretToken: 'xyz',
+      giftMessage: 'Happy Birthday! Enjoy your CodeCrafters membership.',
+      validityInDays: 365,
+      purchasedAt: new Date(),
+      claimedAt: null,
+    });
+
+    await redeemGiftPage.visit({ secret_token: 'xyz' });
+    assert.notOk(redeemGiftPage.giftDetailsContainer.redeemButton.isDisabled, 'Redeem button should be enabled for anonymous users');
+
+    await redeemGiftPage.giftDetailsContainer.redeemButton.hover();
+    assertTooltipContent(assert, { contentString: 'Click to login via GitHub' });
+  });
+
+  test('user cannot redeem a gift if they already have a membership', async function (assert) {
+    testScenario(this.server);
+
+    signInAsSubscriber(this.owner, this.server);
+
+    this.server.schema.membershipGifts.create({
+      secretToken: 'xyz',
+      giftMessage: 'Happy Birthday! Enjoy your CodeCrafters membership.',
+      validityInDays: 365,
+      purchasedAt: new Date(),
+      claimedAt: null,
+    });
+
+    await redeemGiftPage.visit({ secret_token: 'xyz' });
+    assert.ok(redeemGiftPage.giftDetailsContainer.redeemButton.isDisabled, 'Redeem button should be disabled for users with existing membership');
+
+    await redeemGiftPage.giftDetailsContainer.redeemButton.hover();
+
+    assertTooltipContent(assert, {
+      contentString: 'You already have full access to CodeCrafters. You can claim this gift once your membership expires.',
+    });
+  });
+});

--- a/tests/pages/redeem-gift-page.ts
+++ b/tests/pages/redeem-gift-page.ts
@@ -1,14 +1,19 @@
-import { clickable, text, visitable } from 'ember-cli-page-object';
+import { clickable, text, visitable, hasClass, triggerable } from 'ember-cli-page-object';
 import createPage from 'codecrafters-frontend/tests/support/create-page';
 
 export default createPage({
   visit: visitable('/gifts/redeem/:secret_token'),
 
   giftDetailsContainer: {
-    claimButton: { scope: '[data-test-claim-button]' },
+    redeemButton: {
+      scope: '[data-test-redeem-button]',
+      isDisabled: hasClass('cursor-not-allowed'),
+      hover: triggerable('mouseenter'),
+    },
+
     giftMessage: text('[data-test-gift-message]'),
     scope: '[data-test-gift-details-container]',
   },
 
-  clickClaimButton: clickable('[data-test-claim-button]'),
+  clickRedeemButton: clickable('[data-test-redeem-button]'),
 });


### PR DESCRIPTION
Update redeem button to handle user states: disable for users with
existing membership, show loading state during redeem, and trigger
GitHub login for anonymous users. Add contextual tooltips explaining
button state and actions. Introduce acceptance tests covering
redeem button behavior for anonymous users and those with active
memberships to ensure correct UI feedback and enablement.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds redeem action and UI states to gift redemption, including login handling, disabled/loading states, tooltips, and acceptance tests.
> 
> - **Frontend**
>   - **Controller (`app/controllers/gifts/redeem.ts`)**: Injects `router` and `authenticator`; tracks `isRedeemingGift`; adds getters for user state and `redeemButtonIsDisabled`; implements `handleRedeemButtonClick` to initiate login for anonymous users or call `model.redeem` then navigate to `catalog`.
>   - **Template (`app/templates/gifts/redeem.hbs`)**: Replaces `data-test-claim-button` with `data-test-redeem-button`; binds `@isDisabled`; shows GitHub icon for anonymous users; displays loading text (`Redeeming...`); adds tooltips for login prompt and existing-membership restriction.
> - **Data/Model**
>   - **`app/models/membership-gift.ts`**: Adds `redeem` member action (`POST /redeem`) via `ember-api-actions`.
> - **Tests**
>   - **Acceptance**: New tests (`tests/acceptance/redeem-gift-page/redeem-test.js`) verify anonymous login tooltip and disabled state for subscribers.
>   - **Page Object**: Updates selectors and helpers for `redeem` button (`tests/pages/redeem-gift-page.ts`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2e281a17d691dc9b74481e0b660c38367127d1c6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->