### PR TITLE
feat(autofix-container): add autofix request creation and error handling

### DIFF
--- a/app/components/course-admin/submissions-page/submission-details/autofix-container.hbs
+++ b/app/components/course-admin/submissions-page/submission-details/autofix-container.hbs
@@ -10,5 +10,17 @@
     <div class="bg-gray-800 p-4 text-white font-mono text-xs leading-relaxed rounded-sm mb-4">
       This submission doesn't have any autofix requests.
     </div>
+
+    <PrimaryButtonWithSpinner @shouldShowSpinner={{this.createAutofixRequestTask.isRunning}} {{on "click" this.handleCreateAutofixButtonClick}}>
+      Create Autofix Request
+    </PrimaryButtonWithSpinner>
+
+    {{#if this.autofixCreationError}}
+      <AlertWithIcon @type="error" class="mt-3">
+        <p>
+          {{this.autofixCreationError}}
+        </p>
+      </AlertWithIcon>
+    {{/if}}
   {{/if}}
 </div>

--- a/app/components/course-admin/submissions-page/submission-details/autofix-container.ts
+++ b/app/components/course-admin/submissions-page/submission-details/autofix-container.ts
@@ -1,5 +1,10 @@
 import Component from '@glimmer/component';
+import type Store from '@ember-data/store';
 import type SubmissionModel from 'codecrafters-frontend/models/submission';
+import { action } from '@ember/object';
+import { service } from '@ember/service';
+import { task } from 'ember-concurrency';
+import { tracked } from '@glimmer/tracking';
 
 interface Signature {
   Element: HTMLDivElement;
@@ -9,7 +14,30 @@ interface Signature {
   };
 }
 
-export default class AutofixContainer extends Component<Signature> {}
+export default class AutofixContainer extends Component<Signature> {
+  @service declare store: Store;
+
+  @tracked autofixCreationError: string | null = null;
+
+  createAutofixRequestTask = task({ drop: true }, async (): Promise<void> => {
+    this.autofixCreationError = null;
+
+    const autofixRequest = this.store.createRecord('autofix-request', {
+      submission: this.args.submission,
+    });
+
+    try {
+      await autofixRequest.save();
+    } catch {
+      this.autofixCreationError = 'Failed to create autofix request! Try again? Post on #engineering if this persists.';
+    }
+  });
+
+  @action
+  handleCreateAutofixButtonClick() {
+    this.createAutofixRequestTask.perform();
+  }
+}
 
 declare module '@glint/environment-ember-loose/registry' {
   export default interface Registry {


### PR DESCRIPTION
Implement a task to create autofix requests for submissions and handle
errors when the creation fails. Introduce a button in the template to
trigger this task with a loading state spinner and show a user-friendly
error message if saving the request fails. This enables admins to
initiate autofix requests directly from the submission details page.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a button and task to create an `autofix-request` for a submission with spinner feedback and error alert on failure.
> 
> - **Submission Details > Autofix Container**
>   - **Template (`autofix-container.hbs`)**:
>     - Adds `PrimaryButtonWithSpinner` to create an autofix request when none exist, bound to `createAutofixRequestTask` and `handleCreateAutofixButtonClick`.
>     - Displays error via `AlertWithIcon` when `autofixCreationError` is set.
>   - **Component (`autofix-container.ts`)**:
>     - Injects `store` service and tracks `autofixCreationError`.
>     - Implements `createAutofixRequestTask` (drop policy) to create and save an `autofix-request` linked to `@submission`, setting an error message on failure.
>     - Adds `handleCreateAutofixButtonClick` action to trigger the task.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1da7b8820301c19fa8f6c0a32e7d2d3a67b0b719. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->