### PR TITLE
fix(footer): update footer styles and changelog URL

### DIFF
--- a/app/components/footer.hbs
+++ b/app/components/footer.hbs
@@ -39,7 +39,7 @@
         >
           {{#each this.footerLinkGroups as |footerLinkGroup|}}
             <div>
-              <h3 class="text-sm font-semibold text-gray-300 tracking-wider uppercase border-b-2 border-gray-600 inline-flex pb-1">
+              <h3 class="text-sm font-semibold text-gray-300 tracking-wider uppercase border-b-2 border-gray-850 inline-flex pb-1">
                 {{footerLinkGroup.heading}}
               </h3>
               <ul class="mt-4 space-y-4">

--- a/app/components/footer.ts
+++ b/app/components/footer.ts
@@ -64,7 +64,7 @@ export default class Footer extends Component {
         },
         {
           text: 'Changelog',
-          url: 'https://twitter.com/codecraftersio',
+          url: 'https://forum.codecrafters.io/c/announcements/10',
         },
       ],
     };


### PR DESCRIPTION
Change footer heading border color from gray-600 to gray-850 for better
visual contrast. Update the "Changelog" link to point to the official
forum announcements instead of the incorrect Twitter URL. These changes
improve the footer's appearance and ensure navigation links are 
accurate.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adjust footer heading border color and update the Changelog link to the forum announcements.
> 
> - **Footer UI**:
>   - Change footer heading border color to `border-gray-850` in `app/components/footer.hbs`.
> - **Links**:
>   - Update `Company -> Changelog` URL to `https://forum.codecrafters.io/c/announcements/10` in `app/components/footer.ts`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8f85932f982b80333f4cee85f072cfda76e68191. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->