### PR TITLE
fix(ui): remove redundant CLI recommendation from instructions

### DIFF
--- a/app/components/course-page/course-stage-step/test-runner-card/run-tests-instructions.hbs
+++ b/app/components/course-page/course-stage-step/test-runner-card/run-tests-instructions.hbs
@@ -37,10 +37,3 @@
 </div>
 
 <CopyableTerminalCommandWithVariants @variants={{this.commandVariants}} @onVariantSelect={{this.handleVariantSelect}} />
-
-<div class="prose dark:prose-invert prose-sm prose-compact mt-3">
-  <p>
-    We recommend using the
-    <a href="https://codecrafters.io/cli" target="_blank" rel="noopener noreferrer">CodeCrafters&nbsp;CLI</a>, but you can use Git too.
-  </p>
-</div>


### PR DESCRIPTION
Remove the paragraph suggesting the use of the CodeCrafters CLI in the run
tests instructions component. This clarifies the UI by focusing on the
copyable terminal commands and avoids confusing users with unnecessary
recommendations.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Removes the paragraph recommending the CodeCrafters CLI from the run-tests instructions component.
> 
> - **UI**:
>   - **Run tests instructions** (`app/components/course-page/course-stage-step/test-runner-card/run-tests-instructions.hbs`):
>     - Remove paragraph recommending the CodeCrafters CLI, keeping only the copyable test command variants.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 686a4685192ec9376e617108982620275db5530f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->