### PR TITLE
feat(course-page): add analytics events for hint card toggle

### DIFF
--- a/app/components/course-page/course-stage-step/second-stage-your-task-card/implement-solution-step.ts
+++ b/app/components/course-page/course-stage-step/second-stage-your-task-card/implement-solution-step.ts
@@ -3,7 +3,9 @@ import type CourseStageModel from 'codecrafters-frontend/models/course-stage';
 import type RepositoryModel from 'codecrafters-frontend/models/repository';
 import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
+import { service } from '@ember/service';
 import fade from 'ember-animated/transitions/fade';
+import type AnalyticsEventTrackerService from 'codecrafters-frontend/services/analytics-event-tracker';
 
 interface Signature {
   Element: HTMLDivElement;
@@ -16,6 +18,8 @@ interface Signature {
 }
 
 export default class ImplementSolutionStep extends Component<Signature> {
+  @service declare analyticsEventTracker: AnalyticsEventTrackerService;
+
   transition = fade;
 
   @tracked expandedHintIndex: number | null = null;
@@ -32,13 +36,21 @@ export default class ImplementSolutionStep extends Component<Signature> {
 
   @action
   handleHintCardHeaderClick(hintIndex: number): void {
+    const hint = this.solution!.hintsJson![hintIndex]!;
+    const analyticsEventContext = {
+      solution_id: this.solution!.id,
+      hint_number: hintIndex + 1,
+      hint_title: hint.title_markdown,
+    };
+
     if (this.expandedHintIndex === hintIndex) {
-      // Trigger collapsed hint analytics event
       this.expandedHintIndex = null;
+      this.analyticsEventTracker.track('collapsed_stage_solution_hint', analyticsEventContext);
     } else {
-      // Trigger expand hint analytics event
       this.expandedHintIndex = hintIndex;
       this.solutionIsBlurred = true;
+
+      this.analyticsEventTracker.track('expanded_stage_solution_hint', analyticsEventContext);
     }
   }
 


### PR DESCRIPTION
Trigger analytics events when hint cards are expanded or collapsed 
in the implement solution step. This improves tracking of user 
interactions with hints for better insight into user behavior.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Tracks hint expand/collapse in Implement Solution step with contextual analytics payload.
> 
> - **Component**: `app/components/course-page/course-stage-step/second-stage-your-task-card/implement-solution-step.ts`
>   - Add `analyticsEventTracker` service to emit events on hint toggle.
>   - On hint header click:
>     - Track `expanded_stage_solution_hint` and `collapsed_stage_solution_hint` with `{ solution_id, hint_number, hint_title }`.
>     - Maintain existing UI behavior (toggle `expandedHintIndex`, blur solution).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 324fcae0d19da1fa4cb1396df89bd0f6318e2f1d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->