### PR TITLE
feat: add isArchived flag to filter out archived course ideas

### DIFF
--- a/app/components/course-page/configure-extensions-modal/index.ts
+++ b/app/components/course-page/configure-extensions-modal/index.ts
@@ -27,6 +27,7 @@ export default class ConfigureExtensionsModal extends Component<Signature> {
 
   get orderedCourseExtensionIdeas() {
     return this.allCourseExtensionIdeas
+      .filter((item) => !item.isArchived)
       .filter((item) => item.course === this.args.repository.course)
       .filter((item) => item.developmentStatus !== 'released')
       .sort(fieldComparator('sortPositionForRoadmapPage'));

--- a/app/components/latest-releases-card.ts
+++ b/app/components/latest-releases-card.ts
@@ -22,6 +22,7 @@ export default class LatestReleasesCard extends Component<Signature> {
     const releases: Release[] = [];
 
     this.args.courseExtensionIdeas
+      .filter((idea: CourseExtensionIdeaModel) => !idea.isArchived)
       .filter((idea: CourseExtensionIdeaModel) => idea.developmentStatusIsReleased)
       .forEach((idea: CourseExtensionIdeaModel) => {
         releases.push({

--- a/app/controllers/roadmap/course-extension-ideas.ts
+++ b/app/controllers/roadmap/course-extension-ideas.ts
@@ -28,11 +28,15 @@ export default class CourseExtensionIdeasController extends Controller {
   @service declare store: Store;
 
   get orderedCourseExtensionIdeas() {
-    return this.model.courseExtensionIdeas.filter((item) => item.course === this.selectedCourse).sort(fieldComparator('sortPositionForRoadmapPage'));
+    return this.model.courseExtensionIdeas
+      .filter((item) => !item.isArchived)
+      .filter((item) => item.course === this.selectedCourse)
+      .sort(fieldComparator('sortPositionForRoadmapPage'));
   }
 
   get orderedCourses() {
     return this.model.courseExtensionIdeas
+      .filter((item) => !item.isArchived)
       .filter((item) => !item.developmentStatusIsReleased)
       .map((item) => item.course)
       .reduce(uniqReducer(), [])

--- a/app/models/course-extension-idea.ts
+++ b/app/models/course-extension-idea.ts
@@ -16,6 +16,7 @@ export default class CourseExtensionIdeaModel extends Model {
   @attr('date') declare createdAt: Date;
   @attr('string') declare descriptionMarkdown: string;
   @attr('string') declare developmentStatus: string;
+  @attr('boolean') declare isArchived: boolean;
   @attr('string') declare name: string;
   @attr('date') declare releasedAt: Date | null;
   @attr('string') declare slug: string;


### PR DESCRIPTION
Add a new boolean attribute `isArchived` to CourseExtensionIdea model to
mark ideas that should be excluded from active views. Update multiple
components and controllers to filter out archived ideas, ensuring only
relevant and current extension ideas appear in course listings, roadmap,
and latest releases. This improves clarity and user experience by hiding
outdated or deprecated content without deleting data.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces `isArchived` on `CourseExtensionIdea` and filters archived ideas out of roadmap, course modal, and latest releases.
> 
> - **Model**
>   - Add `@attr('boolean') isArchived` to `CourseExtensionIdeaModel` in `app/models/course-extension-idea.ts`.
> - **Filtering/UI**
>   - `app/components/course-page/configure-extensions-modal/index.ts`: exclude archived ideas in `orderedCourseExtensionIdeas`.
>   - `app/components/latest-releases-card.ts`: exclude archived extension ideas from released list.
>   - `app/controllers/roadmap/course-extension-ideas.ts`:
>     - Filter archived ideas in `orderedCourseExtensionIdeas`.
>     - Exclude archived when deriving `orderedCourses`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 013ff552ab9eb8a35521fdf03caae557b255c6cc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->