### PR TITLE
feat(feature-flags): add autofix flow visibility flag

### DIFF
--- a/app/components/course-page/test-results-bar/index.ts
+++ b/app/components/course-page/test-results-bar/index.ts
@@ -7,6 +7,7 @@ import { StepDefinition } from 'codecrafters-frontend/utils/course-page-step-lis
 import { tracked } from '@glimmer/tracking';
 import type AuthenticatorService from 'codecrafters-frontend/services/authenticator';
 import type CoursePageStateService from 'codecrafters-frontend/services/course-page-state';
+import type FeatureFlagsService from 'codecrafters-frontend/services/feature-flags';
 import type CourseStageStep from 'codecrafters-frontend/utils/course-page-step-list/course-stage-step';
 import type RepositoryModel from 'codecrafters-frontend/models/repository';
 import fade from 'ember-animated/transitions/fade';
@@ -31,6 +32,7 @@ export default class TestResultsBar extends Component<Signature> {
 
   @service declare authenticator: AuthenticatorService;
   @service declare coursePageState: CoursePageStateService;
+  @service declare featureFlags: FeatureFlagsService;
   @service declare screen: ScreenService;
 
   @tracked activeTabSlugForLeftPane = 'logs'; // 'logs' | 'autofix'
@@ -62,7 +64,7 @@ export default class TestResultsBar extends Component<Signature> {
       if (courseStageStep.courseStage.isFirst) {
         return ['logs'];
       } else {
-        if (this.authenticator.currentUser?.isStaff && this.autofixRequestForActiveStep) {
+        if (this.featureFlags.canViewAutofixFlow && this.autofixRequestForActiveStep) {
           return ['logs', 'autofix'];
         } else {
           return ['logs'];

--- a/app/controllers/course/stage/instructions.ts
+++ b/app/controllers/course/stage/instructions.ts
@@ -3,6 +3,7 @@ import { inject as service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 import type AuthenticatorService from 'codecrafters-frontend/services/authenticator';
 import type CoursePageStateService from 'codecrafters-frontend/services/course-page-state';
+import type FeatureFlagsService from 'codecrafters-frontend/services/feature-flags';
 import type CourseStageModel from 'codecrafters-frontend/models/course-stage';
 import type RepositoryModel from 'codecrafters-frontend/models/repository';
 import type CourseStageStep from 'codecrafters-frontend/utils/course-page-step-list/course-stage-step';
@@ -13,6 +14,7 @@ import type Store from '@ember-data/store';
 export default class CourseStageInstructionsController extends Controller {
   @service declare authenticator: AuthenticatorService;
   @service declare coursePageState: CoursePageStateService;
+  @service declare featureFlags: FeatureFlagsService;
   @service declare router: RouterService;
   @service declare store: Store;
 
@@ -62,8 +64,7 @@ export default class CourseStageInstructionsController extends Controller {
 
   @action
   handleDidUpdateTestsStatus(_element: HTMLDivElement, [newTestsStatus]: [CourseStageStep['testsStatus']]) {
-    // TODO: Add a feature flag here
-    if (this.authenticator.currentUser?.isStaff) {
+    if (this.featureFlags.canViewAutofixFlow) {
       // For tests passed, let's collapse the test results bar and scroll all the way to the top
       if (newTestsStatus === 'passed') {
         this.coursePageState.testResultsBarIsExpanded = false;

--- a/app/services/feature-flags.ts
+++ b/app/services/feature-flags.ts
@@ -14,6 +14,10 @@ export default class FeatureFlagsService extends Service {
     this.notifiedFeatureFlags = new Set();
   }
 
+  get canViewAutofixFlow(): boolean {
+    return !!(this.getFeatureFlagValue('can-view-autofix-flow') === 'test' || this.currentUser?.isStaff);
+  }
+
   get currentUser(): User | null {
     return this.authenticator.currentUser;
   }


### PR DESCRIPTION
Add a new feature flag `canViewAutofixFlow` to control access to the
autofix flow based on the 'autofix_flow' flag or staff user status.
Update course-page and course stage instructions components to use this
flag for conditionally displaying the autofix tab and enabling related
behaviors, replacing previous staff-only checks. This allows gradual
rollout of autofix features via feature flags.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduce `canViewAutofixFlow` flag and use it to conditionally show the Autofix tab and control test results bar behavior, replacing staff-only checks.
> 
> - **Feature Flags**
>   - Add `FeatureFlagsService.canViewAutofixFlow` (enabled when `getFeatureFlagValue('can-view-autofix-flow') === 'test'` or `currentUser.isStaff`).
> - **Course Page UI**
>   - `app/components/course-page/test-results-bar/index.ts`:
>     - Use `featureFlags.canViewAutofixFlow` to include `autofix` in `availableTabSlugs` when an `autofixRequest` exists.
>     - Inject `FeatureFlagsService`.
>   - `app/controllers/course/stage/instructions.ts`:
>     - Drive test results bar expand/collapse via `featureFlags.canViewAutofixFlow` (expand on `evaluating`, collapse on `passed`; otherwise only scroll to top on `passed`).
>     - Inject `FeatureFlagsService`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 33ca40d94b4d9b49302d65c58f2f8a6b2c9665d0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->