### PR TITLE
style: update dark mode colors and improve institution page UI

### DIFF
--- a/app/components/affiliate-link-page/accept-referral-container.hbs
+++ b/app/components/affiliate-link-page/accept-referral-container.hbs
@@ -1,5 +1,5 @@
 <div
-  class="flex flex-col items-center gap-y-6 bg-teal-50/25 dark:bg-teal-800/40 border-teal-500 dark:border-teal-600 px-4
+  class="flex flex-col items-center gap-y-6 bg-teal-50/25 dark:bg-teal-900/20 border-teal-500 dark:border-teal-600 px-4
     {{if (eq @verticalSize 'tall') 'py-12' 'py-8'}}
     border rounded-md shadow-xl group"
   ...attributes

--- a/app/components/institution-page/claim-offer-card.hbs
+++ b/app/components/institution-page/claim-offer-card.hbs
@@ -1,5 +1,5 @@
 <div
-  class="flex flex-col items-center gap-y-6 bg-teal-50/25 dark:bg-teal-800/40 border border-teal-500 dark:border-teal-600 px-4 py-12 rounded-md shadow-xl max-w-xs"
+  class="flex flex-col items-center gap-y-6 bg-teal-50/25 dark:bg-teal-900/20 border border-teal-500 dark:border-teal-600 px-4 py-12 rounded-md shadow-xl max-w-xs"
   ...attributes
 >
   <div class="flex items-center justify-center gap-2">

--- a/app/routes/institution.ts
+++ b/app/routes/institution.ts
@@ -27,7 +27,7 @@ export default class InstitutionRoute extends BaseRoute {
   }
 
   buildRouteInfoMetadata() {
-    return new RouteInfoMetadata({ allowsAnonymousAccess: true, colorScheme: RouteColorScheme.Light });
+    return new RouteInfoMetadata({ allowsAnonymousAccess: true, colorScheme: RouteColorScheme.Both });
   }
 
   async model(params: { institution_slug: string }) {

--- a/app/templates/institution.hbs
+++ b/app/templates/institution.hbs
@@ -1,15 +1,17 @@
 {{page-title (concat @model.institution.shortName " Campus Program")}}
 
-<div class="bg-white bg-github-green-dot-wall">
+<div class="bg-white dark:bg-gray-950 bg-github-green-dot-wall">
   <div class="container mx-auto lg:max-w-(--breakpoint-xl) pt-8 sm:pt-16 pb-48 px-3 md:px-6">
     <div class="space-y-6 text-center max-w-[580px] mx-auto mb-8">
-      <h1 class="text-3xl text-gray-950 font-bold mb-6 md:text-4xl text-balance">
+      <h1
+        class="text-3xl leading-10 md:text-4xl md:leading-10 text-gradient-to-b from-gray-950 to-gray-700 dark:from-white dark:to-gray-300 font-bold mb-6 text-balance"
+      >
         Become a
         <span class="font-extrabold">better, confident</span>
         programmer.
       </h1>
 
-      <p class="text-gray-700 text-balance text-sm leading-relaxed sm:text-lg sm:leading-relaxed">
+      <p class="text-gray-700 dark:text-gray-300 text-balance text-sm leading-relaxed sm:text-lg sm:leading-relaxed">
         Stop letting advanced programming projects intimidate you. Start approaching them with the calm and confidence of a craftsman who has seen it
         before.
       </p>
@@ -20,18 +22,20 @@
     </div>
 
     <div class="space-y-6 text-center mt-8 mb-8 max-w-[640px] mx-auto">
-      <h2 class="text-3xl md:text-4xl font-bold text-gray-950">
+      <h2
+        class="text-3xl leading-9 md:text-4xl md:leading-10 text-gradient-to-b from-gray-950 to-gray-700 dark:from-white dark:to-gray-300 font-bold"
+      >
         Trusted by senior engineers at
         <span class="italic font-extrabold">the world's best companies</span>
       </h2>
-      <p class="text-sm md:text-lg text-gray-900">
+      <p class="text-sm md:text-lg text-gray-900 dark:text-gray-200">
         Discover how core contributors to Docker and Next.js practice writing code at the edge of their abilities — as well as senior engineers at
         companies like Apple, NVIDIA, and Stripe.
       </p>
     </div>
 
     {{! We're re-using the affiliate link page's logo cloud for now }}
-    <h2 class="text-gray-400 uppercase text-center text-xs mb-5">Trusted by engineers at top companies</h2>
+    <h2 class="text-gray-400 dark:text-gray-500 uppercase text-center text-xs mb-5">Trusted by engineers at top companies</h2>
     <AffiliateLinkPage::LogoCloud />
 
     <img src={{this.BYOXBanner}} alt="Build Your Own X GitHub Banner" class="hidden sm:block sm:w-4/5 mx-auto mt-16" />
@@ -39,14 +43,16 @@
 
     <div class="flex flex-col gap-4 justify-center items-center mt-16">
       <InstitutionPage::ClaimOfferButton @onClick={{this.handleClaimOfferButtonClick}} />
-      <div class="text-xs text-gray-700 text-center">Get a free 1 year membership</div>
+      <div class="text-xs text-gray-700 dark:text-gray-400 text-center">Get a free 1 year membership</div>
     </div>
 
-    <h2 class="text-2xl font-bold text-gray-950 md:text-3xl text-center mt-16">
+    <h2
+      class="text-2xl leading-9 md:text-3xl md:leading-10 font-bold text-gradient-to-b from-gray-950 to-gray-700 dark:from-white dark:to-gray-300 text-center mt-16"
+    >
       Hear it from our members
     </h2>
 
-    <div class="text-gray-500 text-sm text-center mt-2">
+    <div class="text-gray-500 dark:text-gray-400 text-sm text-center mt-2">
       Engineers at top teams love The CodeCrafters Way<sup>TM</sup>.
     </div>
 
@@ -54,7 +60,7 @@
 
     <div class="flex flex-col gap-4 justify-center items-center mt-16">
       <InstitutionPage::ClaimOfferButton @onClick={{this.handleClaimOfferButtonClick}} />
-      <div class="text-xs text-gray-700 text-center">Get a free 1 year membership</div>
+      <div class="text-xs text-gray-700 dark:text-gray-400 text-center">Get a free 1 year membership</div>
     </div>
   </div>
 </div>


### PR DESCRIPTION
Adjust dark mode background and border colors in affiliate-link-page and
claim-offer-card components to improve visual contrast and consistency.
Change institution route color scheme to 'Both' to reflect updated 
design requirements allowing dual theme support.
Enhance institution template with dark mode text and background colors,
add gradient text styles for headings, and improve readability and
aesthetic consistency across light and dark themes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates dark mode colors across institution and affiliate components and switches institution route to support both light and dark themes.
> 
> - **Institution page (`app/templates/institution.hbs`)**:
>   - Adds dark mode background/text and gradient heading styles for improved readability.
>   - Harmonizes supporting text colors and labels for dark mode.
> - **Components**:
>   - `app/components/affiliate-link-page/accept-referral-container.hbs`: tweaks dark background tint.
>   - `app/components/institution-page/claim-offer-card.hbs`: aligns dark background tint with new palette.
> - **Routing**:
>   - `app/routes/institution.ts`: changes `RouteColorScheme` from `Light` to `Both` to allow dual-theme rendering.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 52cfdc47b8cde69c0f400b07869f835042b7e16f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->