### PR TITLE
docs: update linting command to use npm run lint:fix

### DIFF
--- a/.cursor/rules/development-workflow.mdc
+++ b/.cursor/rules/development-workflow.mdc
@@ -5,7 +5,7 @@ alwaysApply: true
 When you're asked to make changes, follow these rules:
 
 - Say consistent with the rest of our codebase. Read other files to understand what our patterns are.
-- Run `npm run lint` after making changes.
+- Run `npm run lint:fix` after making changes.
   - You can ignore any `pauseTest()` related failures. These are needed for debugging purposes.
 - Once linting is successful, you can try running tests if there are ones that cover the area you changed.
   - Only run tests using the browser tool.


### PR DESCRIPTION
Change the linting instruction in the development workflow guide
from `npm run lint` to `npm run lint:fix` to ensure automatic fixing
of lint errors after code changes, improving consistency and efficiency.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates the development workflow to run `npm run lint:fix` instead of `npm run lint`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 042d4e91d97fdb5ef0a94573c7e38efc1dbed71d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->