### PR TITLE
feat(course-page): add step switcher to setup tutorial modal

### DIFF
--- a/app/components/course-page/setup-step-complete-modal.hbs
+++ b/app/components/course-page/setup-step-complete-modal.hbs
@@ -1,6 +1,6 @@
 <ModalBody @allowManualClose={{false}} @onClose={{@onClose}} data-test-setup-step-complete-modal class="px-0! py-0!" ...attributes>
   <AnimatedContainer>
-    <div class="flex flex-col items-center py-12 px-4 sm:px-8">
+    <div class="flex flex-col items-center py-8 px-4 sm:px-8">
       {{#animated-value this.currentScreen use=this.transition duration=500 as |currentScreen|}}
         {{#if (eq currentScreen "start-workflow-tutorial")}}
           <CoursePage::SetupStepCompleteModal::StartWorkflowTutorialScreen
@@ -13,12 +13,14 @@
           <CoursePage::SetupStepCompleteModal::WorkflowTutorialStep1Screen
             @step={{@step}}
             @onNextButtonClick={{this.handleNextButtonClick}}
+            @onStepSelect={{this.handleStepSelect}}
             class="w-full max-w-xs"
           />
         {{else if (eq currentScreen "workflow-tutorial-step-2")}}
           <CoursePage::SetupStepCompleteModal::WorkflowTutorialStep2Screen
             @step={{@step}}
             @onNextButtonClick={{this.handleNextButtonClick}}
+            @onStepSelect={{this.handleStepSelect}}
             class="w-full max-w-xs"
           />
         {{else if (eq currentScreen "workflow-tutorial-completed")}}

--- a/app/components/course-page/setup-step-complete-modal.ts
+++ b/app/components/course-page/setup-step-complete-modal.ts
@@ -65,6 +65,15 @@ export default class SetupStepCompleteModalComponent extends Component<Signature
       throw new Error(`Invalid screen for next button click: ${this.currentScreen}`);
     }
   }
+
+  @action
+  handleStepSelect(stepNumber: number) {
+    if (stepNumber === 1) {
+      this.currentScreen = 'workflow-tutorial-step-1';
+    } else if (stepNumber === 2) {
+      this.currentScreen = 'workflow-tutorial-step-2';
+    }
+  }
 }
 
 declare module '@glint/environment-ember-loose/registry' {

--- a/app/components/course-page/setup-step-complete-modal/step-switcher.hbs
+++ b/app/components/course-page/setup-step-complete-modal/step-switcher.hbs
@@ -1,0 +1,13 @@
+<div class="flex items-center justify-center gap-2" ...attributes>
+  {{#each this.steps as |step|}}
+    <button
+      type="button"
+      class="rounded-full transition-all duration-200 cursor-pointer w-2 h-2
+        {{if (eq step @currentStep) 'bg-teal-500 ring-1 ring-teal-500 ring-offset-1' 'bg-gray-300 dark:bg-gray-600'}}"
+      data-test-step-indicator
+      data-test-step-number={{step}}
+      data-test-is-active={{eq step @currentStep}}
+      {{on "click" (fn this.handleStepClick step)}}
+    ></button>
+  {{/each}}
+</div>

--- a/app/components/course-page/setup-step-complete-modal/step-switcher.ts
+++ b/app/components/course-page/setup-step-complete-modal/step-switcher.ts
@@ -1,0 +1,29 @@
+import Component from '@glimmer/component';
+import { action } from '@ember/object';
+
+interface Signature {
+  Element: HTMLDivElement;
+
+  Args: {
+    currentStep: number;
+    onStepSelect: (stepNumber: number) => void;
+    totalSteps: number;
+  };
+}
+
+export default class StepSwitcherComponent extends Component<Signature> {
+  get steps() {
+    return Array.from({ length: this.args.totalSteps }, (_, i) => i + 1);
+  }
+
+  @action
+  handleStepClick(stepNumber: number) {
+    this.args.onStepSelect(stepNumber);
+  }
+}
+
+declare module '@glint/environment-ember-loose/registry' {
+  export default interface Registry {
+    'CoursePage::SetupStepCompleteModal::StepSwitcher': typeof StepSwitcherComponent;
+  }
+}

--- a/app/components/course-page/setup-step-complete-modal/workflow-tutorial-step1-screen.hbs
+++ b/app/components/course-page/setup-step-complete-modal/workflow-tutorial-step1-screen.hbs
@@ -3,7 +3,7 @@
     <span class="text-gray-700 dark:text-gray-300 font-semibold">1</span>
   </div>
 
-  <div class="px-3 sm:px-6 py-6 bg-gray-50 dark:bg-gray-850 rounded-sm border border-gray-200 dark:border-gray-700 mb-4">
+  <div class="px-3 sm:px-6 py-6 bg-gray-50 dark:bg-gray-850 rounded-sm border border-gray-200 dark:border-gray-700 mb-6">
     <div class="mb-4 font-bold text-lg text-gray-700 dark:text-gray-100 text-center text-pretty">
       Work in your Git repo
     </div>
@@ -27,7 +27,9 @@
     </div>
   </div>
 
-  <PrimaryButton data-test-next-button class="shrink-0" {{on "click" @onNextButtonClick}}>
+  <PrimaryButton data-test-next-button class="mb-6" {{on "click" @onNextButtonClick}}>
     Continue →
   </PrimaryButton>
+
+  <CoursePage::SetupStepCompleteModal::StepSwitcher @currentStep={{1}} @totalSteps={{2}} @onStepSelect={{@onStepSelect}} />
 </div>

--- a/app/components/course-page/setup-step-complete-modal/workflow-tutorial-step1-screen.ts
+++ b/app/components/course-page/setup-step-complete-modal/workflow-tutorial-step1-screen.ts
@@ -7,6 +7,7 @@ interface Signature {
 
   Args: {
     onNextButtonClick: () => void;
+    onStepSelect: (stepNumber: number) => void;
     step: SetupStep;
   };
 }

--- a/app/components/course-page/setup-step-complete-modal/workflow-tutorial-step2-screen.hbs
+++ b/app/components/course-page/setup-step-complete-modal/workflow-tutorial-step2-screen.hbs
@@ -3,7 +3,7 @@
     <span class="text-gray-700 dark:text-gray-300 font-semibold">2</span>
   </div>
 
-  <div class="px-3 sm:px-6 py-6 bg-gray-50 dark:bg-gray-850 rounded-sm border border-gray-200 dark:border-gray-700 mb-4">
+  <div class="px-3 sm:px-6 py-6 bg-gray-50 dark:bg-gray-850 rounded-sm border border-gray-200 dark:border-gray-700 mb-6">
     <div class="mb-4 font-bold text-lg text-gray-700 dark:text-gray-100 text-center text-pretty">
       `git push` to submit
     </div>
@@ -26,7 +26,9 @@
     </div>
   </div>
 
-  <PrimaryButton data-test-next-button class="shrink-0" {{on "click" @onNextButtonClick}}>
+  <PrimaryButton data-test-next-button class="mb-6" {{on "click" @onNextButtonClick}}>
     Continue →
   </PrimaryButton>
+
+  <CoursePage::SetupStepCompleteModal::StepSwitcher @currentStep={{2}} @totalSteps={{2}} @onStepSelect={{@onStepSelect}} />
 </div>

--- a/app/components/course-page/setup-step-complete-modal/workflow-tutorial-step2-screen.ts
+++ b/app/components/course-page/setup-step-complete-modal/workflow-tutorial-step2-screen.ts
@@ -6,6 +6,7 @@ interface Signature {
 
   Args: {
     onNextButtonClick: () => void;
+    onStepSelect: (stepNumber: number) => void;
     step: SetupStep;
   };
 }


### PR DESCRIPTION
Introduce StepSwitcher component to display and switch between tutorial 
steps in the SetupStepCompleteModal. This allows users to navigate 
directly to a specific step in the workflow tutorial instead of only 
progressing linearly.

Update WorkflowTutorialStep1Screen and Step2Screen layouts to include 
the step switcher beneath the Continue button for better navigation.

Add handleStepSelect action in the modal to update currentScreen on step 
selection, supporting dynamic screen changes based on user input.

Adjust modal padding and button margins for improved spacing and visual 
balance.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Add a step switcher to the workflow tutorial modal for direct step navigation, with minor spacing adjustments.
> 
> - **UI**:
>   - **New component**: `CoursePage::SetupStepCompleteModal::StepSwitcher` (props: `currentStep`, `totalSteps`, `onStepSelect`) renders clickable step indicators.
>   - **Integration**: Added `StepSwitcher` to `workflow-tutorial-step-1` and `workflow-tutorial-step-2` screens; both now pass `@onStepSelect` and adjust button spacing (`mb-6`).
>   - **Layout**: Modal content padding reduced (`py-12` → `py-8`).
> - **Logic**:
>   - **Navigation**: Implemented `handleStepSelect(stepNumber)` in `setup-step-complete-modal.ts` to set `currentScreen` to `workflow-tutorial-step-1` or `workflow-tutorial-step-2`. 
>   - **Wiring**: `onStepSelect` plumbed through modal to step screens.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d495c959402063ccc64277c806b63f988e59b626. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->