### PR TITLE
feat(course): update test results bar behavior on test status changes

### DIFF
--- a/app/controllers/course/stage/instructions.ts
+++ b/app/controllers/course/stage/instructions.ts
@@ -62,19 +62,27 @@ export default class CourseStageInstructionsController extends Controller {
 
   @action
   handleDidUpdateTestsStatus(_element: HTMLDivElement, [newTestsStatus]: [CourseStageStep['testsStatus']]) {
-    // For tests passed, let's collapse the test results bar and scroll all the way to the top
-    if (newTestsStatus === 'passed') {
-      this.coursePageState.testResultsBarIsExpanded = false;
-      document.getElementById('course-page-scrollable-area')?.scrollTo({ top: 0, behavior: 'smooth' });
-    }
+    // TODO: Add a feature flag here
+    if (this.authenticator.currentUser?.isStaff) {
+      // For tests passed, let's collapse the test results bar and scroll all the way to the top
+      if (newTestsStatus === 'passed') {
+        this.coursePageState.testResultsBarIsExpanded = false;
+        document.getElementById('course-page-scrollable-area')?.scrollTo({ top: 0, behavior: 'smooth' });
+      }
 
-    // When tests are run, let's expand the test results bar. It'll automatically collapse when tests pass.
-    if (
-      newTestsStatus === 'evaluating' &&
-      this.model.activeRepository.lastSubmission &&
-      !this.model.activeRepository.lastSubmission.clientTypeIsSystem
-    ) {
-      this.coursePageState.testResultsBarIsExpanded = true;
+      // When tests are run, let's expand the test results bar. It'll automatically collapse when tests pass.
+      if (
+        newTestsStatus === 'evaluating' &&
+        this.model.activeRepository.lastSubmission &&
+        !this.model.activeRepository.lastSubmission.clientTypeIsSystem
+      ) {
+        this.coursePageState.testResultsBarIsExpanded = true;
+      }
+    } else {
+      // For tests passed, let's scroll all the way to the top
+      if (newTestsStatus === 'passed') {
+        document.getElementById('course-page-scrollable-area')?.scrollTo({ top: 0, behavior: 'smooth' });
+      }
     }
   }
 


### PR DESCRIPTION
Expand the test results bar when tests start evaluating to provide 
immediate feedback to users. Automatically collapse the bar and scroll 
to the top once tests pass. This improves test result visibility and 
page navigation during the testing process.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Expands the test results bar for staff when tests start evaluating, collapses it and scrolls to top on pass; non-staff only scroll to top on pass.
> 
> - **Course stage instructions controller** (`app/controllers/course/stage/instructions.ts`):
>   - **`handleDidUpdateTestsStatus`**:
>     - For `isStaff` users:
>       - Expand `testResultsBar` when tests enter `evaluating` and the last submission is user-initiated (non-system).
>       - Collapse `testResultsBar` and scroll `#course-page-scrollable-area` to top on `passed`.
>     - For non-staff users:
>       - Scroll `#course-page-scrollable-area` to top on `passed`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 67e158abfdee7600272ad22b5d5272295890b75a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->