### PR TITLE
fix(ui): add dark mode background to file tree preview container

### DIFF
--- a/app/components/course-page/setup-step-complete-modal/workflow-tutorial-step1-screen.hbs
+++ b/app/components/course-page/setup-step-complete-modal/workflow-tutorial-step1-screen.hbs
@@ -14,7 +14,9 @@
       </p>
     </div>
 
-    <div class="w-full h-48 mb-4 bg-white border border-gray-200 dark:border-gray-700 rounded-sm flex flex-col items-stretch justify-center p-4">
+    <div
+      class="w-full h-48 mb-4 bg-white dark:bg-gray-925 border border-gray-200 dark:border-gray-700 rounded-sm flex flex-col items-stretch justify-center p-4"
+    >
       <FileTreePreview @rootFolder={{this.rootFolderForfileTreePreview}} />
     </div>
 


### PR DESCRIPTION
Update the workflow tutorial step 1 screen to apply a dark background
color (dark:bg-gray-925) to the file tree preview container. This 
ensures
Better visual consistency and readability in dark mode themes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Apply a dark-mode background (`dark:bg-gray-925`) to the file tree preview container on the workflow tutorial step 1 screen.
> 
> - **UI**:
>   - **Workflow Tutorial Step 1**: Add `dark:bg-gray-925` to the `FileTreePreview` container for proper dark-mode styling.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 27a2d7af9fcc821f542afc443a73dbd68624c2be. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->