### PR TITLE
fix(ui): update icons and styles for step notices and modal

### DIFF
--- a/app/components/course-page/course-stage-step/tests-passed-notice.hbs
+++ b/app/components/course-page/course-stage-step/tests-passed-notice.hbs
@@ -6,7 +6,7 @@
 >
   <div class="flex items-center flex-wrap gap-4">
     <div class="flex items-center gap-2">
-      {{svg-jar "check-circle" class="w-6 h-6 fill-green-500"}}
+      {{svg-jar "check-circle" class="w-8 h-8 fill-teal-500"}}
 
       <div class="prose prose-sm prose-green dark:prose-invert">
         <p>All tests passed!</p>

--- a/app/components/course-page/previous-steps-incomplete-modal.hbs
+++ b/app/components/course-page/previous-steps-incomplete-modal.hbs
@@ -1,8 +1,6 @@
 <ModalBody @allowManualClose={{false}} @onClose={{@onClose}} data-test-previous-steps-incomplete-modal class="max-w-xl" ...attributes>
   <div class="flex flex-col items-center w-full max-w-2xs">
-    <div class="text-[60px] text-center">
-      ⚠️
-    </div>
+    {{svg-jar "exclamation" class="w-16 h-16 mb-3 fill-yellow-500"}}
 
     <div class="mb-3 font-bold text-2xl text-gray-700 dark:text-gray-100 text-center">
       Previous steps incomplete!

--- a/app/components/course-page/previous-steps-incomplete-notice.hbs
+++ b/app/components/course-page/previous-steps-incomplete-notice.hbs
@@ -5,7 +5,7 @@
 >
   <div class="flex items-center flex-wrap gap-4">
     <div class="flex items-center gap-2">
-      {{svg-jar "exclamation-circle" class="w-8 h-8 fill-yellow-500"}}
+      {{svg-jar "exclamation" class="w-8 h-8 fill-yellow-500 mt-1"}}
 
       <div class="prose prose-sm prose-yellow dark:prose-invert">
         <p>Complete previous steps to access this stage.</p>


### PR DESCRIPTION
Replace exclamation-circle with a simpler exclamation icon and add
top margin in the previous steps incomplete notice to improve alignment.
Increase size and change color from green to teal on the check-circle
icon in the tests passed notice for better visibility.
Swap emoji warning in the incomplete modal with a consistent SVG icon
to maintain visual consistency and improve styling control.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Replace warning icons with a consistent exclamation SVG and adjust tests-passed icon size/color, with minor alignment tweak.
> 
> - **UI**:
>   - **Previous steps incomplete notice** (`app/components/course-page/previous-steps-incomplete-notice.hbs`): switch `exclamation-circle` to `exclamation`; add `mt-1` for alignment.
>   - **Previous steps incomplete modal** (`app/components/course-page/previous-steps-incomplete-modal.hbs`): replace emoji with `exclamation` SVG icon.
>   - **Tests passed notice** (`app/components/course-page/course-stage-step/tests-passed-notice.hbs`): enlarge `check-circle` to `w-8 h-8` and change fill to `teal-500`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 93a07826b56fade3b17460c2d829c172288ecf1e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->