### PR TITLE
Remove legacy `localStorage` keys migration code

### DIFF
--- a/app/services/local-storage.ts
+++ b/app/services/local-storage.ts
@@ -30,17 +30,6 @@ function getLocalStorageKeys(): string[] {
  */
 export default class LocalStorageService extends Service {
   /**
-   * Initialize the service and perform cleanup of known legacy keys.
-   * TODO: legacy key removal is temporary and can be removed after migration.
-   */
-  constructor() {
-    super();
-
-    // TODO: Remove legacy keys from local storage - safe to drop a month after merge
-    this.clearLegacyKeys();
-  }
-
-  /**
    * Number of prefixed keys available in window.localStorage.
    */
   get length(): number {
@@ -53,22 +42,6 @@ export default class LocalStorageService extends Service {
   clear(): void {
     for (const key of getLocalStorageKeys()) {
       this.removeItem(key);
-    }
-  }
-
-  /**
-   * Remove known legacy keys that were stored without the current prefix.
-   * This is a one-time migration helper.
-   */
-  clearLegacyKeys() {
-    for (const key of [
-      'current_user_cache_v1:user_id',
-      'current_user_cache_v1:username',
-      'preferred-language-leaderboard-v1',
-      'leaderboard-team-selection-v1',
-      'session_token_v1',
-    ]) {
-      window.localStorage?.removeItem(key);
     }
   }
 

--- a/tests/unit/services/local-storage-test.js
+++ b/tests/unit/services/local-storage-test.js
@@ -49,38 +49,9 @@ module('Unit | Service | local-storage', function (hooks) {
     service.clear();
 
     // prefixed keys removed
-    assert.strictEqual(service.getItem('existing'), null, 'existing prefixed removed');
-    assert.strictEqual(service.getItem('temp'), null, 'temp prefixed removed');
+    assert.strictEqual(service.getItem('temp'), null, 'prefixed key is removed');
 
     // non-prefixed untouched
     assert.strictEqual(window.localStorage.getItem('other:keep'), 'y', 'non-prefixed key remains');
-  });
-
-  test('clearLegacyKeys removes legacy keys from raw localStorage', function (assert) {
-    const initial = {
-      'cc-frontend:existing': 'yes',
-      'external:keep': 'stay',
-      // legacy keys that clearLegacyKeys should remove
-      'current_user_cache_v1:user_id': '1',
-      'current_user_cache_v1:username': 'u',
-      'preferred-language-leaderboard-v1': 'en',
-      'leaderboard-team-selection-v1': 'team',
-      session_token_v1: 'token',
-    };
-
-    for (const key of Object.keys(initial)) {
-      window.localStorage.setItem(key, initial[key]);
-    }
-
-    const service = this.owner.lookup('service:local-storage');
-    service.clearLegacyKeys();
-
-    assert.strictEqual(window.localStorage.getItem('cc-frontend:existing'), 'yes', 'cc-frontend:existing is preserved');
-    assert.strictEqual(window.localStorage.getItem('external:keep'), 'stay', 'external:keep is preserved');
-    assert.strictEqual(window.localStorage.getItem('current_user_cache_v1:user_id'), null, 'legacy user_id removed');
-    assert.strictEqual(window.localStorage.getItem('current_user_cache_v1:username'), null, 'legacy username removed');
-    assert.strictEqual(window.localStorage.getItem('preferred-language-leaderboard-v1'), null, 'legacy preferred-language removed');
-    assert.strictEqual(window.localStorage.getItem('leaderboard-team-selection-v1'), null, 'legacy leaderboard-team-selection removed');
-    assert.strictEqual(window.localStorage.getItem('session_token_v1'), null, 'legacy session_token removed');
   });
 });


### PR DESCRIPTION
Follow-up to: https://github.com/codecrafters-io/frontend/pull/3226

### Brief

This drops the temporary `clearLegacyKeys` method that was used to remove deprecated keys from `localStorage`

### Checklist

- [x] I've thoroughly self-reviewed my changes
- [x] I've added tests for my changes, unless they affect admin-only areas (or are otherwise not worth testing)
- [x] I've verified any visual changes using Percy (add a commit with `[percy]` in the message to trigger)
