### PR TITLE
feat(route-info): add and use RouteColorScheme in route metadata

### DIFF
--- a/app/routes/code-walkthrough.ts
+++ b/app/routes/code-walkthrough.ts
@@ -2,7 +2,7 @@ import BaseRoute from 'codecrafters-frontend/utils/base-route';
 import { inject as service } from '@ember/service';
 import type Store from '@ember-data/store';
 import type CodeWalkthroughModel from 'codecrafters-frontend/models/code-walkthrough';
-import RouteInfoMetadata from 'codecrafters-frontend/utils/route-info-metadata';
+import RouteInfoMetadata, { RouteColorScheme } from 'codecrafters-frontend/utils/route-info-metadata';
 
 export type ModelType = CodeWalkthroughModel;
 
@@ -10,7 +10,7 @@ export default class CodeWalkthroughRoute extends BaseRoute {
   @service declare store: Store;
 
   buildRouteInfoMetadata() {
-    return new RouteInfoMetadata({ allowsAnonymousAccess: true });
+    return new RouteInfoMetadata({ allowsAnonymousAccess: true, colorScheme: RouteColorScheme.Light });
   }
 
   async model(params: { code_walkthrough_slug: string }): Promise<ModelType> {

--- a/app/routes/concept-group.ts
+++ b/app/routes/concept-group.ts
@@ -6,7 +6,7 @@ import HeadDataService from 'codecrafters-frontend/services/meta-data';
 import Store from '@ember-data/store';
 import RouterService from '@ember/routing/router-service';
 import { inject as service } from '@ember/service';
-import RouteInfoMetadata from 'codecrafters-frontend/utils/route-info-metadata';
+import RouteInfoMetadata, { RouteColorScheme } from 'codecrafters-frontend/utils/route-info-metadata';
 
 export default class ConceptGroupRoute extends BaseRoute {
   @service declare authenticator: AuthenticatorService;
@@ -22,7 +22,7 @@ export default class ConceptGroupRoute extends BaseRoute {
   }
 
   buildRouteInfoMetadata() {
-    return new RouteInfoMetadata({ allowsAnonymousAccess: true });
+    return new RouteInfoMetadata({ allowsAnonymousAccess: true, colorScheme: RouteColorScheme.Light });
   }
 
   deactivate() {

--- a/app/routes/concept.ts
+++ b/app/routes/concept.ts
@@ -8,7 +8,7 @@ import AuthenticatorService from 'codecrafters-frontend/services/authenticator';
 import type MetaDataService from 'codecrafters-frontend/services/meta-data';
 import RouterService from '@ember/routing/router-service';
 import Store from '@ember-data/store';
-import RouteInfoMetadata, { HelpscoutBeaconVisibility } from 'codecrafters-frontend/utils/route-info-metadata';
+import RouteInfoMetadata, { HelpscoutBeaconVisibility, RouteColorScheme } from 'codecrafters-frontend/utils/route-info-metadata';
 import type Transition from '@ember/routing/transition';
 import type ConceptController from 'codecrafters-frontend/controllers/concept';
 import fieldComparator from 'codecrafters-frontend/utils/field-comparator';
@@ -63,7 +63,11 @@ export default class ConceptRoute extends BaseRoute {
   }
 
   buildRouteInfoMetadata() {
-    return new RouteInfoMetadata({ allowsAnonymousAccess: true, beaconVisibility: HelpscoutBeaconVisibility.Hidden });
+    return new RouteInfoMetadata({
+      allowsAnonymousAccess: true,
+      beaconVisibility: HelpscoutBeaconVisibility.Hidden,
+      colorScheme: RouteColorScheme.Light,
+    });
   }
 
   deactivate() {

--- a/app/routes/concepts.js
+++ b/app/routes/concepts.js
@@ -1,13 +1,17 @@
 import { inject as service } from '@ember/service';
 import BaseRoute from 'codecrafters-frontend/utils/base-route';
-import RouteInfoMetadata, { HelpscoutBeaconVisibility } from 'codecrafters-frontend/utils/route-info-metadata';
+import RouteInfoMetadata, { HelpscoutBeaconVisibility, RouteColorScheme } from 'codecrafters-frontend/utils/route-info-metadata';
 import { hash as RSVPHash } from 'rsvp';
 
 export default class ConceptsRoute extends BaseRoute {
   @service store;
 
   buildRouteInfoMetadata() {
-    return new RouteInfoMetadata({ allowsAnonymousAccess: true, beaconVisibility: HelpscoutBeaconVisibility.Hidden });
+    return new RouteInfoMetadata({
+      allowsAnonymousAccess: true,
+      beaconVisibility: HelpscoutBeaconVisibility.Hidden,
+      colorScheme: RouteColorScheme.Light,
+    });
   }
 
   async model() {

--- a/app/routes/debug.ts
+++ b/app/routes/debug.ts
@@ -1,8 +1,8 @@
 import BaseRoute from 'codecrafters-frontend/utils/base-route';
-import RouteInfoMetadata from 'codecrafters-frontend/utils/route-info-metadata';
+import RouteInfoMetadata, { RouteColorScheme } from 'codecrafters-frontend/utils/route-info-metadata';
 
 export default class DebugRoute extends BaseRoute {
   buildRouteInfoMetadata() {
-    return new RouteInfoMetadata({ allowsAnonymousAccess: true });
+    return new RouteInfoMetadata({ allowsAnonymousAccess: true, colorScheme: RouteColorScheme.Light });
   }
 }

--- a/app/routes/gifts/buy.ts
+++ b/app/routes/gifts/buy.ts
@@ -1,5 +1,5 @@
 import BaseRoute from 'codecrafters-frontend/utils/base-route';
-import RouteInfoMetadata from 'codecrafters-frontend/utils/route-info-metadata';
+import RouteInfoMetadata, { RouteColorScheme } from 'codecrafters-frontend/utils/route-info-metadata';
 import type GiftPaymentFlowModel from 'codecrafters-frontend/models/gift-payment-flow';
 import type Store from '@ember-data/store';
 import { inject as service } from '@ember/service';
@@ -10,7 +10,7 @@ export default class GiftsPayRoute extends BaseRoute {
   @service declare store: Store;
 
   buildRouteInfoMetadata() {
-    return new RouteInfoMetadata({ allowsAnonymousAccess: true });
+    return new RouteInfoMetadata({ allowsAnonymousAccess: true, colorScheme: RouteColorScheme.Light });
   }
 
   async model(params: { giftPaymentFlowId?: string }): Promise<ModelType> {

--- a/app/routes/institution.ts
+++ b/app/routes/institution.ts
@@ -5,7 +5,7 @@ import type InstitutionModel from 'codecrafters-frontend/models/institution';
 import type AuthenticatorService from 'codecrafters-frontend/services/authenticator';
 import type MetaDataService from 'codecrafters-frontend/services/meta-data';
 import BaseRoute from 'codecrafters-frontend/utils/base-route';
-import RouteInfoMetadata from 'codecrafters-frontend/utils/route-info-metadata';
+import RouteInfoMetadata, { RouteColorScheme } from 'codecrafters-frontend/utils/route-info-metadata';
 
 export type InstitutionRouteModel = {
   institution: InstitutionModel;
@@ -27,7 +27,7 @@ export default class InstitutionRoute extends BaseRoute {
   }
 
   buildRouteInfoMetadata() {
-    return new RouteInfoMetadata({ allowsAnonymousAccess: true });
+    return new RouteInfoMetadata({ allowsAnonymousAccess: true, colorScheme: RouteColorScheme.Light });
   }
 
   async model(params: { institution_slug: string }) {

--- a/app/routes/join.ts
+++ b/app/routes/join.ts
@@ -5,7 +5,7 @@ import type RouterService from '@ember/routing/router-service';
 import type Store from '@ember-data/store';
 import { inject as service } from '@ember/service';
 import type AffiliateLinkModel from 'codecrafters-frontend/models/affiliate-link';
-import RouteInfoMetadata from 'codecrafters-frontend/utils/route-info-metadata';
+import RouteInfoMetadata, { RouteColorScheme } from 'codecrafters-frontend/utils/route-info-metadata';
 
 export type ModelType = {
   affiliateLink: AffiliateLinkModel;
@@ -27,7 +27,7 @@ export default class JoinRoute extends BaseRoute {
   }
 
   buildRouteInfoMetadata() {
-    return new RouteInfoMetadata({ allowsAnonymousAccess: true });
+    return new RouteInfoMetadata({ allowsAnonymousAccess: true, colorScheme: RouteColorScheme.Light });
   }
 
   async model(params: { affiliateLinkSlug: string }) {

--- a/app/routes/not-found.ts
+++ b/app/routes/not-found.ts
@@ -1,8 +1,8 @@
 import BaseRoute from 'codecrafters-frontend/utils/base-route';
-import RouteInfoMetadata from 'codecrafters-frontend/utils/route-info-metadata';
+import RouteInfoMetadata, { RouteColorScheme } from 'codecrafters-frontend/utils/route-info-metadata';
 
 export default class NotFoundRoute extends BaseRoute {
   buildRouteInfoMetadata() {
-    return new RouteInfoMetadata({ allowsAnonymousAccess: true });
+    return new RouteInfoMetadata({ allowsAnonymousAccess: true, colorScheme: RouteColorScheme.Light });
   }
 }

--- a/app/routes/pay.ts
+++ b/app/routes/pay.ts
@@ -4,7 +4,7 @@ import type CourseModel from 'codecrafters-frontend/models/course';
 import type RegionalDiscountModel from 'codecrafters-frontend/models/regional-discount';
 import type AuthenticatorService from 'codecrafters-frontend/services/authenticator';
 import BaseRoute from 'codecrafters-frontend/utils/base-route';
-import RouteInfoMetadata from 'codecrafters-frontend/utils/route-info-metadata';
+import RouteInfoMetadata, { RouteColorScheme } from 'codecrafters-frontend/utils/route-info-metadata';
 import scrollToTop from 'codecrafters-frontend/utils/scroll-to-top';
 
 export type ModelType = {
@@ -21,7 +21,7 @@ export default class PayRoute extends BaseRoute {
   }
 
   buildRouteInfoMetadata() {
-    return new RouteInfoMetadata({ allowsAnonymousAccess: true });
+    return new RouteInfoMetadata({ allowsAnonymousAccess: true, colorScheme: RouteColorScheme.Light });
   }
 
   async model() {

--- a/app/routes/referral-link.ts
+++ b/app/routes/referral-link.ts
@@ -6,7 +6,7 @@ import scrollToTop from 'codecrafters-frontend/utils/scroll-to-top';
 import RouterService from '@ember/routing/router-service';
 import Store from '@ember-data/store';
 import { inject as service } from '@ember/service';
-import RouteInfoMetadata from 'codecrafters-frontend/utils/route-info-metadata';
+import RouteInfoMetadata, { RouteColorScheme } from 'codecrafters-frontend/utils/route-info-metadata';
 
 export default class ReferralLinkRoute extends BaseRoute {
   @service declare authenticator: AuthenticatorService;
@@ -24,7 +24,7 @@ export default class ReferralLinkRoute extends BaseRoute {
   }
 
   buildRouteInfoMetadata() {
-    return new RouteInfoMetadata({ allowsAnonymousAccess: true });
+    return new RouteInfoMetadata({ allowsAnonymousAccess: true, colorScheme: RouteColorScheme.Light });
   }
 
   async model(params: { referral_link_slug: string }) {

--- a/app/routes/teams/pay.ts
+++ b/app/routes/teams/pay.ts
@@ -6,13 +6,13 @@ import type Store from '@ember-data/store';
 import type TeamsPayController from 'codecrafters-frontend/controllers/teams/pay';
 import type TeamPaymentFlowModel from 'codecrafters-frontend/models/team-payment-flow';
 import type Transition from '@ember/routing/transition';
-import RouteInfoMetadata from 'codecrafters-frontend/utils/route-info-metadata';
+import RouteInfoMetadata, { RouteColorScheme } from 'codecrafters-frontend/utils/route-info-metadata';
 
 export default class TeamsPayRoute extends BaseRoute {
   @service declare store: Store;
 
   buildRouteInfoMetadata() {
-    return new RouteInfoMetadata({ allowsAnonymousAccess: true });
+    return new RouteInfoMetadata({ allowsAnonymousAccess: true, colorScheme: RouteColorScheme.Light });
   }
 
   async model(params: { teamPaymentFlowId?: string }): Promise<TeamPaymentFlowModel> {

--- a/app/routes/user.ts
+++ b/app/routes/user.ts
@@ -5,7 +5,7 @@ import type UserModel from 'codecrafters-frontend/models/user';
 import type AuthenticatorService from 'codecrafters-frontend/services/authenticator';
 import type MetaDataService from 'codecrafters-frontend/services/meta-data';
 import BaseRoute from 'codecrafters-frontend/utils/base-route';
-import RouteInfoMetadata, { HelpscoutBeaconVisibility } from 'codecrafters-frontend/utils/route-info-metadata';
+import RouteInfoMetadata, { HelpscoutBeaconVisibility, RouteColorScheme } from 'codecrafters-frontend/utils/route-info-metadata';
 
 export type ModelType = UserModel | undefined;
 
@@ -36,7 +36,11 @@ export default class UserRoute extends BaseRoute {
   }
 
   buildRouteInfoMetadata() {
-    return new RouteInfoMetadata({ allowsAnonymousAccess: true, beaconVisibility: HelpscoutBeaconVisibility.Hidden });
+    return new RouteInfoMetadata({
+      allowsAnonymousAccess: true,
+      beaconVisibility: HelpscoutBeaconVisibility.Hidden,
+      colorScheme: RouteColorScheme.Light,
+    });
   }
 
   deactivate() {

--- a/app/utils/route-info-metadata.ts
+++ b/app/utils/route-info-metadata.ts
@@ -12,12 +12,12 @@ export enum HelpscoutBeaconVisibility {
 export default class RouteInfoMetadata {
   allowsAnonymousAccess = false;
   beaconVisibility: HelpscoutBeaconVisibility = HelpscoutBeaconVisibility.Visible;
-  colorScheme: RouteColorScheme = RouteColorScheme.Light;
+  colorScheme: RouteColorScheme = RouteColorScheme.Both;
 
   constructor({
     allowsAnonymousAccess = false,
     beaconVisibility = HelpscoutBeaconVisibility.Visible,
-    colorScheme = RouteColorScheme.Light,
+    colorScheme = RouteColorScheme.Both,
   }: {
     allowsAnonymousAccess?: boolean;
     beaconVisibility?: HelpscoutBeaconVisibility;

--- a/tests/unit/utils/route-info-metadata-test.ts
+++ b/tests/unit/utils/route-info-metadata-test.ts
@@ -6,7 +6,7 @@ module('Unit | Utility | route-info-metadata', function () {
     assert.ok(new RouteInfoMetadata());
   });
 
-  test('it defines a property `colorScheme`, by default set to `RouteColorSheme.Light`', function (assert): void {
-    assert.strictEqual(new RouteInfoMetadata().colorScheme, RouteColorScheme.Light);
+  test('it defines a property `colorScheme`, by default set to `RouteColorScheme.Both`', function (assert): void {
+    assert.strictEqual(new RouteInfoMetadata().colorScheme, RouteColorScheme.Both);
   });
 });


### PR DESCRIPTION
Introduce RouteColorScheme property to RouteInfoMetadata to specify
the color scheme preference for routes. Update multiple routes
(concept, join, gifts/buy, code-walkthrough, referral-link) to set
colorScheme to Light alongside existing settings. This change enables
consistent theming control and improves UI customization based on route.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduce `RouteColorScheme` to `RouteInfoMetadata` (default `Both`) and set `colorScheme: Light` across multiple public routes; update tests accordingly.
> 
> - **Utils**:
>   - Update `app/utils/route-info-metadata.ts` to add `RouteColorScheme.Both` and make `colorScheme` default to `Both`.
> - **Routes** (set `colorScheme: Light` via `buildRouteInfoMetadata`):
>   - `app/routes/concept.ts`, `app/routes/concepts.js`, `app/routes/user.ts` (alongside existing `HelpscoutBeaconVisibility` settings)
>   - `app/routes/code-walkthrough.ts`, `app/routes/concept-group.ts`, `app/routes/debug.ts`, `app/routes/gifts/buy.ts`, `app/routes/institution.ts`, `app/routes/join.ts`, `app/routes/not-found.ts`, `app/routes/pay.ts`, `app/routes/referral-link.ts`, `app/routes/teams/pay.ts`
> - **Tests**:
>   - Update `tests/unit/utils/route-info-metadata-test.ts` to expect default `RouteColorScheme.Both`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d241e32ac5c785a3978cb40e873630c93c10a4e9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->