### PR TITLE
fix(config): bump major version to 38.0 to force client updates

### DIFF
--- a/config/environment.js
+++ b/config/environment.js
@@ -49,7 +49,7 @@ module.exports = function (environment) {
 
       // Update the major version number to force all clients to update.
       // The minor version doesn't do anything at the moment, might use in the future.
-      version: `37.0.${process.env.VERCEL_GIT_COMMIT_SHA?.slice(0, 7) || 'dev'}`,
+      version: `38.0.${process.env.VERCEL_GIT_COMMIT_SHA?.slice(0, 7) || 'dev'}`,
     },
     fastboot: {
       hostWhitelist: [/^localhost:\d+$/],


### PR DESCRIPTION
Increase the major version number in the environment config from 37.0
to 38.0. This ensures all clients receive updates and refresh their
cached data accordingly. The minor version remains unused but may be
leveraged in the future.