### PR TITLE
Fix `collapseUnchanged` hiding changed lines in some diffs

### DIFF
--- a/app/utils/code-mirror-collapse-unchanged.ts
+++ b/app/utils/code-mirror-collapse-unchanged.ts
@@ -129,7 +129,7 @@ const ChunkField = StateField.define<readonly Chunk[]>({
 
 function buildCollapsedRanges(state: EditorState, margin: number, minLines: number) {
   const builder = new RangeSetBuilder<Decoration>();
-  const isA = true; // state.facet(mergeConfig).side == 'a';
+  const isA = false; // state.facet(mergeConfig).side == 'a';
   const chunks = state.field(ChunkField);
   let prevLine = 1;
 

--- a/tests/acceptance/course-admin/view-diffs-test.js
+++ b/tests/acceptance/course-admin/view-diffs-test.js
@@ -103,7 +103,7 @@ module('Acceptance | course-admin | view-diffs', function (hooks) {
 
     assert.strictEqual(
       submissionsPage.diffTab.changedFiles[0].codeMirror.content.collapsedLinesPlaceholders[2].text,
-      'Expand 9 unchanged lines',
+      'Expand 7 unchanged lines',
       'The third placeholder should show correct number of lines',
     );
 


### PR DESCRIPTION
Closes #2953 

### Brief

This fixes `collapseUnchanged` hiding modified lines in some diffs.

### Screenshot

<img width="671" height="523" alt="Знімок екрана 2025-11-02 о 20 54 39" src="https://github.com/user-attachments/assets/d0911256-f472-4b71-8cbe-11a6e2d39389" />

### Checklist

- [x] I've thoroughly self-reviewed my changes
- [x] I've added tests for my changes, unless they affect admin-only areas (or are otherwise not worth testing)
- [x] I've verified any visual changes using Percy (add a commit with `[percy]` in the message to trigger)
