### PR TITLE
docs(workflow): update linting guidance for pauseTest failures

### DIFF
--- a/.cursor/rules/development-workflow.mdc
+++ b/.cursor/rules/development-workflow.mdc
@@ -6,6 +6,7 @@ When you're asked to make changes, follow these rules:
 
 - Say consistent with the rest of our codebase. Read other files to understand what our patterns are.
 - Run `npm run lint` after making changes.
+  - You can ignore any `pauseTest()` related failures. These are needed for debugging purposes.
 - Once linting is successful, you can try running tests if there are ones that cover the area you changed.
   - Only run tests using the browser tool.
   - The browser will already be open with a URL like this: `http://localhost:4200/tests/index.html?moduleId=abcd`


### PR DESCRIPTION
Add a note in the development workflow to ignore `pauseTest()` related
failures during linting, as these are intentional and used for debugging
purposes. This clarifies the expected behavior and helps prevent
confusion when running lint checks.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Update development workflow docs to state that `pauseTest()`-related lint failures can be ignored.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9a17591958fe17d2e7994d577a3025c78f0a0b4d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->