### PR TITLE
fix(UI): prevent step title overflow in step list item

### DIFF
--- a/app/components/step-list/item.hbs
+++ b/app/components/step-list/item.hbs
@@ -26,7 +26,7 @@
   </div>
 
   {{! Content }}
-  <div class="flex-grow">
+  <div class="flex-grow min-w-0">
     <div class="flex h-7 items-center">
       <div class="font-semibold text-gray-800 dark:text-gray-200" data-test-step-title>
         {{@step.titleMarkdown}}


### PR DESCRIPTION
Add min-w-0 to the flex-grow container in the step list item component.
This change ensures that long step titles do not overflow their container
and improves layout consistency across different screen sizes and themes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Add `min-w-0` to the content container in `app/components/step-list/item.hbs` to prevent long titles from overflowing.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 78aaf2c87c356d82d93a161666d1abd4268f0f5c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->