### PR TITLE
fix(billing): show renewal section only for active subscriptions

### DIFF
--- a/app/templates/settings/billing.hbs
+++ b/app/templates/settings/billing.hbs
@@ -1,7 +1,7 @@
 <Settings::BillingPage::MembershipSection @user={{@model.user}} />
 <Settings::FormDivider />
 
-{{#if this.model.user.hasActiveSubscription}}
+{{#if @model.user.hasActiveSubscription}}
   <Settings::BillingPage::RenewalSection />
   <Settings::FormDivider />
 {{/if}}


### PR DESCRIPTION
Display the RenewalSection and its divider only if the user has an
active subscription. This prevents showing renewal options to users
without active subscriptions, improving clarity and user experience.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Show the renewal section and its divider only when the user has an active subscription on the billing settings page.
> 
> - **Billing Settings Template** (`app/templates/settings/billing.hbs`):
>   - Conditionally render `Settings::BillingPage::RenewalSection` and `Settings::FormDivider` only when `@model.user.hasActiveSubscription` is true.
>   - No changes to membership, support, or payment history sections.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8363e6b1b7b7dbb31cd457ac7ccf91d1c8d7825b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->