### PR TITLE
feat(course-page): simplify instructions after cloning repository

### DIFF
--- a/app/components/course-page/setup-step/repository-setup-card/clone-repository-step.hbs
+++ b/app/components/course-page/setup-step/repository-setup-card/clone-repository-step.hbs
@@ -54,9 +54,11 @@
     <CopyableTerminalCommand @commands={{array "git commit --allow-empty -m 'test'" "git push origin master"}} />
   </div>
 
-  <div class="prose dark:prose-invert">
-    <p class={{if @isComplete "line-through"}}>
-      When you run the above command, the "Listening for a git push" message below will change, and the first stage will be activated.
-    </p>
-  </div>
+  {{#unless @isComplete}}
+    <div class="prose dark:prose-invert">
+      <p>
+        Run the commands above to proceed to the next stage.
+      </p>
+    </div>
+  {{/unless}}
 </div>


### PR DESCRIPTION
Replace conditional styled message with a clearer prompt to run commands
only when setup is incomplete. This improves user guidance by removing the
redundant "Listening for a git push" explanation and showing a concise
instruction until the step is marked complete.