### PR TITLE
fix(course-overview-page): update route for free or beta course link

### DIFF
--- a/app/components/course-overview-page/notices/paid-course-notice.hbs
+++ b/app/components/course-overview-page/notices/paid-course-notice.hbs
@@ -35,7 +35,7 @@
       <div class="flex items-center flex-wrap flex-col sm:flex-row gap-4">
         {{#if this.freeOrBetaCourse}}
           <LinkTo
-            @route="course"
+            @route="course-overview"
             @model={{this.freeOrBetaCourse.slug}}
             class="w-full sm:w-auto text-center px-4 py-2 text-sm font-semibold bg-gray-800 rounded-sm text-white hover:bg-gray-700"
             data-test-try-free-challenge-button


### PR DESCRIPTION
Change the route from "course" to "course-overview" in the paid course
notice component to ensure users navigate to the correct course overview
page when clicking on free or beta course links. This fixes navigation
issues and improves user experience.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Update the paid-course notice button to link to `course-overview` instead of `course` for free/beta course trials.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 52051707c90503facdd0472c57d6f8fe985b5184. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->