### PR TITLE
fix(ui): always show "Explain more?" button and improve fixed code toggle

### DIFF
--- a/app/components/course-page/test-results-bar/autofix-request-card.hbs
+++ b/app/components/course-page/test-results-bar/autofix-request-card.hbs
@@ -29,20 +29,25 @@
         </:content>
 
         <:overlay>
-          {{#if (eq @autofixRequest.status "success")}}
-            <SecondaryButton class="bg-gray-900 mt-10" {{on "click" this.handleShowExplanationButtonClick}}>
-              <div class="flex items-center gap-2">
-                <div class="flex">{{svg-jar "eye" class="size-6"}}</div>
-                Explain more?
-              </div>
-            </SecondaryButton>
-          {{/if}}
+          <SecondaryButton class="bg-gray-900 mt-2" {{on "click" this.handleShowExplanationButtonClick}}>
+            <div class="flex items-center gap-2">
+              <div class="flex">{{svg-jar "eye" class="size-6"}}</div>
+              Explain more?
+            </div>
+          </SecondaryButton>
         </:overlay>
       </BlurredOverlay>
 
       {{#animated-if (not this.explanationIsBlurred) use=this.transition duration=200}}
-        <BlurredOverlay @isBlurred={{this.diffIsBlurred}} @overlayClass="bg-gray-950/20" class="-mx-4 -mb-4">
-          <:content>
+        <div>
+          {{#animated-if this.diffIsBlurred use=this.transition duration=200}}
+            <SecondaryButton class="bg-gray-900" {{on "click" this.handleShowFixedCodeButtonClick}}>
+              <div class="flex items-center gap-2">
+                <div class="flex">{{svg-jar "eye" class="size-6"}}</div>
+                Show fixed code
+              </div>
+            </SecondaryButton>
+          {{else}}
             <div class="p-4 flex flex-col gap-6">
               {{#each this.changedFilesForRender key="filename" as |changedFile|}}
                 <FileDiffCard
@@ -54,18 +59,8 @@
                 />
               {{/each}}
             </div>
-          </:content>
-          <:overlay>
-            {{#if (eq @autofixRequest.status "success")}}
-              <SecondaryButton class="bg-gray-900 mt-10" {{on "click" this.handleShowFixedCodeButtonClick}}>
-                <div class="flex items-center gap-2">
-                  <div class="flex">{{svg-jar "eye" class="size-6"}}</div>
-                  Show fixed code
-                </div>
-              </SecondaryButton>
-            {{/if}}
-          </:overlay>
-        </BlurredOverlay>
+          {{/animated-if}}
+        </div>
       {{/animated-if}}
     {{/animated-if}}
   </AnimatedContainer>


### PR DESCRIPTION
Remove conditional rendering on the "Explain more?" button so it is 
always visible regardless of autofix request status. Refactor overlay 
logic by replacing BlurredOverlay wrappers with simpler divs and nested 
animated-if blocks. This streamlines showing the "Show fixed code" 
button only when diffs
are blurred, improving clarity and user interaction flow.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Always show the "Explain more?" button and replace BlurredOverlay with animated toggles to show the "Show fixed code" button only when diffs are blurred.
> 
> - **UI (AutofixRequestCard)**
>   - Always show `"Explain more?"` button in the explanation overlay (remove status-based condition).
>   - Replace `BlurredOverlay` around diffs with a simple `div` and nested `animated-if` logic:
>     - Show `"Show fixed code"` button when `diffIsBlurred`.
>     - Render file diffs when not blurred.
>   - Minor spacing tweak on the `"Explain more?"` button (`mt-2`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 881592c7bf130e6139e370a4bf69c9e1db8dd52f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->