### PR TITLE
feat(course-page): improve language proficiency selection flow

### DIFF
--- a/app/components/course-page/introduction-step/create-repository-card/index.hbs
+++ b/app/components/course-page/introduction-step/create-repository-card/index.hbs
@@ -23,11 +23,8 @@
       <CoursePage::IntroductionStep::CreateRepositoryCard::SelectLanguageProficiencyLevelSection
         @isDisabled={{bool this.expandedSection.isDisabled}}
         @repository={{@repository}}
+        @onSelect={{this.expandNextSection}}
       />
-
-      {{#if this.expandedSection.isComplete}}
-        <PrimaryButton class="mt-6" {{on "click" this.expandNextSection}} data-test-next-question-button>↓ Next question</PrimaryButton>
-      {{/if}}
     {{else if (eq this.expandedSection.type "SelectExpectedActivityFrequencySection")}}
       <CoursePage::IntroductionStep::CreateRepositoryCard::SelectExpectedActivityFrequencySection
         @isDisabled={{bool this.expandedSection.isDisabled}}

--- a/app/components/course-page/introduction-step/create-repository-card/select-language-proficiency-level-section.hbs
+++ b/app/components/course-page/introduction-step/create-repository-card/select-language-proficiency-level-section.hbs
@@ -20,15 +20,16 @@
       </TertiaryButton>
     {{/each-in}}
 
-    <AnimatedContainer class="w-full">
-      {{#animated-if this.feedbackAlertMarkdown use=this.transition duration=300}}
-        <AlertWithIcon>
-          {{! The extra #if convinces glint that the value isn't null }}
-          {{#if this.feedbackAlertMarkdown}}
+    {{#if this.feedbackAlertMarkdown}}
+      <AnimatedContainer class="w-full">
+        {{#animated-if this.feedbackAlertMarkdown use=this.transition duration=300}}
+          <AlertWithIcon @type="info">
             {{markdown-to-html this.feedbackAlertMarkdown}}
-          {{/if}}
-        </AlertWithIcon>
-      {{/animated-if}}
-    </AnimatedContainer>
+          </AlertWithIcon>
+        {{/animated-if}}
+      </AnimatedContainer>
+
+      <PrimaryButton class="mt-6" {{on "click" @onSelect}} data-test-next-question-button>↓ Next question</PrimaryButton>
+    {{/if}}
   </div>
 </div>

--- a/app/components/course-page/introduction-step/create-repository-card/select-language-proficiency-level-section.ts
+++ b/app/components/course-page/introduction-step/create-repository-card/select-language-proficiency-level-section.ts
@@ -8,6 +8,7 @@ interface Signature {
 
   Args: {
     isDisabled: boolean;
+    onSelect: () => void;
     repository: RepositoryModel;
   };
 }
@@ -22,10 +23,6 @@ export default class SelectLanguageProficiencyLevelSection extends Component<Sig
       return `First time with ${languageDescriptor} and want to get familiar with its core syntax first? [Browse](https://docs.codecrafters.io/community/learning-resources) our recommended learning resources.`;
     } else if (this.args.repository.languageProficiencyLevel === 'beginner') {
       return `If you're just starting out with ${languageDescriptor}, CodeCrafters can be a good way to learn. To brush up on ${languageDescriptor} syntax first, [check out](https://docs.codecrafters.io/community/learning-resources#picking-up-language-basics) our recommended learning resources.`;
-    } else if (this.args.repository.languageProficiencyLevel === 'intermediate') {
-      return `If you're already familiar with ${languageDescriptor}, CodeCrafters can be a good way to improve. We recommend using our **Code Examples** feature to see code from other users.`;
-    } else if (this.args.repository.languageProficiencyLevel === 'advanced') {
-      return `If you're already familiar with ${languageDescriptor}, CodeCrafters can be a good way to further your mastery. If you get stuck, you can use our **Code Examples** feature to see code from other users.`;
     } else {
       return null;
     }
@@ -39,6 +36,10 @@ export default class SelectLanguageProficiencyLevelSection extends Component<Sig
 
     if (!this.args.repository.isSaving) {
       this.args.repository.languageProficiencyLevel = proficiencyLevel;
+
+      if (!this.feedbackAlertMarkdown) {
+        this.args.onSelect();
+      }
 
       await this.args.repository.save();
     }


### PR DESCRIPTION
Add onSelect callback to SelectLanguageProficiencyLevelSection to notify
parent component when a proficiency level is chosen. Remove intermediate and
advanced level feedback messages to simplify guidance. Show a "Next question"
button conditionally after feedback alert, enabling users to proceed only when
appropriate. This enhances user interaction and navigation through the 
repository setup steps.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds `onSelect` to `SelectLanguageProficiencyLevelSection`, moves the next-step control inside the section with conditional display, auto-advances when no feedback, and removes intermediate/advanced guidance messages.
> 
> - **Create repository flow**
>   - **Language proficiency section (`select-language-proficiency-level-section`)**
>     - Add `@onSelect` arg and invoke it on selection when no `feedbackAlertMarkdown` (auto-advance).
>     - Move "Next question" button into the section; show only when feedback is present; wire to `@onSelect`.
>     - Remove feedback messages for `intermediate` and `advanced` levels.
>     - Set `AlertWithIcon` to `@type="info"` and render alert/button only when `feedbackAlertMarkdown` exists.
>   - **Parent template (`index.hbs`)**
>     - Pass `@onSelect={{this.expandNextSection}}` to the proficiency section.
>     - Remove outer "Next question" button for that section.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 39c2008303fa41659c4bf68e17afcafda2d6f0e8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->