### PR TITLE
refactor(ui): simplify uncomment-code-step component

### DIFF
--- a/app/components/course-page/course-stage-step/first-stage-your-task-card/uncomment-code-step.hbs
+++ b/app/components/course-page/course-stage-step/first-stage-your-task-card/uncomment-code-step.hbs
@@ -1,11 +1,4 @@
 {{#if this.solution}}
-  <div class="prose dark:prose-invert mb-3">
-    <p>
-      Uncomment the following code in
-      <code>{{this.filename}}</code>:
-    </p>
-  </div>
-
   <div class="flex flex-col gap-4">
     {{#each this.solution.changedFiles as |changedFile|}}
       <FileDiffCard @code={{changedFile.diff}} @filename={{changedFile.filename}} @language={{this.solution.language.slug}} />


### PR DESCRIPTION
Remove the introductory paragraph explaining the task in the 
uncomment-code-step component. This streamlines the UI by focusing 
directly on the code differences displayed, improving clarity and 
reducing redundancy.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Removes the introductory paragraph so the component shows only the file diffs.
> 
> - **UI**:
>   - In `app/components/course-page/course-stage-step/first-stage-your-task-card/uncomment-code-step.hbs`:
>     - Remove the explanatory paragraph above the diffs.
>     - Retain display of `FileDiffCard` list and existing repository setup/readme guidance.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 754a8b582a1ec7ad39719089052a6953c3a63378. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->