### PR TITLE
feat: add analytics tracking for reveal actions in autofix card

### DIFF
--- a/app/components/course-page/test-results-bar/autofix-request-card.hbs
+++ b/app/components/course-page/test-results-bar/autofix-request-card.hbs
@@ -49,7 +49,7 @@
             </:content>
             <:overlay>
               {{#if (eq @autofixRequest.status "success")}}
-                <SecondaryButton class="bg-gray-900 mt-10" {{on "click" (fn (mut this.diffWasUnblurred) true)}}>
+                <SecondaryButton class="bg-gray-900 mt-10" {{on "click" this.handleShowFixedCodeButtonClick}}>
                   <div class="flex items-center gap-2">
                     <div class="flex">{{svg-jar "eye" class="size-6"}}</div>
                     Show fixed code
@@ -63,7 +63,7 @@
 
       <:overlay>
         {{#if (eq @autofixRequest.status "success")}}
-          <SecondaryButton class="bg-gray-900 mt-10" {{on "click" (fn (mut this.explanationWasUnblurred) true)}}>
+          <SecondaryButton class="bg-gray-900 mt-10" {{on "click" this.handleShowExplanationButtonClick}}>
             <div class="flex items-center gap-2">
               <div class="flex">{{svg-jar "eye" class="size-6"}}</div>
               Explain more?

--- a/app/components/course-page/test-results-bar/autofix-request-card.ts
+++ b/app/components/course-page/test-results-bar/autofix-request-card.ts
@@ -1,6 +1,9 @@
+import AnalyticsEventTrackerService from 'codecrafters-frontend/services/analytics-event-tracker';
 import Component from '@glimmer/component';
-import type AutofixRequestModel from 'codecrafters-frontend/models/autofix-request';
 import fade from 'ember-animated/transitions/fade';
+import type AutofixRequestModel from 'codecrafters-frontend/models/autofix-request';
+import { action } from '@ember/object';
+import { service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 
 interface Signature {
@@ -13,6 +16,8 @@ interface Signature {
 
 export default class AutofixRequestCard extends Component<Signature> {
   transition = fade;
+
+  @service declare analyticsEventTracker: AnalyticsEventTrackerService;
 
   @tracked diffWasUnblurred = false;
   @tracked explanationWasUnblurred = false;
@@ -54,6 +59,24 @@ export default class AutofixRequestCard extends Component<Signature> {
     }
 
     return !this.explanationWasUnblurred;
+  }
+
+  @action
+  handleShowExplanationButtonClick() {
+    if (this.explanationIsBlurred) {
+      this.analyticsEventTracker.track('revealed_autofix_explanation', { autofix_request_id: this.args.autofixRequest.id });
+    }
+
+    this.explanationWasUnblurred = true;
+  }
+
+  @action
+  handleShowFixedCodeButtonClick() {
+    if (this.diffIsBlurred) {
+      this.analyticsEventTracker.track('revealed_autofix_diff', { autofix_request_id: this.args.autofixRequest.id });
+    }
+
+    this.diffWasUnblurred = true;
   }
 }
 


### PR DESCRIPTION
Replace inline state mutation on button clicks with dedicated 
action handlers in AutofixRequestCard component. Add tracking of 
analytics events when users reveal the fixed code or explanation 
sections, providing insight into user interactions with autofix 
requests.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds action handlers and analytics tracking for revealing the explanation and diff in the Autofix request card.
> 
> - **AutofixRequestCard component**:
>   - **Logic (.ts)**: Injects `AnalyticsEventTrackerService`; adds `@action` handlers `handleShowExplanationButtonClick` and `handleShowFixedCodeButtonClick` to unblur sections and track `revealed_autofix_explanation`/`revealed_autofix_diff` with `autofix_request_id`.
>   - **Template (.hbs)**: Replaces inline state mutations on button clicks with the new action handlers for "Show fixed code" and "Explain more?".
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 74afc32f0b9292f4c99cf8afcc7db2a82c1ff2af. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->