### PR TITLE
test: call onConnect callback when subscribing

### DIFF
--- a/tests/support/fake-action-cable-consumer.ts
+++ b/tests/support/fake-action-cable-consumer.ts
@@ -35,6 +35,10 @@ export default class FakeActionCableConsumer {
     this.#subscriptions[channel] ||= [];
     this.#subscriptions[channel] = [...this.#subscriptions[channel], { id, args, callbacks }];
 
+    if (callbacks.onConnect) {
+      callbacks.onConnect();
+    }
+
     return {
       send: () => {},
       unsubscribe: () => {


### PR DESCRIPTION
Invoke the onConnect callback immediately upon adding a new
subscription in fake-action-cable-consumer. This ensures that any
setup logic depending on connection confirmation runs promptly
during tests, improving test accuracy and behavior simulation.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Immediately invoke `onConnect` when a subscription is created in `tests/support/fake-action-cable-consumer.ts`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d46b2dade6c6aa00bbfc19fc38621c14c7a0afab. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->