### PR TITLE
Conditionally display free course notice based on user access

### DIFF
--- a/app/components/course-overview-page/notices.hbs
+++ b/app/components/course-overview-page/notices.hbs
@@ -14,10 +14,12 @@
     </p>
   </AlertWithIcon>
 {{else if (and @course.isFree @course.isFreeUntil)}}
-  <AlertWithIcon @type="success" data-test-course-free-notice ...attributes>
-    This challenge is free until
-    {{this.formattedCourseIsFreeExpirationDate}}!
-  </AlertWithIcon>
+  {{#unless this.authenticator.currentUser.canAccessMembershipBenefits}}
+    <AlertWithIcon @type="success" data-test-course-free-notice ...attributes>
+      This challenge is free until
+      {{this.formattedCourseIsFreeExpirationDate}}!
+    </AlertWithIcon>
+  {{/unless}}
 {{else if @course.releaseStatusIsDeprecated}}
   <AlertWithIcon @type="info" data-test-course-deprecated-notice ...attributes>
     This challenge is deprecated.<br />


### PR DESCRIPTION
Update the course overview page to only show the free course notice if the current user does not have access to membership benefits. This change enhances the user experience by ensuring relevant information is displayed based on user permissions.

**Checklist**:

- [x] I've thoroughly self-reviewed my changes
- [ ] I've added tests for my changes, unless they affect admin-only areas (or are otherwise not worth testing)
- [ ] I've verified any visual changes using Percy (add a commit with `[percy]` in the message to trigger)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Show the “free until” notice only for users without membership benefits.
> 
> - **Course overview notices**:
>   - Update `app/components/course-overview-page/notices.hbs` to wrap the free notice (`and @course.isFree @course.isFreeUntil`) in `unless this.authenticator.currentUser.canAccessMembershipBenefits`, hiding it for members.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7dfdb6a9cb0c256c560aae8db773add3967fc9ac. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->