### PR TITLE
style: improve dark mode support on concept group page

### DIFF
--- a/app/components/concept-group-page/content.hbs
+++ b/app/components/concept-group-page/content.hbs
@@ -1,4 +1,4 @@
-<div class="bg-white">
+<div class="bg-white dark:bg-gray-950">
   <div class="container mx-auto lg:max-w-(--breakpoint-lg) pt-6 md:pt-10 pb-10 md:pb-48 px-3 md:px-6">
     <div class="grid grid-cols-1 gap-3 md:gap-6 md:grid-cols-2">
       {{#each this.sortedConcepts as |concept|}}

--- a/app/components/concept-group-page/header.hbs
+++ b/app/components/concept-group-page/header.hbs
@@ -1,14 +1,20 @@
-<div class="py-10 md:py-20 border-b border-gray-200 code-walkthrough-header-background" ...attributes>
+<div
+  class="py-10 md:py-20 border-b border-gray-200 dark:border-white/5 bg-gradient-to-b from-white to-gray-50 dark:from-gray-950 dark:to-gray-925"
+  ...attributes
+>
   <div class="container mx-auto lg:max-w-(--breakpoint-lg) px-3 md:px-6">
     <div class="flex items-center justify-between">
       <div>
-        <div class="text-gray-400 uppercase text-xs font-bold tracking-wider mb-2">
+        <div class="text-gray-400 dark:text-gray-500 uppercase text-xs font-bold tracking-wider mb-2">
           COLLECTION
         </div>
-        <h1 class="text-gray-900 text-2xl md:text-5xl font-bold mb-4" data-test-concept-group-title>
+        <h1
+          class="text-gradient-to-b from-gray-950 to-gray-700 dark:from-white dark:to-gray-300 leading-10 md:leading-14 text-2xl md:text-5xl font-bold mb-2"
+          data-test-concept-group-title
+        >
           {{@conceptGroup.title}}
         </h1>
-        <div class="text-gray-600 max-w-xl leading-relaxed mb-4" data-test-concept-group-description>
+        <div class="text-gray-600 dark:text-gray-400 max-w-xl leading-relaxed mb-4" data-test-concept-group-description>
           {{markdown-to-html @conceptGroup.descriptionMarkdown}}
         </div>
         <a
@@ -21,13 +27,13 @@
           <img
             alt="avatar"
             src={{or @conceptGroup.author.avatarUrl "https://github.com/rohitpaulk.png"}}
-            class="w-12 h-12 filter drop-shadow-xs ring-1 ring-white rounded-full shadow-sm brightness-110"
+            class="w-12 h-12 filter drop-shadow-xs ring-1 ring-white dark:ring-white/20 rounded-full shadow-sm brightness-110"
           />
           <div>
-            <div class="text-gray-700 text-xs font-bold mb-0.5" data-test-concept-group-author-username>
+            <div class="text-gray-700 dark:text-gray-300 text-xs font-bold mb-0.5" data-test-concept-group-author-username>
               {{or @conceptGroup.author.username "Paul Kuruvilla"}}
             </div>
-            <div class="text-gray-500 text-xs" data-test-concept-group-author-title>
+            <div class="text-gray-500 dark:text-gray-400 text-xs" data-test-concept-group-author-title>
               {{#if @conceptGroup.author}}
                 Collection Author
               {{else}}

--- a/app/routes/concept-group.ts
+++ b/app/routes/concept-group.ts
@@ -22,7 +22,7 @@ export default class ConceptGroupRoute extends BaseRoute {
   }
 
   buildRouteInfoMetadata() {
-    return new RouteInfoMetadata({ allowsAnonymousAccess: true, colorScheme: RouteColorScheme.Light });
+    return new RouteInfoMetadata({ allowsAnonymousAccess: true, colorScheme: RouteColorScheme.Both });
   }
 
   deactivate() {


### PR DESCRIPTION
Enhance the UI to better support dark mode by updating background
colors, text colors, and borders with appropriate dark variants.
Change the route color scheme to accommodate both light and dark
themes. These updates improve readability and visual consistency
for users in dark mode.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds dark mode styles to the concept group page and sets the route color scheme to support both light and dark themes.
> 
> - **UI (Concept Group Page)**:
>   - `app/components/concept-group-page/content.hbs`: Add `dark:bg-gray-950` for page background.
>   - `app/components/concept-group-page/header.hbs`: Introduce gradient background and dark variants for borders, headings, text, and avatar ring.
> - **Routing**:
>   - `app/routes/concept-group.ts`: Change `colorScheme` to `RouteColorScheme.Both` in route metadata.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e061285454c0717cd43371bf5859bdd7b3017405. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->