### PR TITLE
refactor(course-stage-solution): remove unused explanationMarkdown attr

### DIFF
--- a/app/models/course-stage-solution.ts
+++ b/app/models/course-stage-solution.ts
@@ -10,7 +10,6 @@ export default class CourseStageSolutionModel extends Model.extend(ViewableMixin
 
   @attr() declare authorDetails: { [key: string]: string }; // free-form JSON
   @attr() declare changedFiles: { diff: string; filename: string }[]; // free-form JSON
-  @attr('string') declare explanationMarkdown: string;
   @attr() declare reviewersDetails: Array<{ [key: string]: string }>; // free-form JSON
 
   @belongsTo('course-stage', { async: false, inverse: 'solutions' }) declare courseStage: CourseStageModel;
@@ -18,9 +17,5 @@ export default class CourseStageSolutionModel extends Model.extend(ViewableMixin
 
   get hasContributorDetails() {
     return this.authorDetails || (this.reviewersDetails && this.reviewersDetails[0]);
-  }
-
-  get hasExplanation() {
-    return !!this.explanationMarkdown;
   }
 }


### PR DESCRIPTION
Remove the explanationMarkdown attribute and related hasExplanation 
getter as they are no longer needed. This simplifies the model by 
eliminating unused properties and streamlines data handling.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Removes `explanationMarkdown` attr and `hasExplanation` getter from `app/models/course-stage-solution.ts`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b09beb0cf36d81b97d94b052a25ddeea146c1717. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->