### PR TITLE
style: enhance heading styles with gradient text in catalog page

### DIFF
--- a/app/templates/catalog.hbs
+++ b/app/templates/catalog.hbs
@@ -2,7 +2,9 @@
 
 <div class="container mx-auto lg:max-w-(--breakpoint-lg) pt-6 md:pt-10 pb-10 md:pb-48 px-3 md:px-6">
   <div class="border-b border-gray-200 dark:border-white/5 pb-2 mb-6">
-    <h1 class="text-3xl text-gray-700 dark:text-gray-300 font-bold tracking-tighter">Challenges</h1>
+    <h1 class="text-3xl leading-9 text-gradient-to-b from-gray-950 to-gray-700 dark:from-white dark:to-gray-300 font-bold tracking-tighter">
+      Challenges
+    </h1>
   </div>
 
   {{#if this.authenticator.currentUser.pendingProductWalkthroughFeatureSuggestion}}
@@ -21,7 +23,9 @@
   </div>
 
   <div class="border-b border-gray-200 dark:border-white/5 pb-2 mb-6">
-    <h2 class="text-3xl text-gray-700 dark:text-gray-300 font-bold tracking-tighter">Language Tracks</h2>
+    <h2 class="text-3xl leading-9 text-gradient-to-b from-gray-950 to-gray-700 dark:from-white dark:to-gray-300 font-bold tracking-tighter">
+      Language Tracks
+    </h2>
   </div>
 
   <div class="grid grid-cols-1 gap-3 md:grid-cols-2 lg:grid-cols-3 mb-8">


### PR DESCRIPTION
Add gradient text styling to h1 and h2 headings on the catalog page to
improve visual hierarchy and user experience. This change replaces the
previous solid text color with a subtle gradient that adapts to light
and dark modes, making the headings more visually appealing and
consistent with the overall design theme.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Update catalog page headings to use gradient text with dark-mode support.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6e4c950539cf2c3f3a0d570077fff3d278530ea4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->