### PR TITLE
chore(config): update app major version to 41.0

### DIFF
--- a/config/environment.js
+++ b/config/environment.js
@@ -49,7 +49,7 @@ module.exports = function (environment) {
 
       // Update the major version number to force all clients to update.
       // The minor version doesn't do anything at the moment, might use in the future.
-      version: `40.0.${process.env.VERCEL_GIT_COMMIT_SHA?.slice(0, 7) || 'dev'}`,
+      version: `41.0.${process.env.VERCEL_GIT_COMMIT_SHA?.slice(0, 7) || 'dev'}`,
     },
     fastboot: {
       hostWhitelist: [/^localhost:\d+$/],


### PR DESCRIPTION
Increment the major version number from 40.0 to 41.0 in the
environment configuration. This forces all clients to update,
ensuring they run the latest code and avoid potential
incompatibilities. The minor version is left unchanged for now.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Increase app major version from 40.0 to 41.0 in `config/environment.js`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0851dbfc49add4321a37c86c6144fcdbcc6cb852. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->