### PR TITLE
fix(instructions): comment out auto-scroll on test runner card

### DIFF
--- a/app/controllers/course/stage/instructions.ts
+++ b/app/controllers/course/stage/instructions.ts
@@ -8,7 +8,6 @@ import type RepositoryModel from 'codecrafters-frontend/models/repository';
 import type CourseStageStep from 'codecrafters-frontend/utils/course-page-step-list/course-stage-step';
 import { action } from '@ember/object';
 import type RouterService from '@ember/routing/router-service';
-import { next } from '@ember/runloop';
 import type Store from '@ember-data/store';
 
 export default class CourseStageInstructionsController extends Controller {


### PR DESCRIPTION
Temporarily disable the automatic scrolling to the test runner card when
test status is 'evaluating'. This feature is postponed until a clear
decision is made about the test runner card placement. The scrolling on
tests passing remains unaffected to maintain UX consistency.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Temporarily disables auto-scroll to the test runner when tests are evaluating; scroll-to-top on pass remains.
> 
> - **Controller** (`app/controllers/course/stage/instructions.ts`):
>   - Comment out auto-scroll to `test-runner-card` when tests enter `evaluating`.
>   - Add TODO regarding future placement of the test runner card.
>   - Keep scroll-to-top behavior when tests `passed`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 143ae5968920968208a869f3b6bcfa28f7783156. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->