### PR TITLE
test: update toggle-diff-source-test to expect 3 links

### DIFF
--- a/tests/acceptance/course-page/code-examples/toggle-diff-source-test.js
+++ b/tests/acceptance/course-page/code-examples/toggle-diff-source-test.js
@@ -34,14 +34,14 @@ module('Acceptance | course-page | code-examples | toggle-diff-source', function
     const moreDropdown = codeExamplesPage.solutionCards[0].moreDropdown;
 
     await codeExamplesPage.solutionCards[0].toggleMoreDropdown();
-    await waitUntil(() => moreDropdown.links.length === 2);
+    await waitUntil(() => moreDropdown.links.length === 3);
     assert.ok(moreDropdown.hasLink('View full diff'), 'expected View full diff link to be present');
     assert.notOk(moreDropdown.hasLink('View highlighted files'), 'expected View highlighted files link to not be present');
 
     await moreDropdown.clickOnLink('View full diff');
 
     await codeExamplesPage.solutionCards[0].toggleMoreDropdown();
-    await waitUntil(() => moreDropdown.links.length === 2);
+    await waitUntil(() => moreDropdown.links.length === 3);
     assert.notOk(moreDropdown.hasLink('View full diff'), 'expected View full diff link to be removed');
     assert.ok(moreDropdown.hasLink('View highlighted files'), 'expected View highlighted files link to be present');
   });


### PR DESCRIPTION
Adjust waitUntil assertions in the toggle-diff-source-test to expect
3 links instead of 2 in the moreDropdown. This change aligns the test
with the updated application behavior where an additional link is now
present in the dropdown menu.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Update acceptance test to expect 3 links in Code Examples “more” dropdown before and after toggling “View full diff.”
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c6f12d81c92a72970dbf1785b6fc997214a7ec5c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->