### PR TITLE
Configure `ember-keyboard` to ignore events originating from inputs & textareas

### DIFF
--- a/app/components/feedback-button/index.hbs
+++ b/app/components/feedback-button/index.hbs
@@ -33,7 +33,6 @@
               placeholder={{or @placeholderText "Your feedback..."}}
               required
               {{markdown-input}}
-              {{on "keydown" this.handleTextareaKeydown}}
             />
 
             <div class="flex justify-between items-center">

--- a/app/components/feedback-button/index.ts
+++ b/app/components/feedback-button/index.ts
@@ -90,13 +90,6 @@ export default class FeedbackButton extends Component<Signature> {
   handleSentimentOptionSelected(sentimentOption: string) {
     this.feedbackSubmission.selectedSentiment = sentimentOption;
   }
-
-  @action
-  handleTextareaKeydown(event: KeyboardEvent) {
-    // TEMP: Avoid conflict with concepts keyboard shortcuts.
-    // TODO:Find a cleaner way
-    event.stopPropagation();
-  }
 }
 
 declare module '@glint/environment-ember-loose/registry' {

--- a/config/environment.js
+++ b/config/environment.js
@@ -25,6 +25,10 @@ module.exports = function (environment) {
       disableInstrumentComponents: true,
     },
 
+    emberKeyboard: {
+      disableOnInputFields: true,
+    },
+
     x: {
       backendUrl: process.env.BACKEND_URL || 'https://test-backend.ngrok.io',
 
@@ -51,6 +55,7 @@ module.exports = function (environment) {
       // The minor version doesn't do anything at the moment, might use in the future.
       version: `41.0.${process.env.VERCEL_GIT_COMMIT_SHA?.slice(0, 7) || 'dev'}`,
     },
+
     fastboot: {
       hostWhitelist: [/^localhost:\d+$/],
     },


### PR DESCRIPTION
Closes #3243

### Brief

This prevents keystrokes leaking from the feedback textarea, as well as from all other inputs and textareas, by configuring `ember-keyboard` to ignore inputs & textareas.

### Details

Added `emberKeyboard: { disableOnInputFields: true }` to our `config/environment.js`

We use `on-key` helper from `ember-keyboard` addon to subscribe components to keyboard events, and they have a dedicated section for inputs & textareas [in their README](https://adopted-ember-addons.github.io/ember-keyboard/usage):

<img width="657" height="695" alt="Знімок екрана 2025-11-22 о 16 25 43" src="https://github.com/user-attachments/assets/97daba8c-de18-47b3-a500-d522b55a80f6" />

### Checklist

- [x] I've thoroughly self-reviewed my changes
- [x] I've added tests for my changes, unless they affect admin-only areas (or are otherwise not worth testing)
- [x] I've verified any visual changes using Percy (add a commit with `[percy]` in the message to trigger)
