### PR TITLE
fix(ui): improve spacing and typography in incomplete steps modal

### DIFF
--- a/app/components/course-page/previous-steps-incomplete-modal.hbs
+++ b/app/components/course-page/previous-steps-incomplete-modal.hbs
@@ -4,11 +4,11 @@
       ⚠️
     </div>
 
-    <div class="mb-1 font-bold text-2xl text-gray-700 dark:text-gray-100 text-center">
+    <div class="mb-3 font-bold text-2xl text-gray-700 dark:text-gray-100 text-center">
       Previous steps incomplete!
     </div>
 
-    <div class="prose dark:prose-invert prose-compact mb-5" data-test-completion-message>
+    <div class="prose dark:prose-invert prose-sm mb-5" data-test-completion-message>
       <p class="text-balance text-center">
         This step depends on previous steps that you haven't completed yet.
       </p>


### PR DESCRIPTION
Increase bottom margin of the modal title for better separation and
change the prose size to improve readability and visual balance in the
previous steps incomplete modal. These adjustments enhance the UI
clarity and user experience when displaying incomplete step warnings.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Increase title bottom margin and switch from `prose-compact` to `prose-sm` for improved readability in the incomplete steps modal.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0725fd8eb77c5950875031d32dbf0d3bd227ba78. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->