### PR TITLE
Open course admin submissions in a new tab instead of transitioning

### DIFF
--- a/app/components/course-page/repository-dropdown/index.ts
+++ b/app/components/course-page/repository-dropdown/index.ts
@@ -44,7 +44,7 @@ export default class CoursePageRepositoryDropdown extends Component<Signature> {
   @action
   async handleAdminButtonClick(dropdownActions: { close: () => void }) {
     dropdownActions.close();
-    this.router.transitionTo('course-admin.submissions', this.args.activeRepository.course.slug);
+    window.open(this.router.urlFor('course-admin.submissions', this.args.activeRepository.course.slug), '_blank');
   }
 
   @action


### PR DESCRIPTION
**Issue:**

CMD+clicking no longer works since the admin button isn't a `<a>` tag anymore.

**Workaround:**

Always open a new tab.

**Checklist**:

- [x] I've thoroughly self-reviewed my changes
- [x] They affect admin-only areas (or are otherwise not worth testing)
- [ ] I've verified any visual changes using Percy (add a commit with `[percy]` in the message to trigger)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Change admin submissions action to open in a new tab using `window.open` instead of in-app transition.
> 
> - **Course Page Dropdown**:
>   - Update `handleAdminButtonClick` in `app/components/course-page/repository-dropdown/index.ts` to use `window.open(this.router.urlFor('course-admin.submissions', ...), '_blank')` instead of `router.transitionTo`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ecaaafcd34f5c804ef81c0399585f0d4397184ee. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->