### PR TITLE
fix(affiliate-link-page): remove opacity from company logos

### DIFF
--- a/app/components/affiliate-link-page/logo-cloud.hbs
+++ b/app/components/affiliate-link-page/logo-cloud.hbs
@@ -3,7 +3,7 @@
     <div
       class="px-5 py-8 sm:px-10 sm:py-8 md:px-10 md:p-10 lg:px-8 lg:py-12 h-24 md:h-32 w-full flex items-center justify-stretch relative bg-gray-50 dark:bg-gray-925"
     >
-      <img alt={{company.name}} src={{company.image}} class="opacity-40 object-contain w-full h-full brightness-0 dark:invert dark:opacity-20" />
+      <img alt={{company.name}} src={{company.image}} class="opacity-40 object-contain w-full h-full brightness-0 dark:invert" />
     </div>
   {{/each}}
 </div>


### PR DESCRIPTION
Remove the opacity-20 class from dark mode images to improve logo
visibility while maintaining dark theme styling. This change enhances
the visual clarity of logos on the affiliate link page without 
affecting layout or overall design.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Removes the `dark:opacity-20` class from logo images in `affiliate-link-page/logo-cloud.hbs` to improve dark-mode visibility.
> 
> - **Frontend**
>   - **Affiliate Link Page** (`app/components/affiliate-link-page/logo-cloud.hbs`):
>     - Remove `dark:opacity-20` from logo `<img>` classes, keeping `dark:invert` so logos render at standard opacity in dark mode.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ec811294bb28ffec73405d4ba42a171ea32a957e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->