### PR TITLE
chore: bump major version to 40.0 to force client update

### DIFF
--- a/config/environment.js
+++ b/config/environment.js
@@ -49,7 +49,7 @@ module.exports = function (environment) {
 
       // Update the major version number to force all clients to update.
       // The minor version doesn't do anything at the moment, might use in the future.
-      version: `39.0.${process.env.VERCEL_GIT_COMMIT_SHA?.slice(0, 7) || 'dev'}`,
+      version: `40.0.${process.env.VERCEL_GIT_COMMIT_SHA?.slice(0, 7) || 'dev'}`,
     },
     fastboot: {
       hostWhitelist: [/^localhost:\d+$/],


### PR DESCRIPTION
Update the major version number from 39 to 40 in the environment
configuration. This change forces all clients to update to the latest
version, ensuring compatibility and consistency across deployments.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Bump app version from 39.0 to 40.0 in `config/environment.js` to force client updates.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 255f1352be7c44922246dbc4fa9b2464423f48ba. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->