### PR TITLE
fix(course-overview): clean up paid course notice styling and text

### DIFF
--- a/app/components/course-overview-page/notices/paid-course-notice.hbs
+++ b/app/components/course-overview-page/notices/paid-course-notice.hbs
@@ -10,8 +10,8 @@
 
       <div class="prose prose-sm mb-4">
         <p>
-          You're welcome to study the full challenge structure and stage instructions for free. A membership is needed for submitting code and
-          viewing solutions.
+          You're welcome to study the full challenge structure and stage instructions for free. A membership is needed for submitting code and viewing
+          solutions.
         </p>
 
         {{#if this.freeOrBetaCourse}}


### PR DESCRIPTION
Remove the 'prose-compact' class to improve spacing in the paid course
notice component. Clarify wording about membership by replacing "your
code" with "code" and "those of others" with "solutions" for better
readability.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adjust spacing and clarify wording in the paid course notice template.
> 
> - **UI: Paid course notice (`app/components/course-overview-page/notices/paid-course-notice.hbs`)**
>   - Remove `prose-compact` from `prose prose-sm` block to adjust spacing.
>   - Update copy to say "submitting code" and "viewing solutions" for clarity.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 26c120d576ab75886b5c295e3d4de6119d6984a1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->