### PR TITLE
Convert `{{#animated-if}}` syntax to `<AnimatedIf />`

### DIFF
--- a/app/components/welcome-page/onboarding-survey-wizard/index.hbs
+++ b/app/components/welcome-page/onboarding-survey-wizard/index.hbs
@@ -1,17 +1,22 @@
 <div class="border border-gray-200 p-4 sm:p-8 bg-white max-w-(--breakpoint-md) w-full rounded-sm" data-test-onboarding-survey-wizard>
   <AnimatedContainer>
-    {{#animated-if (eq this.currentStep 1) use=this.fade}}
-      <WelcomePage::OnboardingSurveyWizard::Step1
-        @onContinueButtonClick={{this.handleContinueButtonClick}}
-        @onSurveyUpdated={{this.handleSurveyUpdated}}
-        @onboardingSurvey={{@onboardingSurvey}}
-      />
-    {{else}}{{#if (eq this.currentStep 2)}}
-        <WelcomePage::OnboardingSurveyWizard::Step2
-          @onboardingSurvey={{@onboardingSurvey}}
+    <AnimatedIf @predicate={{(eq this.currentStep 1)}} @use={{this.fade}}>
+      <:default>
+        <WelcomePage::OnboardingSurveyWizard::Step1
           @onContinueButtonClick={{this.handleContinueButtonClick}}
           @onSurveyUpdated={{this.handleSurveyUpdated}}
+          @onboardingSurvey={{@onboardingSurvey}}
         />
-      {{/if}}{{/animated-if}}
+      </:default>
+      <:else>
+        {{#if (eq this.currentStep 2)}}
+          <WelcomePage::OnboardingSurveyWizard::Step2
+            @onboardingSurvey={{@onboardingSurvey}}
+            @onContinueButtonClick={{this.handleContinueButtonClick}}
+            @onSurveyUpdated={{this.handleSurveyUpdated}}
+          />
+        {{/if}}
+      </:else>
+    </AnimatedIf>
   </AnimatedContainer>
 </div>


### PR DESCRIPTION
Closes #2990 

### Brief

This is an experimental fix to prevent prettier from messing up `{{#animated-if}}` + `{{else if}}` blocks

### Details

 - Use `<AnimatedIf />` syntax instead of `{{#animated-if}}` in onboarding survey wizard

### Checklist

- [ ] I've thoroughly self-reviewed my changes
- [ ] I've added tests for my changes, unless they affect admin-only areas (or are otherwise not worth testing)
- [ ] I've verified any visual changes using Percy (add a commit with `[percy]` in the message to trigger)
