### PR TITLE
fix(utils): correct property name for course description

### DIFF
--- a/mirage/utils/create-course-from-data.js
+++ b/mirage/utils/create-course-from-data.js
@@ -12,7 +12,7 @@ export default function createCourseFromData(server, courseData) {
       name: courseExtensionData.name,
       slug: courseExtensionData.slug,
       position: courseExtensionPosition,
-      descriptionMarkdown: courseExtensionData.description_md,
+      descriptionMarkdown: courseExtensionData.description_markdown,
     });
 
     courseExtensionPosition++;


### PR DESCRIPTION
Update create-course-from-data.js to use the correct property
description_markdown instead of description_md. This fixes data
mapping errors and ensures course descriptions are properly loaded.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Use `description_markdown` (not `description_md`) when creating `course-extension.descriptionMarkdown` in `create-course-from-data.js`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 72b3bc98a87f2006d7d1c4c9249c3f36a158a8a6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->