### PR TITLE
feat(course-card): dynamically set route and models for stage links

### DIFF
--- a/app/components/track-page/course-card/stage-list-item.hbs
+++ b/app/components/track-page/course-card/stage-list-item.hbs
@@ -1,6 +1,6 @@
 <LinkTo
-  @route="course.stage.instructions"
-  @models={{array @stage.course.slug @stage.slug}}
+  @route={{this.routeAndModels.route}}
+  @models={{this.routeAndModels.models}}
   class="block hover:bg-gray-50 dark:hover:bg-gray-700/50 py-1.5 -mx-1.5 px-1.5 rounded-sm"
   data-test-stage-list-item
   ...attributes

--- a/app/components/track-page/course-card/stage-list-item.ts
+++ b/app/components/track-page/course-card/stage-list-item.ts
@@ -14,6 +14,14 @@ interface Signature {
 
 export default class StageListItem extends Component<Signature> {
   @service declare authenticator: AuthenticatorService;
+
+  get routeAndModels(): { route: string; models: string[] } {
+    if (this.args.stage.isFirst && !this.args.isComplete) {
+      return { route: 'course.introduction', models: [this.args.stage.course.slug] };
+    } else {
+      return { route: 'course.stage.instructions', models: [this.args.stage.course.slug, this.args.stage.slug] };
+    }
+  }
 }
 
 declare module '@glint/environment-ember-loose/registry' {


### PR DESCRIPTION
Add a computed property to determine the route and models based on stage
completion and position. Link to the course introduction if the stage is
the first and incomplete; otherwise, link to stage instructions. This
improves navigation accuracy and user experience on the track page.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Stage links now compute route/models: first incomplete stages go to course introduction; others go to stage instructions.
> 
> - **Frontend**
>   - **Stage link routing**: In `track-page/course-card/stage-list-item.{ts,hbs}` add `routeAndModels` getter to compute `route`/`models`.
>     - First incomplete stage → `course.introduction` with `[course.slug]`.
>     - Otherwise → `course.stage.instructions` with `[course.slug, stage.slug]`.
>     - Update template to use `this.routeAndModels.route` and `this.routeAndModels.models`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit af0d6438d9b6f21baf3d11c749494525d06cb0c8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->