### PR TITLE
fix(submissions-page): improve autofix request button and error display

### DIFF
--- a/app/components/course-admin/submissions-page/submission-details/autofix-container.hbs
+++ b/app/components/course-admin/submissions-page/submission-details/autofix-container.hbs
@@ -10,17 +10,21 @@
     <div class="bg-gray-800 p-4 text-white font-mono text-xs leading-relaxed rounded-sm mb-4">
       This submission doesn't have any autofix requests.
     </div>
+  {{/if}}
 
-    <PrimaryButtonWithSpinner @shouldShowSpinner={{this.createAutofixRequestTask.isRunning}} {{on "click" this.handleCreateAutofixButtonClick}}>
+  <PrimaryButtonWithSpinner @shouldShowSpinner={{this.createAutofixRequestTask.isRunning}} {{on "click" this.handleCreateAutofixButtonClick}}>
+    {{#if (gt @submission.autofixRequests.length 0)}}
+      Retry Autofix Request
+    {{else}}
       Create Autofix Request
-    </PrimaryButtonWithSpinner>
-
-    {{#if this.autofixCreationError}}
-      <AlertWithIcon @type="error" class="mt-3">
-        <p>
-          {{this.autofixCreationError}}
-        </p>
-      </AlertWithIcon>
     {{/if}}
+  </PrimaryButtonWithSpinner>
+
+  {{#if this.autofixCreationError}}
+    <AlertWithIcon @type="error" class="mt-3">
+      <p>
+        {{this.autofixCreationError}}
+      </p>
+    </AlertWithIcon>
   {{/if}}
 </div>


### PR DESCRIPTION
Update the autofix request button to conditionally show "Retry Autofix 
Request" when there are existing requests, otherwise display "Create 
Autofix Request". Fix template syntax by properly closing the conditional 
block. Move the error alert outside the button to ensure correct UI 
rendering. These changes enhance user clarity and improve component 
structure.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Conditionally label the autofix action button, fix an unclosed if-block, and relocate the error alert for proper rendering.
> 
> - **Submissions Page – Autofix Container (`app/components/.../autofix-container.hbs`)**:
>   - **Button behavior**: Conditionally label button as `Retry Autofix Request` when `@submission.autofixRequests.length > 0`, else `Create Autofix Request`.
>   - **Template fix**: Properly close the `{{#if}}` block around the autofix request list.
>   - **Error handling**: Move `autofixCreationError` alert outside the button for correct UI rendering.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 767bb3638cb1237c8c6fc8ed91de1db1f9d22943. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->