### PR TITLE
fix(concept-list): ensure only published concepts are included

### DIFF
--- a/app/components/track-page/primer-concept-group-section/concept-list.ts
+++ b/app/components/track-page/primer-concept-group-section/concept-list.ts
@@ -23,7 +23,7 @@ export default class ConceptList extends Component<Signature> {
     return this.args.conceptGroup.conceptSlugs.reduce((acc, slug) => {
       const concept = this.store.peekAll('concept').find((concept) => concept.slug === slug);
 
-      if (concept) {
+      if (concept && concept.statusIsPublished) {
         acc.push(concept);
       }
 


### PR DESCRIPTION

**Checklist**:

- [x] I've thoroughly self-reviewed my changes
- [ ] I've added tests for my changes, unless they affect admin-only areas (or are otherwise not worth testing)
- [ ] I've verified any visual changes using Percy (add a commit with `[percy]` in the message to trigger)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Filters `sortedConcepts` in `app/components/track-page/primer-concept-group-section/concept-list.ts` to include only concepts with `statusIsPublished`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8503f96d86c609c3b7483328ff30634abb4debde. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->