### PR TITLE
style(ui): add dark mode support for gift payment pages

### DIFF
--- a/app/components/gift-payment-page/choose-plan-step-container.hbs
+++ b/app/components/gift-payment-page/choose-plan-step-container.hbs
@@ -3,9 +3,17 @@
     {{#each this.pricingPlans as |plan|}}
       <div
         class="flex items-start justify-between border
-          {{if (eq @giftPaymentFlow.pricingPlanId plan.id) 'border-teal-500' 'border-gray-200 hover:border-gray-300'}}
+          {{if
+            (eq @giftPaymentFlow.pricingPlanId plan.id)
+            'border-teal-500 dark:border-teal-400'
+            'border-gray-200 dark:border-white/10 hover:border-gray-300 dark:hover:border-white/20'
+          }}
           rounded p-4
-          {{if (eq @giftPaymentFlow.pricingPlanId plan.id) 'bg-teal-50' 'bg-white hover:bg-gray-50'}}"
+          {{if
+            (eq @giftPaymentFlow.pricingPlanId plan.id)
+            'bg-teal-50 dark:bg-teal-950/30'
+            'bg-white dark:bg-gray-925 hover:bg-gray-50 dark:hover:bg-gray-900'
+          }}"
         role="button"
         {{on "click" (fn this.handlePlanSelect plan)}}
         data-test-plan-card
@@ -13,25 +21,25 @@
         <div class="flex items-start gap-3">
           <div
             class="flex-shrink-0 flex items-center justify-center w-4 h-4 border rounded-full mt-0.5
-              {{if (eq @giftPaymentFlow.pricingPlanId plan.id) 'border-teal-500' 'border-gray-400'}}"
+              {{if (eq @giftPaymentFlow.pricingPlanId plan.id) 'border-teal-500 dark:border-teal-400' 'border-gray-400 dark:border-gray-600'}}"
           >
             {{#if (eq @giftPaymentFlow.pricingPlanId plan.id)}}
-              <div class="w-2.5 h-2.5 bg-teal-500 rounded-full"></div>
+              <div class="w-2.5 h-2.5 bg-teal-500 dark:bg-teal-400 rounded-full"></div>
             {{/if}}
           </div>
 
           <div>
             <div class="flex items-center gap-x-1.5">
-              <span class="text-gray-600 font-bold text-sm">
+              <span class="text-gray-600 dark:text-gray-300 font-bold text-sm">
                 {{plan.title}}
                 pass
               </span>
               {{#if (eq plan.validityInMonths 12)}}
-                <span class="inline-block bg-teal-500 text-white font-bold rounded px-1.5 py-1 text-xxs uppercase">popular</span>
+                <span class="inline-block bg-teal-500 dark:bg-teal-600 text-white font-bold rounded px-1.5 py-1 text-xxs uppercase">popular</span>
               {{/if}}
             </div>
 
-            <div class="prose prose-xs prose-compact mt-1 text-gray-500">
+            <div class="prose prose-xs prose-compact dark:prose-invert mt-1 text-gray-500 dark:text-gray-400">
               {{#if plan.validityInMonths}}
                 <p>
                   Access to all membership benefits for
@@ -47,7 +55,7 @@
         </div>
 
         <div class="flex flex-col items-end pl-4 flex-shrink-0">
-          <div class="text-gray-600 font-bold">
+          <div class="text-gray-600 dark:text-gray-300 font-bold">
             ${{plan.priceInDollars}}
           </div>
         </div>
@@ -56,7 +64,7 @@
   </div>
 
   <div class="mt-6 flex gap-4 justify-between items-stretch sm:items-center flex-col-reverse sm:flex-row">
-    <div class="text-xs text-gray-500 text-center">
+    <div class="text-xs text-gray-500 dark:text-gray-400 text-center">
       Your total will be ${{this.selectedPlan.priceInDollars}}.
     </div>
 

--- a/app/components/gift-payment-page/confirm-and-pay-step-container.hbs
+++ b/app/components/gift-payment-page/confirm-and-pay-step-container.hbs
@@ -1,21 +1,27 @@
 <GiftPaymentPage::StepContainer @title="Confirm & Pay" data-test-confirm-and-pay-step-container>
   <Alert @color="blue" class="mb-3">
     <div>
-      <div class="prose prose-blue prose-xs prose-compact">
-        <h4>
-          Your membership gift details
+      <div class="prose prose-blue prose-xs prose-compact dark:prose-invert">
+        <h4 class="border-b pb-0.5 border-blue-500/60 inline-block">
+          Gift details
         </h4>
 
         <ul>
           <li>
             You are purchasing a
             <b>{{this.selectedPlan.title}} pass</b>
-            gift (<button type="button" class="underline cursor-pointer" {{on "click" (fn @onNavigationItemClick 2)}}>change</button>)
+            gift
+
+            <span class="whitespace-nowrap">
+              (<button type="button" class="underline cursor-pointer" {{on "click" (fn @onNavigationItemClick 2)}}>change</button>)
+            </span>
           </li>
           <li>
             Your payment receipt will be sent to
             <b>{{@giftPaymentFlow.senderEmailAddress}}</b>
-            (<button type="button" class="underline cursor-pointer" {{on "click" (fn @onNavigationItemClick 1)}}>change</button>)
+            <span class="whitespace-nowrap">
+              (<button type="button" class="underline cursor-pointer" {{on "click" (fn @onNavigationItemClick 1)}}>change</button>)
+            </span>
           </li>
         </ul>
       </div>
@@ -23,8 +29,8 @@
   </Alert>
 
   <Alert @color="teal" class="mt-3">
-    <div class="prose prose-xs prose-green prose-compact">
-      <h4>
+    <div class="prose prose-xs prose-green prose-compact dark:prose-invert">
+      <h4 class="border-b pb-0.5 border-green-500/60 inline-block">
         Next steps
       </h4>
 
@@ -40,9 +46,9 @@
     </div>
   </Alert>
 
-  <div class="bg-gray-50/50 rounded-sm border border-gray-200 p-3 mt-3">
-    <div class="prose prose-xs prose-compact">
-      <h4>
+  <div class="bg-gray-50/50 dark:bg-gray-900/50 rounded-sm border border-gray-200 dark:border-white/10 p-3 mt-3">
+    <div class="prose prose-xs prose-compact dark:prose-invert">
+      <h4 class="border-b pb-0.5 border-gray-500/60 inline-block">
         Expiry and refunds
       </h4>
 
@@ -60,15 +66,15 @@
     </div>
   </div>
 
-  <div class="h-px bg-gray-100 mt-6 mb-6"></div>
+  <div class="h-px bg-gray-100 dark:bg-white/10 mt-6 mb-6"></div>
 
   <div class="flex gap-4 justify-between items-stretch sm:items-center flex-col-reverse sm:flex-row">
     {{#if this.errorMessage}}
-      <div class="text-red-600 text-sm font-semibold">
+      <div class="text-red-600 dark:text-red-400 text-sm font-semibold">
         {{this.errorMessage}}
       </div>
     {{else}}
-      <div class="text-xs text-gray-500 text-center">
+      <div class="text-xs text-gray-500 dark:text-gray-400 text-center">
         Payments are processed securely using Stripe.
       </div>
     {{/if}}

--- a/app/components/gift-payment-page/enter-details-step-container.hbs
+++ b/app/components/gift-payment-page/enter-details-step-container.hbs
@@ -5,30 +5,30 @@
         @value={{@giftPaymentFlow.senderEmailAddress}}
         @type="email"
         {{on "blur" this.handleInputBlur}}
-        class="text-sm rounded-sm px-3 py-2 placeholder-gray-300 focus:outline-hidden focus:ring-2 focus:ring-teal-500 border border-gray-200 w-full"
+        class="text-sm rounded-sm px-3 py-2 placeholder-gray-300 dark:placeholder-gray-700 focus:outline-hidden focus:ring-2 focus:ring-teal-500 border border-gray-200 dark:border-white/10 w-full text-gray-950 dark:text-gray-100 bg-white dark:bg-gray-925"
         id="sender_email_address_input"
         placeholder="john@example.com"
         required
       />
     </GiftPaymentPage::GiftDetailsForm::Section>
 
-    <div class="h-px bg-gray-100 mt-6 mb-6"></div>
+    <div class="h-px bg-gray-100 dark:bg-white/10 mt-6 mb-6"></div>
 
     <GiftPaymentPage::GiftDetailsForm::Section @title="Gift Message" @description="Optional. You can edit this after purchase.">
       <Textarea
         @value={{@giftPaymentFlow.giftMessage}}
         {{on "blur" this.handleInputBlur}}
-        class="text-sm rounded-sm px-3 py-2 placeholder-gray-300 focus:outline-hidden focus:ring-2 focus:ring-teal-500 border border-gray-200 w-full"
+        class="text-sm rounded-sm px-3 py-2 placeholder-gray-300 dark:placeholder-gray-700 focus:outline-hidden focus:ring-2 focus:ring-teal-500 border border-gray-200 dark:border-white/10 w-full text-gray-950 dark:text-gray-100 bg-white dark:bg-gray-925"
         id="gift_message_input"
         placeholder={{this.giftMessageInputPlaceholder}}
         rows="5"
       />
     </GiftPaymentPage::GiftDetailsForm::Section>
 
-    <div class="h-px bg-gray-100 mt-6 mb-6"></div>
+    <div class="h-px bg-gray-100 dark:bg-white/10 mt-6 mb-6"></div>
 
     <div class="flex gap-4 justify-between items-stretch sm:items-center flex-col-reverse sm:flex-row">
-      <div class="text-xs text-gray-500">
+      <div class="text-xs text-gray-500 dark:text-gray-400">
         You'll receive a gift link that you can send to the recipient.
       </div>
       <div>

--- a/app/components/gift-payment-page/gift-details-form/section.hbs
+++ b/app/components/gift-payment-page/gift-details-form/section.hbs
@@ -1,7 +1,7 @@
 <div class="grid grid-cols-1 sm:grid-cols-2">
   <div class="pb-6 pr-0 sm:pb-0 sm:pr-4">
-    <div class="text-gray-700 font-semibold text-lg mb-1">{{@title}}</div>
-    <div class="text-gray-400 text-xs">{{@description}}</div>
+    <div class="text-gray-700 dark:text-gray-300 font-semibold text-lg mb-1">{{@title}}</div>
+    <div class="text-gray-400 dark:text-gray-600 text-xs">{{@description}}</div>
   </div>
 
   <div>

--- a/app/components/gift-payment-page/navigation-container-item.hbs
+++ b/app/components/gift-payment-page/navigation-container-item.hbs
@@ -1,9 +1,9 @@
 <div class="relative hover:opacity-100 {{unless (or @isComplete @isCurrent) 'cursor-not-allowed'}}" role="button" ...attributes>
   <div
     class="h-4 w-4
-      {{if (or @isComplete @isCurrent) 'bg-teal-500' 'bg-gray-300'}}
+      {{if (or @isComplete @isCurrent) 'bg-teal-500' 'bg-gray-300 dark:bg-gray-700'}}
       border-2
-      {{if (or @isComplete @isCurrent) 'border-teal-500' 'border-gray-300'}}
+      {{if (or @isComplete @isCurrent) 'border-teal-500' 'border-gray-300 dark:border-gray-700'}}
       rounded-full"
   >
     {{#if @isComplete}}
@@ -13,7 +13,7 @@
 
   <div
     class="absolute -left-20 -right-20 top-6 text-center uppercase font-semibold text-xs sm:text-base
-      {{if (or @isComplete @isCurrent) 'text-teal-500' 'text-gray-300'}}"
+      {{if (or @isComplete @isCurrent) 'text-teal-500 dark:text-teal-400' 'text-gray-300 dark:text-gray-600'}}"
   >
     {{@name}}
   </div>

--- a/app/components/gift-payment-page/navigation-container.hbs
+++ b/app/components/gift-payment-page/navigation-container.hbs
@@ -6,7 +6,7 @@
     {{on "click" (fn @onNavigationItemClick 1)}}
   />
 
-  <div class="h-0.5 w-16 sm:w-40 {{if (gt @currentStep 1) 'bg-teal-500' 'bg-gray-200'}} ml-4 mr-4"></div>
+  <div class="h-0.5 w-16 sm:w-40 {{if (gt @currentStep 1) 'bg-teal-500' 'bg-gray-200 dark:bg-white/10'}} ml-4 mr-4"></div>
 
   <GiftPaymentPage::NavigationContainerItem
     @isComplete={{includes 2 @completedSteps}}
@@ -15,7 +15,7 @@
     {{on "click" (fn @onNavigationItemClick 2)}}
   />
 
-  <div class="h-0.5 w-16 sm:w-40 {{if (gt @currentStep 2) 'bg-teal-500' 'bg-gray-200'}} ml-4 mr-4"></div>
+  <div class="h-0.5 w-16 sm:w-40 {{if (gt @currentStep 2) 'bg-teal-500' 'bg-gray-200 dark:bg-white/10'}} ml-4 mr-4"></div>
 
   <GiftPaymentPage::NavigationContainerItem
     @isComplete={{includes 3 @completedSteps}}

--- a/app/components/gift-payment-page/step-container.hbs
+++ b/app/components/gift-payment-page/step-container.hbs
@@ -1,6 +1,6 @@
-<div class="w-full max-w-xl bg-white border border-gray-200 rounded-sm p-6" ...attributes>
-  <div class="text-gray-700 font-bold mb-1 uppercase">{{@title}}</div>
-  <div class="h-px bg-gray-100 mt-2 mb-6"></div>
+<div class="w-full max-w-xl bg-white dark:bg-gray-925 border border-gray-200 dark:border-white/10 rounded-sm p-6" ...attributes>
+  <div class="text-gray-700 dark:text-gray-300 font-bold mb-1 uppercase">{{@title}}</div>
+  <div class="h-px bg-gray-100 dark:bg-white/10 mt-2 mb-6"></div>
 
   {{yield}}
 </div>

--- a/app/routes/gifts/buy.ts
+++ b/app/routes/gifts/buy.ts
@@ -10,7 +10,7 @@ export default class GiftsPayRoute extends BaseRoute {
   @service declare store: Store;
 
   buildRouteInfoMetadata() {
-    return new RouteInfoMetadata({ allowsAnonymousAccess: true, colorScheme: RouteColorScheme.Light });
+    return new RouteInfoMetadata({ allowsAnonymousAccess: true, colorScheme: RouteColorScheme.Both });
   }
 
   async model(params: { giftPaymentFlowId?: string }): Promise<ModelType> {

--- a/app/templates/gifts/buy.hbs
+++ b/app/templates/gifts/buy.hbs
@@ -2,7 +2,9 @@
 
 <div class="container mx-auto lg:max-w-(--breakpoint-lg) pt-16 pb-48 px-3 md:px-6">
   <div class="flex flex-col items-center">
-    <h1 class="text-center text-3xl text-gray-700 font-bold tracking-tighter mb-12">Gift a CodeCrafters membership</h1>
+    <h1
+      class="text-center text-3xl leading-9 text-gradient-to-b from-gray-950 to-gray-700 dark:from-white dark:to-gray-300 font-bold tracking-tighter mb-12"
+    >Gift a CodeCrafters membership</h1>
 
     {{#if false}}
       {{! TODO: Add success step }}
@@ -15,20 +17,15 @@
       />
 
       <AnimatedContainer class="w-full max-w-xl">
-        {{#animated-if (eq this.currentStep 1) use=this.transition duration=200}}
-          <GiftPaymentPage::EnterDetailsStepContainer @giftPaymentFlow={{this.model}} @onContinueButtonClick={{this.handleContinueButtonClick}} />
-        {{else}}
-          {{#animated-if (eq this.currentStep 2) use=this.transition duration=200}}
+        {{#animated-value this.currentStep use=this.transition duration=200 as |step|}}
+          {{#if (eq step 1)}}
+            <GiftPaymentPage::EnterDetailsStepContainer @giftPaymentFlow={{this.model}} @onContinueButtonClick={{this.handleContinueButtonClick}} />
+          {{else if (eq step 2)}}
             <GiftPaymentPage::ChoosePlanStepContainer @giftPaymentFlow={{this.model}} @onContinueButtonClick={{this.handleContinueButtonClick}} />
-          {{else}}
-            {{#animated-if (eq this.currentStep 3) use=this.transition duration=200}}
-              <GiftPaymentPage::ConfirmAndPayStepContainer
-                @giftPaymentFlow={{this.model}}
-                @onNavigationItemClick={{this.handleNavigationItemClick}}
-              />
-            {{/animated-if}}
-          {{/animated-if}}
-        {{/animated-if}}
+          {{else if (eq step 3)}}
+            <GiftPaymentPage::ConfirmAndPayStepContainer @giftPaymentFlow={{this.model}} @onNavigationItemClick={{this.handleNavigationItemClick}} />
+          {{/if}}
+        {{/animated-value}}
       </AnimatedContainer>
     {{/if}}
   </div>


### PR DESCRIPTION
Update styling for gift payment components to improve dark mode
support by adding appropriate dark variants for backgrounds,
text, borders, and placeholders. Enhance visual consistency and
accessibility in dark theme, including input fields, dividers,
plan selection cards, and container backgrounds.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds dark mode styling across gift payment pages, enables dark color scheme for the route, and refactors step transitions to use animated-value.
> 
> - **UI (Gift payment flow)**
>   - Add dark mode variants for backgrounds, text, borders, placeholders, and prose across `step-container`, `enter-details`, `choose-plan`, `confirm-and-pay`, and navigation components.
>   - Tweak plan card selection states, badges, dividers, and alert section headers (bordered titles).
> - **Routing**
>   - Set `RouteColorScheme.Both` in `app/routes/gifts/buy.ts`.
> - **Templates/Animation**
>   - Replace nested `animated-if` with `animated-value` for step transitions in `app/templates/gifts/buy.hbs`.
>   - Update page title styling (gradient) and minor layout tweaks (e.g., `whitespace-nowrap`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3e4a87776ccbfdc9a275db11e944680269b9b738. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->