### PR TITLE
style: reduce top margin of Explain more button to mt-6

### DIFF
--- a/app/components/course-page/test-results-bar/autofix-request-card.hbs
+++ b/app/components/course-page/test-results-bar/autofix-request-card.hbs
@@ -30,7 +30,7 @@
 
         <:overlay>
           {{#if (eq @autofixRequest.status "success")}}
-            <SecondaryButton class="bg-gray-900 mt-10" {{on "click" this.handleShowExplanationButtonClick}}>
+            <SecondaryButton class="bg-gray-900 mt-6" {{on "click" this.handleShowExplanationButtonClick}}>
               <div class="flex items-center gap-2">
                 <div class="flex">{{svg-jar "eye" class="size-6"}}</div>
                 Explain more?


### PR DESCRIPTION
Decrease the top margin of the Explain more button in the autofix
request card component from mt-10 to mt-6 to improve visual spacing
and alignment. This change enhances the UI consistency and overall
appearance on the course page test results bar.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Reduce top margin of the "Explain more?" SecondaryButton in `app/components/course-page/test-results-bar/autofix-request-card.hbs` from `mt-10` to `mt-6`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e166b489172283f7f427ec7707ec696f12dfe285. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->