### PR TITLE
refactor(test-results-bar): simplify collapse button handling

### DIFF
--- a/app/components/course-page/test-results-bar/index.hbs
+++ b/app/components/course-page/test-results-bar/index.hbs
@@ -24,7 +24,6 @@
   >
     {{#if this.isExpanded}}
       <CoursePage::TestResultsBar::TopSection
-        @onCollapseButtonClick={{this.handleCollapseButtonClick}}
         @activeTabSlug={{this.activeTabSlug}}
         @onActiveTabSlugChange={{fn (mut this.activeTabSlug)}}
         @availableTabSlugs={{this.availableTabSlugs}}
@@ -47,9 +46,12 @@
         />
       {{/if}}
 
-      <div class="absolute top-[3px] left-0 right-0 flex items-center justify-center">
-        {{! TODO: Add this back when we have a way to resize the logs section. }}
-        {{! <div class="w-20 h-1 rounded-full bg-gray-700 cursor-ns-resize hover:bg-gray-600"></div> }}
+      <div
+        class="absolute top-0 right-0 flex px-6 py-5 items-center justify-center text-gray-500 hover:text-gray-400"
+        {{on "click" this.handleCollapseButtonClick}}
+        role="button"
+      >
+        {{svg-jar "x" class="w-5 h-5 fill-current"}}
       </div>
     {{/if}}
   </div>

--- a/app/components/course-page/test-results-bar/top-section.hbs
+++ b/app/components/course-page/test-results-bar/top-section.hbs
@@ -10,7 +10,4 @@
       />
     {{/each}}
   </ul>
-  <div class="flex items-center justify-center text-gray-500 hover:text-gray-400" {{on "click" @onCollapseButtonClick}} role="button">
-    {{svg-jar "x" class="w-5 h-5 fill-current"}}
-  </div>
 </div>

--- a/app/components/course-page/test-results-bar/top-section.ts
+++ b/app/components/course-page/test-results-bar/top-section.ts
@@ -7,7 +7,6 @@ interface Signature {
   Args: {
     activeTabSlug: string;
     availableTabSlugs: string[];
-    onCollapseButtonClick: () => void;
     onActiveTabSlugChange: (slug: string) => void;
   };
 }


### PR DESCRIPTION
Remove the onCollapseButtonClick arg from TopSection and move the collapse
button out of TopSection into the main component template. This consolidates
the collapse button logic and prepares for future UI refinements related to
log section resizing.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Moves the collapse button from `TopSection` into `index.hbs`, removing the `onCollapseButtonClick` arg and updating templates accordingly.
> 
> - **Test Results Bar**:
>   - **Collapse control**:
>     - Move collapse button UI/handler to `app/components/course-page/test-results-bar/index.hbs` (top-right clickable "x").
>     - Remove collapse button from `TopSection` template and stop passing `@onCollapseButtonClick`.
>   - **TopSection API**:
>     - Remove `onCollapseButtonClick` arg from `top-section.ts` `Signature`.
>   - **Layout**:
>     - Minor template adjustments to accommodate new collapse control placement.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b6bd6869b5969622e53a1691b9873985bf844715. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->