### PR TITLE
Revert "style: update free course notice text color to teal-600"

### DIFF
--- a/app/components/course-overview-page/notices/free-course-notice.hbs
+++ b/app/components/course-overview-page/notices/free-course-notice.hbs
@@ -15,7 +15,7 @@
           {{date-format @course.isFreeUntil format="d MMMM yyyy"}}.
         {{/if}}
       </h3>
-      <p class="text-teal-600 text-sm mb-4">
+      <p class="text-teal-800 text-sm mb-4">
         The core challenge experience is completely free
         {{#if @course.isFreeThisMonth}}
           this month.


### PR DESCRIPTION
Reverts codecrafters-io/frontend#3290

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Darkens the paragraph text in `course-overview-page/notices/free-course-notice.hbs` from `text-teal-600` to `text-teal-800`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 005c305ad5e8428c49feb3f027360a69f0cacae1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->