### PR TITLE
test: add gift redemption test and update redeem flow

### DIFF
--- a/app/controllers/gifts/redeem.ts
+++ b/app/controllers/gifts/redeem.ts
@@ -7,6 +7,7 @@ import type { ModelType } from 'codecrafters-frontend/routes/gifts/redeem';
 import { action } from '@ember/object';
 import { inject as service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
+import { waitFor } from '@ember/test-waiters';
 
 export default class GiftsRedeemController extends Controller {
   BYOXBanner = BYOXBanner;
@@ -33,6 +34,7 @@ export default class GiftsRedeemController extends Controller {
   }
 
   @action
+  @waitFor
   async handleRedeemButtonClick() {
     if (this.currentUserIsAnonymous) {
       this.authenticator.initiateLogin();
@@ -48,7 +50,8 @@ export default class GiftsRedeemController extends Controller {
 
     try {
       await this.model.redeem({});
-      this.router.transitionTo('catalog');
+      await this.authenticator.syncCurrentUser(); // Ensure newly created membership is available immediately
+      this.router.transitionTo('settings.billing');
     } catch (error) {
       // TODO: Handle error appropriately
       this.isRedeemingGift = false;

--- a/mirage/handlers/membership-gifts.js
+++ b/mirage/handlers/membership-gifts.js
@@ -1,3 +1,5 @@
+import CurrentMirageUser from '../utils/current-mirage-user';
+
 export default function (server) {
   server.get('/membership-gifts', function (schema, request) {
     const secretToken = request.queryParams['secret_token'];
@@ -7,5 +9,24 @@ export default function (server) {
     }
 
     return schema.membershipGifts.where({ secretToken });
+  });
+
+  server.post('/membership-gifts/:id/redeem', function (schema, request) {
+    const membershipGift = schema.membershipGifts.find(request.params.id);
+
+    if (!membershipGift) {
+      return new Response(404, {}, { error: 'Gift not found' });
+    }
+
+    membershipGift.update({ redeemedAt: new Date() });
+
+    schema.subscriptions.create({
+      user: schema.users.find(CurrentMirageUser.currentUserId),
+      source: membershipGift,
+      startDate: membershipGift.redeemedAt.toISOString(),
+      cancelAt: new Date(membershipGift.redeemedAt.getTime() + membershipGift.validityInDays * 24 * 60 * 60 * 1000).toISOString(),
+    });
+
+    return {};
   });
 }


### PR DESCRIPTION
Add a new acceptance test to verify the full gift redemption flow,
including creating a gift, redeeming it, and confirming membership 
activation on the billing page.

Enhance the redeem controller by awaiting authenticator sync after
redeeming to ensure immediate membership availability and redirect
to the billing page instead of the catalog.

Update Mirage handlers to support redeeming membership gifts by
marking gifts as redeemed and creating corresponding subscription
records with appropriate start and cancel dates.

These changes improve test coverage for the redeem feature, fix user
experience by accurate redirection, and enhance backend mocking for
gift redemption.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates gift redemption to sync user and redirect to billing, adds Mirage redeem endpoint, and adds an acceptance test for the full redemption flow.
> 
> - **Gift redemption flow**:
>   - In `app/controllers/gifts/redeem.ts`:
>     - Await `authenticator.syncCurrentUser()` post-redeem and redirect to `settings.billing` (was `catalog`).
>     - Use `@waitFor` on `handleRedeemButtonClick` to stabilize async behavior.
> - **Mirage backend**:
>   - In `mirage/handlers/membership-gifts.js`:
>     - Add `POST /membership-gifts/:id/redeem` to mark gifts redeemed and create a `subscription` for the current user with correct `startDate`/`cancelAt`.
> - **Tests**:
>   - In `tests/acceptance/redeem-gift-page/redeem-test.js`:
>     - Add test for successful redemption that lands on `/settings/billing` and shows membership active.
>     - Minor auth helper updates and tooltip assertions retained for other scenarios.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9172d075f32f16c45a7f647bcddf4c04da8c96c3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->