### PR TITLE
fix(ui): allow vertical scrolling in autofix request card

### DIFF
--- a/app/components/course-page/test-results-bar/autofix-request-card.hbs
+++ b/app/components/course-page/test-results-bar/autofix-request-card.hbs
@@ -1,4 +1,4 @@
-<div class="bg-gray-850 rounded-sm border border-white/5 p-4 w-full max-w-xl overflow-hidden" ...attributes data-test-autofix-request-card>
+<div class="bg-gray-850 rounded-sm border border-white/5 p-4 w-full max-w-xl overflow-y-auto" ...attributes data-test-autofix-request-card>
   <AnimatedContainer>
     {{#animated-value @autofixRequest.status duration=200 use=this.transition as |status|}}
       {{#if (eq status "in_progress")}}


### PR DESCRIPTION
Change the overflow style from hidden to auto on the y-axis in the
autofix-request-card component to enable vertical scrolling when content
exceeds the component height. This improves usability by preventing content
from being clipped.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Change container overflow from hidden to overflow-y-auto to allow vertical scrolling when content exceeds the card height.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0e0caf64fc0ce9353a8b85eb66dee58ecaadb13b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->