### PR TITLE
fix(course-stage-step): remove unnecessary collapse prop from card

### DIFF
--- a/app/components/course-page/course-stage-step/your-task-card/index.hbs
+++ b/app/components/course-page/course-stage-step/your-task-card/index.hbs
@@ -1,6 +1,5 @@
 <CoursePage::InstructionsCard
   @contentIdentifier={{@courseStage.id}}
-  @isCollapsedByDefault={{true}}
   id="your-task-card"
   data-test-your-task-card
   class="group/your-task-card"


### PR DESCRIPTION
Remove `@isCollapsedByDefault={{true}}` from YourTaskCard component in
the CourseStageStep to simplify the card behavior. This change ensures
the card is always expanded by default, improving user visibility and
interaction.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Removes `@isCollapsedByDefault={{true}}` from `course-page/course-stage-step/your-task-card/index.hbs` to keep the instructions card expanded by default.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a3894f659a0bd9aa5d0a099da35c613d8d14783c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->