### PR TITLE
chore: remove deprecated Google Analytics gtag script

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -53,16 +53,6 @@
       fbq('track', 'PageView');
     </script>
     <!-- End Facebook Pixel Code -->
-
-    <!-- Don't think we need this anymore? -->
-    <!-- <script async src="https://www.googletagmanager.com/gtag/js?id=G-N8D6K4M2HE"></script> -->
-    <!-- <script>
-      window.dataLayer = window.dataLayer || [];
-      function gtag(){dataLayer.push(arguments);}
-      gtag('js', new Date());
-
-      gtag('config', 'G-N8D6K4M2HE');
-    </script> -->
   </head>
   <body style="margin: 0; background-color: rgb(248 250 252)">
     <!-- Google Tag Manager (noscript) -->


### PR DESCRIPTION
Remove commented-out Google Analytics gtag script from index.html as it
is no longer needed. This cleanup reduces clutter and potential confusion
in the codebase by eliminating outdated tracking code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Remove commented-out Google Analytics gtag snippet from `app/index.html`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8bbaf981dbd2437f04a5dff503e83dd2ae7152bf. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->