### PR TITLE
style: update free course notice text color to teal-600

### DIFF
--- a/app/components/course-overview-page/notices/free-course-notice.hbs
+++ b/app/components/course-overview-page/notices/free-course-notice.hbs
@@ -15,7 +15,7 @@
           {{date-format @course.isFreeUntil format="d MMMM yyyy"}}.
         {{/if}}
       </h3>
-      <p class="text-teal-800 text-sm mb-4">
+      <p class="text-teal-600 text-sm mb-4">
         The core challenge experience is completely free
         {{#if @course.isFreeThisMonth}}
           this month.


### PR DESCRIPTION
Change the text color in the free course notice from teal-800 to 
teal-600 to improve visual consistency and readability within the course
overview
page. This adjustment refines the design without altering functionality.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Update free course notice paragraph text color from `text-teal-800` to `text-teal-600` in `app/components/course-overview-page/notices/free-course-notice.hbs`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2cfe9ac0605d1bfd9ae5615fdb6dfe0bafd1d9f8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->