### PR TITLE
refactor(ui): separate explanation and diff overlays in autofix card

### DIFF
--- a/app/components/course-page/test-results-bar/autofix-request-card.hbs
+++ b/app/components/course-page/test-results-bar/autofix-request-card.hbs
@@ -18,7 +18,7 @@
       {{/if}}
     {{/animated-value}}
 
-    {{#if (eq @autofixRequest.status "in_progress")}}
+    {{#animated-if (eq @autofixRequest.status "in_progress") use=this.transition duration=200}}
       <CoursePage::TestResultsBar::AutofixRequestCard::LogstreamSection class="mt-3" @autofixRequest={{@autofixRequest}} />
     {{else}}
       <BlurredOverlay @isBlurred={{this.explanationIsBlurred}} @overlayClass="bg-gray-950/20" class="-mx-4 -mb-4">
@@ -40,7 +40,7 @@
         </:overlay>
       </BlurredOverlay>
 
-      {{#unless this.explanationIsBlurred}}
+      {{#animated-if (not this.explanationIsBlurred) use=this.transition duration=200}}
         <BlurredOverlay @isBlurred={{this.diffIsBlurred}} @overlayClass="bg-gray-950/20" class="-mx-4 -mb-4">
           <:content>
             <div class="p-4 flex flex-col gap-6">
@@ -66,7 +66,7 @@
             {{/if}}
           </:overlay>
         </BlurredOverlay>
-      {{/unless}}
-    {{/if}}
+      {{/animated-if}}
+    {{/animated-if}}
   </AnimatedContainer>
 </div>


### PR DESCRIPTION
- Moved the diff content and its blurred overlay outside the 
explanation's overlay - Improved clarity and user interaction by 
enabling independent blurring of explanation and code diffs - Fixed 
- layering issues
- Prepared the UI for more flexible states when displaying autofix 
- requests

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Splits explanation and diff into independent blurred overlays with animated transitions and updated overlay actions.
> 
> - **UI (autofix request card)**:
>   - **Separate overlays**: Explanation and code diff moved into distinct `BlurredOverlay` blocks; diff renders only when `explanationIsBlurred` is false.
>   - **Animations**: Wrap `in_progress` section and diff block with `animated-if` using `this.transition` (`duration=200`).
>   - **Actions**: Explanation overlay button changed to “Explain more?” calling `handleShowExplanationButtonClick`; diff overlay retains “Show fixed code.”
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a3beab561e68d07a958826b6d55a0dd3c025d6d8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->