### PR TITLE
style: improve dark mode styling and layout consistency

### DIFF
--- a/app/components/code-walkthrough-page/content.hbs
+++ b/app/components/code-walkthrough-page/content.hbs
@@ -1,9 +1,9 @@
-<div class="bg-white">
+<div class="bg-white dark:bg-gray-950">
   <div class="container mx-auto lg:max-w-(--breakpoint-lg) px-3 md:px-6">
     <div class="flex flex-col-reverse md:flex-row">
       <div class="md:pr-8 pt-10 pb-20 w-full min-w-0">
         {{#if @codeWalkthrough.introductionMarkdown}}
-          <div class="leading-7 prose mb-4">
+          <div class="leading-7 prose dark:prose-invert mb-4">
             {{markdown-to-html @codeWalkthrough.introductionMarkdown}}
           </div>
         {{/if}}
@@ -12,19 +12,19 @@
         <CodeWalkthrough @model={{@codeWalkthrough}} />
 
         {{#if @codeWalkthrough.conclusionMarkdown}}
-          <div class="leading-7 prose mt-8 mb-8">
+          <div class="leading-7 prose dark:prose-invert mt-8 mb-8">
             {{markdown-to-html @codeWalkthrough.conclusionMarkdown}}
           </div>
         {{/if}}
 
         {{#if @codeWalkthrough.hackerNewsUrl}}
-          <div class="h-px border-t border-gray-200 mb-6"></div>
+          <div class="h-px border-t border-gray-200 dark:border-gray-800 mb-6"></div>
           {{! @glint-expect-error: not ts-ified yet }}
           <DiscussOnHnButton @link={{@codeWalkthrough.hackerNewsUrl}} />
         {{/if}}
       </div>
 
-      <div class="border-b border-gray-200 md:border-b-0 md:border-l md:pl-8 shrink-0 w-full md:w-64 py-6 md:py-10">
+      <div class="border-b border-gray-200 dark:border-gray-800 md:border-b-0 md:border-l md:pl-8 shrink-0 w-full md:w-64 py-6 md:py-10">
         <CodeWalkthroughPage::MetadataItem @icon="clock" class="mb-3">
           <span class="font-semibold">3 min</span>
           reading time

--- a/app/components/code-walkthrough-page/header.hbs
+++ b/app/components/code-walkthrough-page/header.hbs
@@ -1,27 +1,29 @@
-<div class="py-10 md:py-20 border-b border-gray-200 code-walkthrough-header-background">
+<div class="py-10 md:py-20 border-b border-gray-200 dark:border-gray-800 bg-gradient-to-b from-white to-gray-50 dark:from-gray-950 dark:to-gray-925">
   <div class="container mx-auto lg:max-w-(--breakpoint-lg) px-3 md:px-6">
     <div class="flex items-center justify-between">
       <div>
-        <div class="text-gray-400 uppercase text-xs font-bold tracking-wider mb-2">
+        <div class="text-gray-400 dark:text-gray-500 uppercase text-xs font-bold tracking-wider mb-2">
           SOURCE WALKTHROUGH
         </div>
-        <h1 class="text-gray-900 text-2xl md:text-5xl font-bold mb-4">
+        <h1
+          class="text-gradient-to-b from-gray-950 to-gray-700 dark:from-white dark:to-gray-300 leading-10 md:leading-14 text-2xl md:text-5xl font-bold mb-4"
+        >
           {{@codeWalkthrough.title}}
         </h1>
-        <div class="text-gray-600 max-w-lg leading-relaxed mb-4">
+        <div class="text-gray-600 dark:text-gray-400 max-w-lg leading-relaxed mb-4">
           {{@codeWalkthrough.descriptionMarkdown}}
         </div>
         <a href="https://github.com/rohitpaulk" class="inline-flex gap-x-2 items-center" target="_blank" rel="noopener noreferrer">
           <img
             alt="avatar"
             src="https://github.com/rohitpaulk.png"
-            class="w-12 h-12 filter drop-shadow-xs ring-1 ring-white rounded-full shadow-sm brightness-110"
+            class="w-12 h-12 filter drop-shadow-xs ring-1 ring-white dark:ring-gray-800 rounded-full shadow-sm brightness-110"
           />
           <div>
-            <div class="text-gray-700 text-xs font-bold mb-0.5">
+            <div class="text-gray-700 dark:text-gray-300 text-xs font-bold mb-0.5">
               Paul Kuruvilla
             </div>
-            <div class="text-gray-500 text-xs">
+            <div class="text-gray-500 dark:text-gray-400 text-xs">
               CTO, CodeCrafters
             </div>
           </div>

--- a/app/components/code-walkthrough.hbs
+++ b/app/components/code-walkthrough.hbs
@@ -2,7 +2,7 @@
   {{#each this.sections as |section|}}
     {{#if (eq section.type "ProseSection")}}
       <div
-        class="leading-7 prose max-w-none mb-6 code-walkthrough-prose"
+        class="leading-7 prose dark:prose-invert max-w-none mb-6 code-walkthrough-prose"
         {{did-insert this.handleDidInsertProseSectionHTML}}
         {{did-update this.handleDidUpdateProseSectionHTML section.HTML}}
       >

--- a/app/routes/code-walkthrough.ts
+++ b/app/routes/code-walkthrough.ts
@@ -10,7 +10,7 @@ export default class CodeWalkthroughRoute extends BaseRoute {
   @service declare store: Store;
 
   buildRouteInfoMetadata() {
-    return new RouteInfoMetadata({ allowsAnonymousAccess: true, colorScheme: RouteColorScheme.Light });
+    return new RouteInfoMetadata({ allowsAnonymousAccess: true, colorScheme: RouteColorScheme.Both });
   }
 
   async model(params: { code_walkthrough_slug: string }): Promise<ModelType> {

--- a/app/styles/pages/code-walkthrough-page.css
+++ b/app/styles/pages/code-walkthrough-page.css
@@ -1,7 +1,7 @@
-.code-walkthrough-header-background {
-  background: linear-gradient(180deg, #eff6ff 0%, rgb(239 246 255 / 50%) 100%);
-}
-
 .code-walkthrough-prose pre[class*='language-'] {
   background-color: #f1f5f9;
+}
+
+.code-walkthrough-prose pre[class*='language-']:is(.dark *) {
+  background-color: oklch(21% 0.034 264.665deg); /* gray-900 */
 }

--- a/mirage/utils/create-code-walkthrough.js
+++ b/mirage/utils/create-code-walkthrough.js
@@ -40,5 +40,6 @@ export default function createCodeWalkthroughWalkthrough(server, slug) {
     ],
 
     slug: slug,
+    title: 'How Redis binds to a port',
   });
 }


### PR DESCRIPTION
Update components and styles to enhance dark mode support by adding
dark mode color variants and adjusting backgrounds, borders, and text
colors for better readability. Remove deprecated background gradient
class and replace it with updated styles supporting both light and
dark themes.
Add title field to code walkthrough mock data for completeness.
Change route metadata to allow both light and dark color schemes.
These changes improve the user experience by ensuring consistent and
accessible visuals across different color schemes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Add dark-mode styling and gradients to code walkthrough pages, enable both color schemes, and include a title in mock data.
> 
> - **UI (code walkthrough pages)**:
>   - Add dark mode variants for backgrounds, text, borders, and `prose` in `code-walkthrough-page/content.hbs`, `header.hbs`, and `code-walkthrough.hbs`.
>   - Replace header background with gradient supporting light/dark; adjust title gradient and avatar ring colors.
> - **Styles**:
>   - Remove `code-walkthrough-header-background` rule.
>   - Add dark-mode code block background in `code-walkthrough-page.css`.
> - **Routing**:
>   - Set route `colorScheme` to `Both` in `app/routes/code-walkthrough.ts`.
> - **Mocks**:
>   - Add `title` to Mirage `code-walkthrough` factory.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 992d28c3f16a880349f1094502fa39cf643118c2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->