### PR TITLE
feat(test-results-bar): separate mouse and touch resize handlers

### DIFF
--- a/app/components/course-page/test-results-bar/index.hbs
+++ b/app/components/course-page/test-results-bar/index.hbs
@@ -8,8 +8,8 @@
     <div
       class="group/resize-handler h-3 bg-transparent absolute top-0 left-0 right-0 flex items-center justify-center cursor-ns-resize z-10"
       role="button"
-      {{on "mousedown" this.startResize}}
-      {{on "touchstart" this.startResize}}
+      {{on "mousedown" this.startMouseResize}}
+      {{on "touchstart" this.startTouchResize}}
       data-test-resize-handler
     >
       <div class="bg-gray-700 group-hover/resize-handler:bg-gray-500 h-0.5 rounded-sm w-16">

--- a/app/components/course-page/test-results-bar/index.ts
+++ b/app/components/course-page/test-results-bar/index.ts
@@ -91,19 +91,27 @@ export default class TestResultsBar extends Component<Signature> {
   }
 
   @action
-  startResize(event: MouseEvent | TouchEvent) {
+  startMouseResize(event: MouseEvent) {
+    // Trigger mouse resize on left click only
+    if (event.button !== 0) {
+      return;
+    }
+
+    event.preventDefault();
+
+    this.isResizing = true;
+    document.addEventListener('mousemove', this.handleMouseResize);
+    document.addEventListener('mouseup', this.stopMouseResize);
+  }
+
+  @action
+  startTouchResize(event: TouchEvent) {
     event.preventDefault();
 
     this.isResizing = true;
 
-    // Trigger mouse resize on left click only
-    if (event instanceof MouseEvent && event.button === 0) {
-      document.addEventListener('mousemove', this.handleMouseResize);
-      document.addEventListener('mouseup', this.stopMouseResize);
-    } else {
-      document.addEventListener('touchmove', this.handleTouchResize);
-      document.addEventListener('touchend', this.stopTouchResize);
-    }
+    document.addEventListener('touchmove', this.handleTouchResize);
+    document.addEventListener('touchend', this.stopTouchResize);
   }
 
   @action

--- a/tests/acceptance/course-page/test-results-bar/resize-test.js
+++ b/tests/acceptance/course-page/test-results-bar/resize-test.js
@@ -9,6 +9,7 @@ import { setupAnimationTest } from 'ember-animated/test-support';
 import { setupApplicationTest } from 'codecrafters-frontend/tests/helpers';
 import { setupWindowMock } from 'ember-window-mock/test-support';
 import { signIn } from 'codecrafters-frontend/tests/support/authentication-helpers';
+import { settled } from '@ember/test-helpers';
 
 module('Acceptance | course-page | test-results-bar | resize', function (hooks) {
   setupApplicationTest(hooks);
@@ -98,6 +99,7 @@ module('Acceptance | course-page | test-results-bar | resize', function (hooks) 
     await coursePage.testResultsBar.resizeHandler.touchStart();
     await coursePage.testResultsBar.resizeHandler.touchMove({ touches: [{ clientY: window.innerHeight - desiredHeight + 1 }] });
     await coursePage.testResultsBar.resizeHandler.touchEnd();
+    await settled(); // Flakiness, this seems to fix it
 
     let testResultsBarHeight = coursePage.testResultsBar.height;
     assert.strictEqual(testResultsBarHeight, desiredHeight, 'Test results bar should be resized using touch');


### PR DESCRIPTION
Refactor resize start actions by splitting startResize into 
startMouseResize and startTouchResize to clearly separate mouse 
and touch event handling. This prevents unnecessary checks 
within a single method and improves event management.

Add event listeners for mousemove and mouseup only on left 
mouse button clicks in startMouseResize. Maintain touch event 
handling in startTouchResize.

Update template bindings to use the new actions.

Fix flaky touch resize acceptance test by awaiting settled() 
after touchEnd to ensure stable test results.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Split resize start logic into mouse/touch-specific handlers, update template bindings, restrict mouse to left-click, and deflake touch resize test with settled.
> 
> - **Component `CoursePage::TestResultsBar`**:
>   - Split `startResize` into `startMouseResize` and `startTouchResize` with dedicated event wiring and teardown (`mousemove`/`mouseup` vs `touchmove`/`touchend`).
>   - Enforce left-click-only initiation in `startMouseResize`; maintain `handleMouseResize`/`handleTouchResize` height calculations.
>   - Update template bindings in `app/components/course-page/test-results-bar/index.hbs` to use `startMouseResize`/`startTouchResize`.
> - **Tests**:
>   - Mouse resize test asserts right-click is ignored and left-click resizes to expected height.
>   - Touch resize test adds `await settled()` after `touchEnd` to reduce flakiness and validates height persistence across collapse/expand.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f1c524f60123b5fcba80baeec0e891014318a448. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->