### PR TITLE
feat(concepts): add dark mode styles and update route color scheme

### DIFF
--- a/app/routes/concepts.js
+++ b/app/routes/concepts.js
@@ -10,7 +10,7 @@ export default class ConceptsRoute extends BaseRoute {
     return new RouteInfoMetadata({
       allowsAnonymousAccess: true,
       beaconVisibility: HelpscoutBeaconVisibility.Hidden,
-      colorScheme: RouteColorScheme.Light,
+      colorScheme: RouteColorScheme.Both,
     });
   }
 

--- a/app/templates/concepts.hbs
+++ b/app/templates/concepts.hbs
@@ -1,8 +1,8 @@
 {{page-title "Concepts"}}
 
-<div class="container mx-auto lg:max-w-(--breakpoint-lg) pt-6 md:pt-10 pb-10 md:pb-48 px-3 md:px-6">
-  <div class="border-b border-gray-200 pb-2 mb-6 flex items-center justify-between">
-    <h1 class="text-3xl text-gray-700 font-bold tracking-tighter">Concepts</h1>
+<div class="container mx-auto lg:max-w-(--breakpoint-lg) pt-6 md:pt-10 pb-10 md:pb-48 px-3 md:px-6 dark:bg-gray-950">
+  <div class="border-b border-gray-200 dark:border-white/5 pb-2 mb-6 flex items-center justify-between">
+    <h1 class="text-3xl text-gray-700 dark:text-gray-100 font-bold tracking-tighter">Concepts</h1>
     <div>
       {{#if this.shouldShowCreateConceptButton}}
         <TertiaryButtonWithSpinner
@@ -14,7 +14,7 @@
           data-test-create-concept-button
         >
           <div class="flex items-center">
-            {{svg-jar "plus-circle" class="w-5 h-5 mr-1.5 text-gray-400"}}
+            {{svg-jar "plus-circle" class="w-5 h-5 mr-1.5 text-gray-400 dark:text-gray-600"}}
             New concept
           </div>
         </TertiaryButtonWithSpinner>


### PR DESCRIPTION
Update concepts route to support both light and dark color schemes.
Enhance concepts template with dark mode styles for background, borders,
and text to improve readability in dark environments. Adjust button icon
color in dark mode for better visibility. These changes improve UI 
consistency and accessibility for users preferring dark mode.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Enable both light and dark color schemes and add dark-mode styles to the Concepts page.
> 
> - **UI (`app/templates/concepts.hbs`)**:
>   - Add dark mode classes: container background `dark:bg-gray-950`, borders `dark:border-white/5`, header text `dark:text-gray-100`, and plus icon `dark:text-gray-600`.
> - **Routing (`app/routes/concepts.js`)**:
>   - Set route metadata `colorScheme` to `RouteColorScheme.Both` (from `Light`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 300dd7c8127170fe5b02e8532f1ebf89825df5bf. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->