### PR TITLE
refactor: always show leaderboard link and simplify feature flag usage

### DIFF
--- a/app/components/course-page/current-step-complete-modal.hbs
+++ b/app/components/course-page/current-step-complete-modal.hbs
@@ -8,7 +8,7 @@
       {{if (eq this.currentStep.type "CourseStageStep") "Stage Completed!" "Step Completed!"}}
     </div>
 
-    {{#if this.shouldShowLanguageLeaderboardRankSection}}
+    {{#if (eq this.currentStep.type "CourseStageStep")}}
       {{! If condition prevents type errors w/ Repository#language being nullable }}
       {{#if this.currentStepAsCourseStageStep.repository.language}}
         <CoursePage::CurrentStepCompleteModal::LanguageLeaderboardRankSection

--- a/app/components/course-page/current-step-complete-modal.ts
+++ b/app/components/course-page/current-step-complete-modal.ts
@@ -29,10 +29,6 @@ export default class CurrentStepCompleteModal extends Component<Signature> {
     return this.coursePageState.nextStep;
   }
 
-  get shouldShowLanguageLeaderboardRankSection() {
-    return this.currentStep.type === 'CourseStageStep' && this.featureFlags.shouldSeeLeaderboard;
-  }
-
   get stepForNextOrActiveStepButton() {
     return this.nextStep?.type === 'BaseStagesCompletedStep' ? this.nextStep : this.args.activeStep;
   }

--- a/app/components/header/index.ts
+++ b/app/components/header/index.ts
@@ -69,14 +69,12 @@ export default class Header extends Component<Signature> {
       { text: 'Roadmap', route: 'roadmap', type: 'route' },
     ];
 
-    if (this.featureFlags.shouldSeeLeaderboard) {
-      links.push({
-        text: 'Leaderboard',
-        route: 'leaderboard',
-        type: 'route',
-        routeParams: [this.preferredLanguageLeaderboard.defaultLanguageSlug],
-      });
-    }
+    links.push({
+      text: 'Leaderboard',
+      route: 'leaderboard',
+      type: 'route',
+      routeParams: [this.preferredLanguageLeaderboard.defaultLanguageSlug],
+    });
 
     return links;
   }

--- a/app/services/feature-flags.ts
+++ b/app/services/feature-flags.ts
@@ -18,10 +18,6 @@ export default class FeatureFlagsService extends Service {
     return this.authenticator.currentUser;
   }
 
-  get shouldSeeLeaderboard(): boolean {
-    return this.currentUser?.isStaff || this.getFeatureFlagValue('should-see-leaderboard') === 'test';
-  }
-
   getFeatureFlagValue(flagName: string): string | null | undefined {
     const value = this.currentUser?.featureFlags?.[flagName];
 


### PR DESCRIPTION
Remove conditional check on leaderboard feature flag when adding the
Leaderboard link in the header to display it for all users. Eliminate
the shouldSeeLeaderboard getter from the feature flags service as it
is no longer used. Also simplify the course page modal by removing
the redundant computed property that checked the leaderboard feature
flag, instead relying directly on current step type checks in the
template. These changes improve code clarity and ensure the leaderboard
is consistently accessible.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Always show the Leaderboard link and remove the `shouldSeeLeaderboard` feature-flag checks, simplifying modal logic to rely on step type.
> 
> - **UI/Header**:
>   - Always include `Leaderboard` link (with `preferredLanguageLeaderboard.defaultLanguageSlug` route param).
> - **Course Page Modal**:
>   - Replace feature-flag-based check with direct `CourseStageStep` type check in `current-step-complete-modal.hbs`.
>   - Remove redundant `shouldShowLanguageLeaderboardRankSection` getter in `current-step-complete-modal.ts`.
> - **Feature Flags**:
>   - Remove `shouldSeeLeaderboard` getter from `feature-flags.ts` and its usages.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d212bbe75f9ba2533aef1c561b2a5cd1b3abfeb9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->