### PR TITLE
feat(ui): add dark mode styling to referral and testimonial pages

### DIFF
--- a/app/components/referral-link-page/accept-referral-container.hbs
+++ b/app/components/referral-link-page/accept-referral-container.hbs
@@ -1,12 +1,14 @@
 <div class="flex justify-center items-center" ...attributes>
-  <div class="flex flex-col items-center max-w-xs bg-white px-4 py-12 border border-gray-200 rounded-lg shadow-lg">
+  <div
+    class="flex flex-col items-center max-w-xs bg-white dark:bg-gray-900 px-4 py-12 border border-gray-200 dark:border-gray-800 rounded-lg shadow-lg"
+  >
     <div class="flex items-center justify-center">
       <AvatarImage
         @user={{@referralLink.user}}
-        class="w-16 h-16 border border-gray-300 rounded-sm shadow-xs group-hover:shadow-sm mr-2 transition-shadow"
+        class="w-16 h-16 border border-gray-300 dark:border-gray-700 rounded-sm shadow-xs group-hover:shadow-sm mr-2 transition-shadow"
       />
 
-      {{svg-jar "plus" class="w-10 h-10 text-gray-600 mr-2 opacity-90 group-hover:opacity-100 transition-all"}}
+      {{svg-jar "plus" class="w-10 h-10 text-gray-600 dark:text-gray-400 mr-2 opacity-90 group-hover:opacity-100 transition-all"}}
 
       <img class="h-14" src={{this.logoImage}} alt="CodeCrafters" />
     </div>
@@ -19,7 +21,10 @@
     </div>
 
     {{#if this.currentUserAlreadyAcceptedReferralOffer}}
-      <div class="py-6 px-5 mt-6 rounded-sm bg-teal-50 border border-teal-600 prose" data-test-accepted-referral-notice>
+      <div
+        class="py-6 px-5 mt-6 rounded-sm bg-teal-50 dark:bg-teal-900/30 border border-teal-600 dark:border-teal-700 prose"
+        data-test-accepted-referral-notice
+      >
         <p>
           🎉 Offer Accepted!
         </p>
@@ -72,7 +77,7 @@
         {{/if}}
       </div>
 
-      <div class="text-gray-500 text-xs mt-3">
+      <div class="text-gray-500 dark:text-gray-400 text-xs mt-3">
         No credit card required.
       </div>
     {{/if}}

--- a/app/components/referral-link-page/testimonial-list-item.hbs
+++ b/app/components/referral-link-page/testimonial-list-item.hbs
@@ -1,33 +1,37 @@
 <a
   href={{@testimonial.link}}
-  class="block py-4 pr-6 pl-4 group bg-white rounded-sm border border-gray-200"
+  class="block py-4 pr-6 pl-4 group bg-white dark:bg-gray-900 rounded-sm border border-gray-200 dark:border-gray-850"
   target="_blank"
   rel="noopener noreferrer"
   ...attributes
 >
   <span class="flex">
     <span class="flex flex-col items-center mr-3 px-1">
-      <span class="w-px bg-gray-200 group-hover:bg-gray-300 grow mb-2 transition-colors">
+      <span class="w-px bg-gray-200 dark:bg-gray-850 group-hover:bg-gray-300 dark:group-hover:bg-gray-700 grow mb-2 transition-colors">
       </span>
-      <span class="text-4xl text-indigo-400 leading-none font-bold h-5">
+      <span class="text-4xl text-indigo-400 dark:text-indigo-600 leading-none font-bold h-5">
         &ldquo;
       </span>
-      <span class="w-px bg-gray-200 group-hover:bg-gray-300 grow mb-2 transition-colors">
+      <span class="w-px bg-gray-200 dark:bg-gray-850 group-hover:bg-gray-300 dark:group-hover:bg-gray-700 grow mb-2 transition-colors">
       </span>
     </span>
     <span class="grow flex flex-col">
-      <span class="text-gray-600 text-sm mb-2 leading-relaxed grow">
+      <span class="text-gray-600 dark:text-gray-300 text-sm mb-2 leading-relaxed grow">
         {{@testimonial.text}}
       </span>
     </span>
   </span>
   <span class="flex items-start">
-    <img alt="avatar" src={{@testimonial.authorAvatarImage}} class="w-6 h-6 filter drop-shadow-xs ring-1 ring-white rounded-full shadow-sm mr-3" />
+    <img
+      alt="avatar"
+      src={{@testimonial.authorAvatarImage}}
+      class="w-6 h-6 filter drop-shadow-xs ring-1 ring-white dark:ring-gray-925 rounded-full shadow-sm mr-3"
+    />
     <span class="block mt-0.5">
-      <span class="block text-gray-600 group-hover:underline text-sm transition-colors font-semibold mb-0.5">
+      <span class="block text-gray-600 dark:text-gray-300 group-hover:underline text-sm transition-colors font-semibold mb-0.5">
         {{@testimonial.authorName}}
       </span>
-      <span class="block text-gray-500 text-xs">
+      <span class="block text-gray-500 dark:text-gray-500 text-xs">
         {{@testimonial.authorDesignation}}
       </span>
     </span>

--- a/app/routes/referral-link.ts
+++ b/app/routes/referral-link.ts
@@ -24,7 +24,7 @@ export default class ReferralLinkRoute extends BaseRoute {
   }
 
   buildRouteInfoMetadata() {
-    return new RouteInfoMetadata({ allowsAnonymousAccess: true, colorScheme: RouteColorScheme.Light });
+    return new RouteInfoMetadata({ allowsAnonymousAccess: true, colorScheme: RouteColorScheme.Both });
   }
 
   async model(params: { referral_link_slug: string }) {

--- a/app/templates/referral-link.hbs
+++ b/app/templates/referral-link.hbs
@@ -1,23 +1,29 @@
 {{page-title (concat "Join " @model.referralLink.user.username)}}
 
-<div class="container mx-auto lg:max-w-(--breakpoint-lg) py-16 pb-48 px-3 md:px-6">
-  <h1 class="text-2xl font-bold text-gray-700 md:text-3xl text-center">
-    Join the best.
-  </h1>
+<div class="bg-white dark:bg-gray-950">
+  <div class="container mx-auto lg:max-w-(--breakpoint-lg) py-16 pb-48 px-3 md:px-6">
+    <h1
+      class="text-2xl leading-9 md:text-3xl md:leading-10 font-bold text-gradient-to-b from-gray-950 to-gray-700 dark:from-white dark:to-gray-300 text-center"
+    >
+      Join the best.
+    </h1>
 
-  <ReferralLinkPage::AcceptReferralContainer
-    @acceptedReferralOfferFreeUsageGrant={{@model.acceptedReferralOfferFreeUsageGrant}}
-    @referralLink={{@model.referralLink}}
-    class="mt-8"
-  />
+    <ReferralLinkPage::AcceptReferralContainer
+      @acceptedReferralOfferFreeUsageGrant={{@model.acceptedReferralOfferFreeUsageGrant}}
+      @referralLink={{@model.referralLink}}
+      class="mt-8"
+    />
 
-  <h2 class="text-2xl font-bold text-gray-700 md:text-3xl text-center mt-16">
-    Hear it from our members
-  </h2>
+    <h2
+      class="text-2xl leading-9 md:text-3xl md:leading-10 font-bold text-gradient-to-b from-gray-950 to-gray-700 dark:from-white dark:to-gray-300 text-center mt-16"
+    >
+      Hear it from our members
+    </h2>
 
-  <div class="text-gray-500 text-sm text-center mt-2">
-    Engineers at top teams love The CodeCrafters Way<sup>TM</sup>.
+    <div class="text-gray-500 dark:text-gray-400 text-sm text-center mt-2">
+      Engineers at top teams love The CodeCrafters Way<sup>TM</sup>.
+    </div>
+
+    <TestimonialList class="mt-10" />
   </div>
-
-  <TestimonialList class="mt-10" />
 </div>


### PR DESCRIPTION
Update referral acceptance container, testimonial list items,
and referral-link template to support dark mode.
Add dark background, text, and border colors for better contrast
in dark theme, improving accessibility and user experience at night.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Add dark theme styles and enable dark/light color scheme for referral link and testimonial pages.
> 
> - **Dark mode support**
>   - Enable dark/light switching by setting `colorScheme: RouteColorScheme.Both` in `app/routes/referral-link.ts`.
>   - Apply dark theme styles across referral pages:
>     - `app/templates/referral-link.hbs`: wrap with dark-compatible background, gradient heading styles, and dark text colors.
>     - `app/components/referral-link-page/accept-referral-container.hbs`: add dark variants for background, borders, icons, avatar ring, and text.
>     - `app/components/referral-link-page/testimonial-list-item.hbs`: add dark variants for background, borders, dividers, text, and avatar ring.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 665e0deeeb2f9ec199b2a341c683f910bb1d1505. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->