### PR TITLE
fix(ui): make FAQ answers more compact in collapsible list

### DIFF
--- a/app/components/collapsible-faq-list-item.hbs
+++ b/app/components/collapsible-faq-list-item.hbs
@@ -15,7 +15,7 @@
   <AnimatedContainer>
     {{#animated-if @isOpen use=this.transition duration=200}}
       <div class="pb-3 pl-6">
-        <div class="prose dark:prose-invert">{{markdown-to-html @faq.answer_markdown}}</div>
+        <div class="prose dark:prose-invert prose-compact">{{markdown-to-html @faq.answer_markdown}}</div>
       </div>
     {{/animated-if}}
   </AnimatedContainer>


### PR DESCRIPTION
Add prose-compact class to FAQ answer container to reduce whitespace and create a tighter, more readable layout within the collapsible FAQ list items for improved visual presentation.

**Checklist**:

- [ ] I've thoroughly self-reviewed my changes
- [ ] I've added tests for my changes, unless they affect admin-only areas (or are otherwise not worth testing)
- [ ] I've verified any visual changes using Percy (add a commit with `[percy]` in the message to trigger)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds `prose-compact` to the FAQ answer container in `app/components/collapsible-faq-list-item.hbs` to tighten spacing.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6f3fa3ada5ef19a68543a7897ed48fcd69839474. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->