### PR TITLE
feat(modifier): add fire-confetti-on-insert modifier

### DIFF
--- a/app/modifiers/fire-confetti-on-insert.ts
+++ b/app/modifiers/fire-confetti-on-insert.ts
@@ -1,0 +1,23 @@
+import Modifier from 'ember-modifier';
+import { inject as service } from '@ember/service';
+import type ConfettiService from 'codecrafters-frontend/services/confetti';
+
+interface Signature {
+  Args: {
+    Positional: [];
+  };
+}
+
+export default class FireConfettiOnInsertModifier extends Modifier<Signature> {
+  @service declare confetti: ConfettiService;
+
+  modify(element: HTMLElement, _positional: []) {
+    this.confetti.fireFromElement(element);
+  }
+}
+
+declare module '@glint/environment-ember-loose/registry' {
+  export default interface Registry {
+    'fire-confetti-on-insert': typeof FireConfettiOnInsertModifier;
+  }
+}


### PR DESCRIPTION
Introduce a new Ember modifier that triggers the confetti service
to fire confetti from the inserted element. This change enables 
easy reuse of confetti effects on element insertion across the app, 
improving user feedback and celebration for interactive UI events.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds an Ember modifier that fires confetti from the inserted element and registers it in Glint.
> 
> - **Ember**:
>   - **New modifier** `app/modifiers/fire-confetti-on-insert.ts`:
>     - Injects `ConfettiService` and triggers `confetti.fireFromElement(element)` on element insertion via `modify`.
>     - Registers `'fire-confetti-on-insert'` in `@glint/environment-ember-loose/registry`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2824017b699fbebd77ec7166f0875f551e7bd01e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->