### PR TITLE
feat: add 'internal' creatorType to autofix requests

### DIFF
--- a/app/components/course-page/test-results-bar/index.ts
+++ b/app/components/course-page/test-results-bar/index.ts
@@ -50,7 +50,7 @@ export default class TestResultsBar extends Component<Signature> {
 
     return (
       (this.args.repository.lastSubmission?.autofixRequests || [])
-        .filter((request) => !request.creatorTypeIsStaff)
+        .filter((request) => !request.creatorTypeIsStaffOrInternal)
         .filter((request) => request.submission === this.args.repository.lastSubmission)
         .filter((request) => request.submission.courseStage === courseStageStep.courseStage)
         .at(-1) || null

--- a/app/models/autofix-request.ts
+++ b/app/models/autofix-request.ts
@@ -7,7 +7,7 @@ export default class AutofixRequestModel extends Model {
   @belongsTo('submission', { async: false, inverse: 'autofixRequests' }) declare submission: SubmissionModel;
   @belongsTo('repository', { async: false, inverse: 'autofixRequests' }) declare repository: RepositoryModel;
 
-  @attr('string') declare creatorType: 'user' | 'system' | 'staff';
+  @attr('string') declare creatorType: 'user' | 'system' | 'staff' | 'internal';
   @attr() declare changedFiles: { diff: string; filename: string }[]; // free-form JSON
   @attr('date') declare createdAt: Date;
   @attr('string') declare explanationMarkdown: string;
@@ -21,8 +21,8 @@ export default class AutofixRequestModel extends Model {
     return `${config.x.backendUrl}/admin/autofix_requests/${this.id}`;
   }
 
-  get creatorTypeIsStaff() {
-    return this.creatorType === 'staff';
+  get creatorTypeIsStaffOrInternal() {
+    return this.creatorType === 'staff' || this.creatorType === 'internal';
   }
 
   get logs(): string {


### PR DESCRIPTION
Extend AutofixRequest model to include a new creatorType 'internal'
alongside 'staff'. Update the creatorTypeIsStaff getter to also check
for 'internal' creators. Modify filtering logic in test-results-bar to
exclude autofix requests from both staff and internal creators when
determining the last applicable request. This change clarifies and
improves the classification of autofix request creators for more
accurate handling in the UI.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds 'internal' creatorType to `AutofixRequest` and updates the test results bar to ignore staff/internal requests when selecting the latest applicable autofix.
> 
> - **Model (`app/models/autofix-request.ts`)**:
>   - Extend `creatorType` union to include `"internal"`.
>   - Replace `creatorTypeIsStaff` with `creatorTypeIsStaffOrInternal` to cover both `"staff"` and `"internal"`.
> - **UI (`app/components/course-page/test-results-bar/index.ts`)**:
>   - Update autofix selection filter to use `!request.creatorTypeIsStaffOrInternal`, excluding staff/internal requests from consideration.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2516c475b8c738bd6803f3823d465026e5889bc3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->