### PR TITLE
fix(course-card): improve opacity behavior for locked courses

### DIFF
--- a/app/components/course-card/index.hbs
+++ b/app/components/course-card/index.hbs
@@ -1,6 +1,6 @@
 <LinkTo
   class="group bg-white dark:bg-gray-925 p-5 rounded-md shadow-sm hover:shadow-md transition-shadow cursor-pointer flex flex-col justify-between border border-gray-200 dark:border-white/5 relative
-    {{if this.shouldShowLockIcon 'opacity-50 hover:opacity-100'}}"
+    {{if this.shouldShowLockIcon 'opacity-50 dark:opacity-30 hover:opacity-100 dark:hover:opacity-100'}}"
   @route={{this.linkToRoute.name}}
   @model={{this.linkToRoute.model}}
   @query={{this.linkToRoute.query}}


### PR DESCRIPTION
Adjust opacity classes on course-card link to enhance visual
indication of locked state in both light and dark modes. The
change adds dark mode-specific opacity settings to maintain
consistent feedback when hovering over locked course cards.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adjusts locked course-card link classes to include dark-mode opacity and hover behavior.
> 
> - **UI**:
>   - Update `app/components/course-card/index.hbs` to refine locked state styling on `LinkTo`:
>     - Add `dark:opacity-30` and `dark:hover:opacity-100` alongside existing `opacity-50` and `hover:opacity-100`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 81d06a821c0079e27c8f62ed695cc8d36f606d74. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->