### PR TITLE
fix(animation): shorten modal dismissal animation duration

### DIFF
--- a/app/components/course-page/course-stage-step/tests-passed-overlay.hbs
+++ b/app/components/course-page/course-stage-step/tests-passed-overlay.hbs
@@ -6,7 +6,7 @@
 >
   <:content>
     <AnimatedContainer>
-      {{#animated-if this.modalWasDismissed duration=200 use=this.transition}}
+      {{#animated-if this.modalWasDismissed duration=150 use=this.transition}}
         <CoursePage::CourseStageStep::TestsPassedNotice
           class="px-3 md:px-6 lg:px-10 w-full scroll-mt-20"
           {{! Ensure this is visible when modal is dismissed }}

--- a/app/components/course-page/current-step-complete-overlay.hbs
+++ b/app/components/course-page/current-step-complete-overlay.hbs
@@ -6,7 +6,7 @@
 >
   <:content>
     <AnimatedContainer>
-      {{#animated-if this.modalWasDismissed duration=200 use=this.transition}}
+      {{#animated-if this.modalWasDismissed duration=150 use=this.transition}}
         <CoursePage::CompletedStepNotice
           {{! @glint-expect-error repository is nullable according to coursePageState }}
           @repository={{this.coursePageState.stepList.repository}}

--- a/app/components/course-page/previous-steps-incomplete-overlay.hbs
+++ b/app/components/course-page/previous-steps-incomplete-overlay.hbs
@@ -6,7 +6,7 @@
 >
   <:content>
     <AnimatedContainer>
-      {{#animated-if this.modalWasDismissed duration=200 use=this.transition}}
+      {{#animated-if this.modalWasDismissed duration=150 use=this.transition}}
         <CoursePage::PreviousStepsIncompleteNotice
           @step={{@currentStep}}
           class="px-3 md:px-6 lg:px-10 w-full scroll-mt-20"


### PR DESCRIPTION
Reduce the animation duration from 200ms to 150ms in the current
step complete, previous steps incomplete, and tests passed overlays
to create a snappier and more responsive user experience when
dismissing modals.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Shortens the modal dismissal animation from 200ms to 150ms across course page overlays.
> 
> - **UI/Animation**:
>   - Reduce `animated-if` `duration` from `200` to `150` in:
>     - `app/components/course-page/current-step-complete-overlay.hbs`
>     - `app/components/course-page/previous-steps-incomplete-overlay.hbs`
>     - `app/components/course-page/course-stage-step/tests-passed-overlay.hbs`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 177152770e66a04491467049f3960ac1ece7543a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->