### PR TITLE
fix(style): improve modal layout and typography in previous steps warning

### DIFF
--- a/app/components/course-page/previous-steps-incomplete-modal.hbs
+++ b/app/components/course-page/previous-steps-incomplete-modal.hbs
@@ -8,8 +8,8 @@
       Previous steps incomplete!
     </div>
 
-    <div class="prose dark:prose-invert prose-compact mb-5 text-center" data-test-completion-message>
-      <p class="text-pretty">
+    <div class="prose dark:prose-invert prose-compact mb-5" data-test-completion-message>
+      <p class="text-balance text-center">
         This step depends on previous steps that you haven't completed yet.
       </p>
     </div>


### PR DESCRIPTION
Add max width to modal content container for better spacing and
replace 'prose' text style with 'prose-compact' and updated paragraph
class to enhance readability and visual balance in the incomplete steps
warning modal. These changes improve the modal's appearance and user
experience.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Refines the previous-steps incomplete modal by adding a max-width container, switching to `prose-compact`, and adjusting text centering for improved readability.
> 
> - **UI/Styling**
>   - In `app/components/course-page/previous-steps-incomplete-modal.hbs`:
>     - Add `max-w-2xs` to content container to constrain width.
>     - Replace `prose` with `prose-compact` and move `text-center` from wrapper to paragraph.
>     - Remove redundant `class="w-full"` from `ModalBody`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 27f891264966e2844faab03306966b6db667a112. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->