### PR TITLE
chore: bump app major version to 42.0 for client update

### DIFF
--- a/config/environment.js
+++ b/config/environment.js
@@ -53,7 +53,7 @@ module.exports = function (environment) {
 
       // Update the major version number to force all clients to update.
       // The minor version doesn't do anything at the moment, might use in the future.
-      version: `41.0.${process.env.VERCEL_GIT_COMMIT_SHA?.slice(0, 7) || 'dev'}`,
+      version: `42.0.${process.env.VERCEL_GIT_COMMIT_SHA?.slice(0, 7) || 'dev'}`,
     },
 
     fastboot: {


### PR DESCRIPTION
Update the major version number from 41.0 to 42.0 in the environment
configuration to force all clients to update. This ensures that clients
will use the latest code changes and prevents compatibility issues.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Bumps `ENV.x.version` from `41.0` to `42.0` in `config/environment.js`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9cb98d79255f856abb8327a68b8ace9ec88d75b6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->