### PR TITLE
fix(ui): improve hint card colors for dark mode support

### DIFF
--- a/app/components/course-page/course-stage-step/second-stage-your-task-card/hint-card.hbs
+++ b/app/components/course-page/course-stage-step/second-stage-your-task-card/hint-card.hbs
@@ -6,11 +6,11 @@
   {{! bg-gradient-to-b from-white to-gray-100 dark:from-gray-800 dark:to-gray-900 }}
   <div class="flex items-center p-3 gap-1.5" {{on "click" this.handleHeaderClick}} role="button">
     <div class="flex items-center justify-center transition-transform duration-200 rotate-90 {{if this.isExpanded 'rotate-180'}}">
-      <span class="text-gray-400 triangle-up" aria-hidden="true">
+      <span class="text-gray-400 dark:text-gray-600 triangle-up" aria-hidden="true">
       </span>
     </div>
-    <span class="text-gray-700">
-      <span class="font-semibold text-gray-700">Hint #{{add @hintIndex 1}}:</span>
+    <span class="text-gray-800 dark:text-gray-200">
+      <span class="font-semibold">Hint #{{add @hintIndex 1}}:</span>
       {{@hint.title_markdown}}
     </span>
   </div>


### PR DESCRIPTION
Update text and icon colors in the hint card component to enhance  
readability in dark mode. Adjust the triangle icon and text spans to  
use darker shades when in dark mode, ensuring better contrast and a  
consistent user experience across themes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adjusts hint card icon and header text colors to improve contrast in dark mode (and slightly darkens light-mode text).
> 
> - **UI – Hint Card (`app/components/.../hint-card.hbs`)**:
>   - **Dark mode**: Add `dark:text-gray-600` to the triangle icon; set header text to `dark:text-gray-200`.
>   - **Light mode**: Increase header text contrast (`text-gray-700` → `text-gray-800`).
>   - Remove redundant color from the bold "Hint #" label.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 01deae15af294314b8ddc09bc239bf8fde718f66. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->