### PR TITLE
refactor: sort courses before finding beta or free course

### DIFF
--- a/app/components/course-overview-page/notices/paid-course-notice.ts
+++ b/app/components/course-overview-page/notices/paid-course-notice.ts
@@ -15,11 +15,17 @@ export default class PaidCourseNotice extends Component<Signature> {
   @service declare store: Store;
 
   get betaCourse(): CourseModel | null {
-    return this.store.peekAll('course').find((course: CourseModel) => course.releaseStatusIsBeta);
+    return this.store
+      .peekAll('course')
+      .sortBy('sortPositionForTrack')
+      .find((course: CourseModel) => course.releaseStatusIsBeta);
   }
 
   get freeCourse(): CourseModel | null {
-    return this.store.peekAll('course').find((course: CourseModel) => course.isFree);
+    return this.store
+      .peekAll('course')
+      .sortBy('sortPositionForTrack')
+      .find((course: CourseModel) => course.isFree);
   }
 
   get freeOrBetaCourse(): CourseModel | null {


### PR DESCRIPTION
Sort courses by sortPositionForTrack before searching to ensure
consistent selection of beta and free courses in the paid course
notice component. This improves reliability and predictability
of which course is displayed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Sorts `course` records by `sortPositionForTrack` before finding the beta or free course in `PaidCourseNotice`.
> 
> - **Course overview notice** (`app/components/course-overview-page/notices/paid-course-notice.ts`):
>   - Sort `store.peekAll('course')` by `sortPositionForTrack` before selecting:
>     - `betaCourse` (uses `releaseStatusIsBeta`)
>     - `freeCourse` (uses `isFree`)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d1191bb0b23a7ad7e52a35a32a39b0264c5d81d5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->