### PR TITLE
Fix cropping of leaderboard sidebar expansion icon

### DIFF
--- a/app/templates/course.hbs
+++ b/app/templates/course.hbs
@@ -89,7 +89,7 @@
         class="{{if this.leaderboardIsExpanded 'w-64 xl:w-80 pr-6' 'pr-4'}}
           pt-6 shrink-0 border-l border-gray-200 dark:border-white/5 bg-gray-50 dark:bg-gray-950 hidden md:block group"
       >
-        <div class="sticky top-14">
+        <div class="sticky top-14 z-11">
           {{#if this.leaderboardIsExpanded}}
             <CoursePage::CollapseLeaderboardButton
               class="opacity-0 group-hover:opacity-100 absolute top-6 -left-3.5 z-10"


### PR DESCRIPTION
Closes #3100

### Brief

This bumps the z-index for leaderboard sidebar to fix cropping of expand/collapse button

### Screenshot

<img width="432" height="249" alt="Знімок екрана 2025-11-22 о 17 34 09" src="https://github.com/user-attachments/assets/70506d10-8672-43ae-aea4-1624f2ef9480" />

### Checklist

- [x] I've thoroughly self-reviewed my changes
- [x] I've added tests for my changes, unless they affect admin-only areas (or are otherwise not worth testing)
- [x] I've verified any visual changes using Percy (add a commit with `[percy]` in the message to trigger)
