### PR TITLE
fix(loading-skeleton): add dark mode background support

### DIFF
--- a/app/components/loading-skeleton.hbs
+++ b/app/components/loading-skeleton.hbs
@@ -1,2 +1,2 @@
-<div class="bg-gray-200 animate-pulse {{if @isCircle 'rounded-full' 'rounded-sm h-4'}}" style={{html-safe this.widthStyle}} ...attributes>
+<div class="bg-gray-200 dark:bg-gray-800 animate-pulse {{if @isCircle 'rounded-full' 'rounded-sm h-4'}}" style={{html-safe this.widthStyle}} ...attributes>
 </div>


### PR DESCRIPTION
Add dark mode styling to loading skeleton by applying a dark
background class. This improves visibility and consistency when
using dark themes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Add dark mode background styling to the loading skeleton component via `dark:bg-gray-800`.
> 
> - **UI**:
>   - **Loading Skeleton (`app/components/loading-skeleton.hbs`)**: Add dark mode background class `dark:bg-gray-800` to improve visibility in dark themes.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f0ac682f2f76ee8873952fc3879c24fead901030. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->