### PR TITLE
fix: constrain modal max width consistently across all modals

### DIFF
--- a/app/components/affiliate-page/create-payout-modal/index.hbs
+++ b/app/components/affiliate-page/create-payout-modal/index.hbs
@@ -1,4 +1,4 @@
-<ModalBody @allowManualClose={{true}} @onClose={{@onClose}} class="w-full" data-test-create-payout-modal>
+<ModalBody @allowManualClose={{true}} @onClose={{@onClose}} class="w-full max-w-xl" data-test-create-payout-modal>
   <div class="mb-8 font-semibold text-2xl text-gray-600 mr-6">
     Initiate payout
   </div>

--- a/app/components/concept-admin/delete-concept-modal.hbs
+++ b/app/components/concept-admin/delete-concept-modal.hbs
@@ -1,4 +1,4 @@
-<ModalBody @allowManualClose={{true}} @onClose={{@onClose}} class="w-full" data-test-delete-concept-modal>
+<ModalBody @allowManualClose={{true}} @onClose={{@onClose}} class="w-full max-w-xl" data-test-delete-concept-modal>
   <div class="mb-6 font-semibold text-2xl text-gray-600 mr-8">
     Delete Concept
   </div>

--- a/app/components/course-page/configure-extensions-modal/index.hbs
+++ b/app/components/course-page/configure-extensions-modal/index.hbs
@@ -1,4 +1,4 @@
-<ModalBody @isWide={{true}} @allowManualClose={{true}} @onClose={{@onClose}} class="w-full" data-test-configure-extensions-modal>
+<ModalBody @allowManualClose={{true}} @onClose={{@onClose}} class="w-full max-w-(--breakpoint-lg)" data-test-configure-extensions-modal>
   <div class="mb-6 font-semibold text-2xl text-gray-800 dark:text-gray-50 mr-8">
     Configure Extensions
   </div>

--- a/app/components/course-page/configure-github-integration-modal/index.hbs
+++ b/app/components/course-page/configure-github-integration-modal/index.hbs
@@ -1,4 +1,4 @@
-<ModalBody @allowManualClose={{true}} @onClose={{@onClose}} class="w-full" data-test-configure-github-integration-modal>
+<ModalBody @allowManualClose={{true}} @onClose={{@onClose}} class="w-full max-w-xl" data-test-configure-github-integration-modal>
   <div class="mb-6 font-semibold text-2xl text-gray-800 dark:text-gray-50 mr-8">
     Publish to GitHub
   </div>

--- a/app/components/course-page/course-stage-step/first-stage-your-task-card/submit-code-step.hbs
+++ b/app/components/course-page/course-stage-step/first-stage-your-task-card/submit-code-step.hbs
@@ -57,7 +57,7 @@
 
 {{#if this.isCommitModalOpen}}
   <ModalBackdrop class="cursor-pointer">
-    <ModalBody @allowManualClose={{true}} @onClose={{this.handleCommitModalClose}} @isWide={{true}} class="w-fit cursor-default">
+    <ModalBody @allowManualClose={{true}} @onClose={{this.handleCommitModalClose}} class="w-fit cursor-default max-w-(--breakpoint-lg)">
       <div class="mb-6 font-semibold text-2xl text-gray-800 dark:text-gray-200 mr-8">
         Commit changes
       </div>
@@ -129,7 +129,7 @@
 
 {{#if this.isPushModalOpen}}
   <ModalBackdrop class="cursor-pointer">
-    <ModalBody @allowManualClose={{true}} @onClose={{this.handlePushModalClose}} @isWide={{true}} class="w-fit cursor-default">
+    <ModalBody @allowManualClose={{true}} @onClose={{this.handlePushModalClose}} class="w-fit cursor-default max-w-(--breakpoint-lg)">
       <div class="mb-6 font-semibold text-2xl text-gray-800 dark:text-gray-200 mr-8">
         Push changes
       </div>

--- a/app/components/course-page/course-stage-step/stage-incomplete-modal.hbs
+++ b/app/components/course-page/course-stage-step/stage-incomplete-modal.hbs
@@ -1,4 +1,4 @@
-<ModalBody @allowManualClose={{false}} @onClose={{@onClose}} class="w-full" data-test-stage-incomplete-modal>
+<ModalBody @allowManualClose={{false}} @onClose={{@onClose}} class="w-full max-w-xl" data-test-stage-incomplete-modal>
   <div class="mb-4 font-semibold text-2xl text-gray-800 dark:text-gray-100 mr-6">
     Stage incomplete
   </div>

--- a/app/components/course-page/course-stage-step/tests-passed-modal/index.hbs
+++ b/app/components/course-page/course-stage-step/tests-passed-modal/index.hbs
@@ -1,4 +1,4 @@
-<ModalBody class="w-full" @allowManualClose={{false}} @onClose={{@onClose}} data-test-tests-passed-modal ...attributes>
+<ModalBody class="w-full max-w-xl" @allowManualClose={{false}} @onClose={{@onClose}} data-test-tests-passed-modal ...attributes>
   <AnimatedContainer>
     <div class="flex flex-col items-center w-full">
       {{#animated-if (eq this.action "choose_action")}}

--- a/app/components/course-page/current-step-complete-modal.hbs
+++ b/app/components/course-page/current-step-complete-modal.hbs
@@ -1,4 +1,4 @@
-<ModalBody @allowManualClose={{false}} @onClose={{@onClose}} data-test-current-step-complete-modal ...attributes>
+<ModalBody @allowManualClose={{false}} @onClose={{@onClose}} data-test-current-step-complete-modal class="max-w-xl" ...attributes>
   <div class="flex flex-col items-center w-full">
     <div class="text-[60px]">
       🎉

--- a/app/components/course-page/delete-repository-modal.hbs
+++ b/app/components/course-page/delete-repository-modal.hbs
@@ -1,4 +1,4 @@
-<ModalBody @allowManualClose={{true}} @onClose={{@onClose}} class="w-full" data-test-delete-repository-modal>
+<ModalBody @allowManualClose={{true}} @onClose={{@onClose}} class="w-full max-w-xl" data-test-delete-repository-modal>
   <div class="mb-6 font-semibold text-2xl text-gray-800 dark:text-gray-200 mr-8">
     Delete Repository
   </div>

--- a/app/components/course-page/previous-steps-incomplete-modal.hbs
+++ b/app/components/course-page/previous-steps-incomplete-modal.hbs
@@ -1,4 +1,4 @@
-<ModalBody @allowManualClose={{false}} @onClose={{@onClose}} data-test-previous-steps-incomplete-modal ...attributes>
+<ModalBody @allowManualClose={{false}} @onClose={{@onClose}} data-test-previous-steps-incomplete-modal class="max-w-xl" ...attributes>
   <div class="flex flex-col items-center w-full max-w-2xs">
     <div class="text-[60px] text-center">
       ⚠️

--- a/app/components/course-page/progress-banner-modal.hbs
+++ b/app/components/course-page/progress-banner-modal.hbs
@@ -1,5 +1,5 @@
 {{! @glint-nocheck: not typesafe yet }}
-<ModalBody @allowManualClose={{true}} @onClose={{@onClose}} class="w-full" data-test-progress-banner-modal>
+<ModalBody @allowManualClose={{true}} @onClose={{@onClose}} class="w-full max-w-xl" data-test-progress-banner-modal>
   <div class="mb-6 font-semibold text-2xl text-gray-600 mr-6">
     Progress Banner
   </div>

--- a/app/components/course-page/setup-step-complete-modal.hbs
+++ b/app/components/course-page/setup-step-complete-modal.hbs
@@ -1,4 +1,4 @@
-<ModalBody @allowManualClose={{false}} @onClose={{@onClose}} data-test-setup-step-complete-modal class="px-0! py-0!" ...attributes>
+<ModalBody @allowManualClose={{false}} @onClose={{@onClose}} data-test-setup-step-complete-modal class="px-0! py-0! max-w-xl" ...attributes>
   <AnimatedContainer>
     <div class="flex flex-col items-center py-8 px-4 sm:px-8" {{did-insert this.handleDidInsert}}>
       {{#animated-value this.currentScreen use=this.transition duration=500 as |currentScreen|}}

--- a/app/components/course-page/share-progress-modal/index.hbs
+++ b/app/components/course-page/share-progress-modal/index.hbs
@@ -1,4 +1,4 @@
-<ModalBody @allowManualClose={{true}} @onClose={{@onClose}} class="w-full" data-test-share-progress-modal>
+<ModalBody @allowManualClose={{true}} @onClose={{@onClose}} class="w-full max-w-xl" data-test-share-progress-modal>
   <div class="mb-6 font-semibold text-2xl text-gray-800 dark:text-gray-50 mr-6">
     Share your progress with friends
   </div>

--- a/app/components/institution-page/campus-program-application-modal.hbs
+++ b/app/components/institution-page/campus-program-application-modal.hbs
@@ -1,4 +1,4 @@
-<ModalBody @allowManualClose={{true}} @onClose={{@onClose}} class="w-full" data-test-campus-program-application-modal>
+<ModalBody @allowManualClose={{true}} @onClose={{@onClose}} class="w-full max-w-xl" data-test-campus-program-application-modal>
   <div class="mb-6 font-semibold text-2xl text-gray-800 dark:text-gray-200 mr-8">
     Campus Program Application
   </div>

--- a/app/components/modal-body.hbs
+++ b/app/components/modal-body.hbs
@@ -1,6 +1,5 @@
 <div
-  class="rounded-md shadow-xs overflow-hidden border border-gray-300 dark:border-white/10 relative shrink overflow-y-auto px-4 py-12 sm:px-8 min-h-0 bg-white dark:bg-gray-850
-    {{if @isWide 'max-w-(--breakpoint-lg)' 'max-w-xl'}}"
+  class="rounded-md shadow-xs overflow-hidden border border-gray-300 dark:border-white/10 relative shrink overflow-y-auto px-4 py-12 sm:px-8 min-h-0 bg-white dark:bg-gray-850"
   {{on-click-outside this.handleClickOutside}}
   ...attributes
 >

--- a/app/components/modal-body.ts
+++ b/app/components/modal-body.ts
@@ -6,7 +6,6 @@ interface Signature {
 
   Args: {
     allowManualClose?: boolean;
-    isWide?: boolean;
     onClose?: () => void;
     shouldHideCloseButton?: boolean;
   };

--- a/app/components/pay-page/choose-membership-plan-modal.hbs
+++ b/app/components/pay-page/choose-membership-plan-modal.hbs
@@ -1,4 +1,10 @@
-<ModalBody @allowManualClose={{true}} @shouldHideCloseButton={{true}} @onClose={{@onClose}} class="w-full" data-test-choose-membership-plan-modal>
+<ModalBody
+  @allowManualClose={{true}}
+  @shouldHideCloseButton={{true}}
+  @onClose={{@onClose}}
+  class="w-full max-w-xl"
+  data-test-choose-membership-plan-modal
+>
   <div class="mb-6">
     <div class="font-bold text-2xl text-gray-600 text-center text-balance">
       Invest in the membership that pays for itself many times over.

--- a/app/components/settings/delete-account-modal.hbs
+++ b/app/components/settings/delete-account-modal.hbs
@@ -1,4 +1,4 @@
-<ModalBody @allowManualClose={{true}} @onClose={{@onClose}} class="w-full" data-test-delete-account-modal>
+<ModalBody @allowManualClose={{true}} @onClose={{@onClose}} class="w-full max-w-xl" data-test-delete-account-modal>
   <div class="mb-6 font-semibold text-2xl text-gray-600 mr-8">
     Delete Account
   </div>


### PR DESCRIPTION
Remove invalid @isWide usage in ModalBody and replace with explicit
max-width utility classes to enforce consistent maximum widths.

Apply max-w-xl or max-w-(--breakpoint-lg) classes to modals to prevent
excessive width on large screens. This improves layout stability,
visual consistency, and better conforms to design specifications.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Replaces ModalBody isWide with explicit max-w-* classes and updates all modal usages to enforce consistent widths.
> 
> - **Modal infrastructure**:
>   - Remove `@isWide` arg from `ModalBody` (`modal-body.ts`) and drop conditional max-width logic from `modal-body.hbs`.
> - **Modals updated (explicit widths)**:
>   - Add `max-w-xl` or `max-w-(--breakpoint-lg)` to modal invocations across `affiliate`, `concept-admin`, `course-page` (configure, tests-passed, stage-incomplete, current/setup step complete, progress banner, share progress, delete repository, submit-code troubleshoot), `pay-page`, `institution-page`, and `settings` components.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 774e2aad8a5079772f9a8e9f304485ca82ae4c1b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->