### PR TITLE
fix(autofix-request-card): simplify animated-if usage and reorder overlays

### DIFF
--- a/app/components/course-page/test-results-bar/autofix-request-card.hbs
+++ b/app/components/course-page/test-results-bar/autofix-request-card.hbs
@@ -18,7 +18,8 @@
       {{/if}}
     {{/animated-value}}
 
-    {{#animated-if (eq @autofixRequest.status "in_progress") use=this.transition duration=200}}
+    {{! Investigate issue with animated-if usage here }}
+    {{#if (eq @autofixRequest.status "in_progress")}}
       <CoursePage::TestResultsBar::AutofixRequestCard::LogstreamSection class="mt-3" @autofixRequest={{@autofixRequest}} />
     {{else}}
       <div>
@@ -69,6 +70,6 @@
           </BlurredOverlay>
         {{/animated-if}}
       </div>
-    {{/animated-if}}
+    {{/if}}
   </AnimatedContainer>
 </div>


### PR DESCRIPTION
Replace animated-if with plain if for in_progress status to avoid issues
with animation behavior. Reorganize BlurredOverlay sections for better
clarity: show explanation markdown with overlay first, then animate the
display of changed files with their overlay. Update button labels and
spacing to improve user experience when showing explanations and fixed
code. These changes fix UI glitches and enhance code readability.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Switches from animated-if to plain if for the in-progress log stream and restructures overlays to show explanation first, then animate the diff reveal.
> 
> - **UI (autofix request card `app/components/course-page/test-results-bar/autofix-request-card.hbs`)**:
>   - **Control flow**: Replace `{{#animated-if}}` with `{{#if}}` for `in_progress` state around `LogstreamSection`.
>   - **Overlay restructure**:
>     - Show explanation markdown in `BlurredOverlay` first with "Explain more?" action.
>     - Animate display of changed files in a second `BlurredOverlay` using `{{#animated-if (not this.explanationIsBlurred)}}` with "Show fixed code" action.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 281e63d124c46b5d109eeeb5abc17ea3b89e0f1c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->