### PR TITLE
style: enhance header text styles with gradient and spacing fixes

### DIFF
--- a/app/components/course-overview-page/header.hbs
+++ b/app/components/course-overview-page/header.hbs
@@ -1,6 +1,6 @@
 <div class="flex items-center justify-between" ...attributes data-test-course-overview-header>
   <div>
-    <h1 class="text-3xl md:text-5xl text-gray-800 dark:text-gray-100 font-bold tracking-tighter mb-3">{{@course.name}}</h1>
+    <h1 class="text-gradient-to-b from-gray-900 to-gray-700 dark:from-white dark:to-gray-300  leading-10 md:leading-14 text-3xl md:text-5xl font-bold tracking-tighter mb-1">{{@course.name}}</h1>
 
     <p class="text-gray-600 dark:text-gray-400 mb-6">
       {{@course.shortDescription}}

--- a/app/components/track-page/header/index.hbs
+++ b/app/components/track-page/header/index.hbs
@@ -1,7 +1,10 @@
 <div class="flex items-center justify-between" ...attributes data-test-track-header>
   <div class="grow">
-    <div class="flex items-center justify-between mb-1 md:mb-3">
-      <h1 class="text-3xl md:text-5xl text-gray-800 dark:text-gray-100 font-bold tracking-tighter">
+    <div class="flex items-center justify-between mb-1 md:mb-1.5">
+      {{! pr-2 is used because tracking-tighter can cause the background gradient to cut off the ending "." character }}
+      <h1
+        class="text-gradient-to-b from-gray-900 to-gray-700 dark:from-white dark:to-gray-300 leading-10 md:leading-14 text-3xl md:text-5xl font-bold tracking-tighter pr-2"
+      >
         Master
         {{@language.name}}.
       </h1>


### PR DESCRIPTION
Update track-page and course-overview-page headers to apply a text 
gradient that adapts to light and dark modes, improving visual appeal. 
Adjust vertical margins for better spacing consistency across screen 
sizes. Add right padding to the track-page header title to prevent the 
background gradient from cutting off the trailing period. These changes 
improve readability and aesthetics of the page headers.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Apply gradient typography to course and track header titles, with line-height and spacing tweaks plus padding to prevent trailing period cutoff.
> 
> - **UI headers**:
>   - `app/components/course-overview-page/header.hbs`:
>     - Style `h1` with gradient text (light/dark), increase line-height, and reduce bottom margin (`mb-3` → `mb-1`).
>   - `app/components/track-page/header/index.hbs`:
>     - Style `h1` with gradient text (light/dark), add `leading-10 md:leading-14`, and add `pr-2` to avoid gradient cutting off the trailing period.
>     - Adjust container spacing (`md:mb-3` → `md:mb-1.5`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a51cda4e9983259e9f30307a4ab6ee1affe172d9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->