### PR TITLE
style: update gradient text styles for discount notices

### DIFF
--- a/app/components/pay-page/referral-discount-notice.hbs
+++ b/app/components/pay-page/referral-discount-notice.hbs
@@ -7,7 +7,7 @@
     <img src={{this.iconImage}} alt="treasure" class="w-8 animate-spin-once" />
   </div>
 
-  <div class="bg-repeating-gradient-to-b from-yellow-100 to-amber-500 text-transparent bg-clip-text leading-7 inline-block mt-0.5">
+  <div class="text-gradient-to-b from-yellow-100 to-amber-500 leading-7 inline-block mt-0.5">
     {{#if @discount.affiliateReferral.affiliateLink.avatarIsGitHubAvatar}}
       <img
         alt="avatar"

--- a/app/components/pay-page/signup-discount-notice.hbs
+++ b/app/components/pay-page/signup-discount-notice.hbs
@@ -7,7 +7,7 @@
     <img src={{this.iconImage}} alt="treasure" class="w-8 animate-spin-once" />
   </div>
 
-  <div class="bg-repeating-gradient-to-b from-yellow-100 to-amber-500 text-transparent bg-clip-text leading-7 inline-block mt-0.5">
+  <div class="text-gradient-to-b from-yellow-100 to-amber-500 leading-7 inline-block mt-0.5">
     New user offer: Subscribe in
     <span class="font-bold percy-timestamp font-mono text-lg border-b border-yellow-500 border-dashed">{{this.timeLeftText}}</span>
     to get

--- a/app/components/pay-page/stage2-completion-discount-notice.hbs
+++ b/app/components/pay-page/stage2-completion-discount-notice.hbs
@@ -7,7 +7,7 @@
     <img src={{this.iconImage}} alt="treasure" class="w-8 animate-spin-once" />
   </div>
 
-  <div class="bg-repeating-gradient-to-b from-yellow-100 to-amber-500 text-transparent bg-clip-text leading-7 inline-block mt-0.5">
+  <div class="text-gradient-to-b from-yellow-100 to-amber-500 leading-7 inline-block mt-0.5">
     Nice work completing stage 2! Subscribe in
     <span class="font-bold percy-timestamp font-mono text-lg border-b border-yellow-500 border-dashed">{{this.timeLeftText}}</span>
     to get

--- a/app/styles/utilities.css
+++ b/app/styles/utilities.css
@@ -4,8 +4,10 @@
 
 /* https://bengammon.co.uk/css-repeatable-linear-gradients-on-multiple-lines-of-text/ */
 @layer utilities {
-  .bg-repeating-gradient-to-b {
-    background-image: repeating-linear-gradient(to bottom, var(--tw-gradient-from), var(--tw-gradient-to) 1.75rem);
+  .text-gradient-to-b {
+    background-image: repeating-linear-gradient(to bottom, var(--tw-gradient-from), var(--tw-gradient-to) var(--tw-leading));
+    color: transparent;
+    background-clip: text;
   }
 }
 


### PR DESCRIPTION
Replace the deprecated bg-repeating-gradient-to-b utility with a new
text-gradient-to-b class that correctly applies a repeating linear
gradient background clipped to text. Remove redundant text-transparent
and bg-clip-text classes from discount notice components to rely on the
updated utility. This change ensures consistent and cleaner gradient
text styling across pay-page discount notices.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Swap `bg-repeating-gradient-to-b` for new `text-gradient-to-b` utility and apply it across pay-page discount notices.
> 
> - **Styles**:
>   - Add `utilities.css` `text-gradient-to-b` utility using `repeating-linear-gradient(...)` with `var(--tw-leading)`, setting `color: transparent` and `background-clip: text`.
>   - Remove deprecated `bg-repeating-gradient-to-b` usage.
> - **Components (pay-page)**:
>   - Update gradient text classes in `referral-discount-notice.hbs`, `signup-discount-notice.hbs`, and `stage2-completion-discount-notice.hbs` to use `text-gradient-to-b`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fed5f496eef778eeecf5b031e5b2b7d0eea8f59a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->