### PR TITLE
fix(ui): update test runner icon to outlined version

### DIFF
--- a/app/components/course-admin/tester-versions-page/version-list-item.hbs
+++ b/app/components/course-admin/tester-versions-page/version-list-item.hbs
@@ -41,7 +41,7 @@
           </svg>
 
           <div class="flex items-center gap-x-1 text-teal-500" data-test-provisioned-test-runners-count>
-            {{svg-jar "command-line" class="h-4 w-4"}}
+            {{svg-jar "command-line-outline" class="h-4 w-4"}}
             <span class="font-semibold">
               {{@courseTesterVersion.provisionedTestRunnersCount}}
             </span>


### PR DESCRIPTION
Change the test runner SVG icon from "command-line" to
"command-line-outline" in the version list item component to
improve visual clarity and consistency in the UI.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Switches the test runner icon to the outlined variant in `version-list-item.hbs` for provisioned test runner count.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e8a18c4a1e41eff16f893688479cd4eecf70f427. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->