### PR TITLE
feat(course-page): add "Copy ID" option for staff users

### DIFF
--- a/app/components/course-page/course-stage-step/community-solution-card/more-dropdown.hbs
+++ b/app/components/course-page/course-stage-step/community-solution-card/more-dropdown.hbs
@@ -19,6 +19,10 @@
       {{/if}}
 
       <DropdownLink @text="Collapse example" @icon="x-circle" {{on "click" (fn this.handleCollapseExampleLinkClick dd.actions)}} />
+
+      {{#if (current-user-is-staff)}}
+        <DropdownLink @text="Copy ID" @icon="clipboard-copy" {{on "click" (fn this.handleCopyIdLinkClick dd.actions)}} data-test-copy-id-link />
+      {{/if}}
     </div>
   </dd.Content>
 </BasicDropdown>

--- a/app/components/course-page/course-stage-step/community-solution-card/more-dropdown.ts
+++ b/app/components/course-page/course-stage-step/community-solution-card/more-dropdown.ts
@@ -21,6 +21,12 @@ export default class MoreDropdown extends Component<Signature> {
   }
 
   @action
+  async handleCopyIdLinkClick(dropdownActions: { close: () => void }) {
+    await navigator.clipboard.writeText(this.args.solution.id);
+    dropdownActions.close();
+  }
+
+  @action
   handleViewFullDiffLinkClick(dropdownActions: { close: () => void }) {
     this.args.onDiffSourceChange('changed-files');
     dropdownActions.close();


### PR DESCRIPTION
Add a "Copy ID" link to the community solution card dropdown menu, visible
only to staff users. Clicking the link copies the solution ID to the
clipboard and closes the dropdown. This improves staff workflow by allowing
quick access to solution IDs without manual selection.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a staff-only "Copy ID" action to the community solution card dropdown that copies the solution ID to the clipboard and closes the menu.
> 
> - **Community Solution Card dropdown (`more-dropdown`)**:
>   - Template (`app/components/.../more-dropdown.hbs`):
>     - Adds staff-only `Copy ID` `DropdownLink` with `clipboard-copy` icon and `data-test-copy-id-link`.
>   - Component (`app/components/.../more-dropdown.ts`):
>     - Implements `handleCopyIdLinkClick` action to write `this.args.solution.id` to `navigator.clipboard` and close the dropdown.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6cc8f66367575ca871b414488dfa78577ac48e19. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->