### PR TITLE
feat(adapter): add x-browser-url header with current URL

### DIFF
--- a/app/adapters/application.ts
+++ b/app/adapters/application.ts
@@ -34,6 +34,8 @@ export default class ApplicationAdapter extends JSONAPIAdapter {
       if (this.cookies.read('_gcl_aw')) {
         headers['x-google-click-id'] = this.cookies.read('_gcl_aw')!;
       }
+
+      headers['x-browser-url'] = window.location.href;
     }
 
     headers['x-codecrafters-client-version'] = this.versionTracker.currentVersion;


### PR DESCRIPTION
Include the current window location in the request headers as
'x-browser-url' to provide the server with the client's URL context.
This aids in better tracking and debugging of requests from the client side.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds `x-browser-url` header (from `window.location.href`) to all requests in `app/adapters/application.ts`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 52820884cd1c5e046beb239fbe4b6d7a26337478. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->