### PR TITLE
style: increase gift message font size to 2xl

### DIFF
--- a/app/templates/gifts/redeem.hbs
+++ b/app/templates/gifts/redeem.hbs
@@ -14,7 +14,7 @@
           </div>
 
           <div
-            class="text-gray-100 font-(family-name:--font-cursive) text-xl whitespace-pre-wrap text-center text-pretty"
+            class="text-gray-100 font-(family-name:--font-cursive) text-2xl whitespace-pre-wrap text-center text-pretty"
           >{{@model.giftMessage}}</div>
         </div>
       {{/if}}


### PR DESCRIPTION
Update the gift message font size from xl to 2xl on the redeem
page to improve readability and visual emphasis. This change
enhances the user experience by making the message more prominent.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Increase gift message font size from `text-xl` to `text-2xl` in `app/templates/gifts/redeem.hbs` to improve readability.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d0020c1ec8d7a7444de74fb7db429f3dab859761. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->