### PR TITLE
feat(gift-payment): move save logic out of step containers

### DIFF
--- a/app/components/gift-payment-page/choose-plan-step-container.ts
+++ b/app/components/gift-payment-page/choose-plan-step-container.ts
@@ -4,7 +4,6 @@ import type { PricingPlan } from 'codecrafters-frontend/components/pay-page/choo
 import { PRICING_PLANS } from 'codecrafters-frontend/components/pay-page/choose-membership-plan-modal';
 import { action } from '@ember/object';
 import { next } from '@ember/runloop';
-import { task } from 'ember-concurrency';
 import { tracked } from '@glimmer/tracking';
 
 interface Signature {
@@ -13,6 +12,7 @@ interface Signature {
   Args: {
     giftPaymentFlow: GiftPaymentFlowModel;
     onContinueButtonClick: () => void;
+    onGiftPaymentFlowUpdate: () => void;
   };
 }
 
@@ -44,19 +44,15 @@ export default class ChoosePlanStepContainer extends Component<Signature> {
   @action
   async handleContinueButtonClick() {
     this.isProcessingContinueButtonClick = true;
-    await this.saveGiftPaymentFlowTask.perform();
+    this.args.onGiftPaymentFlowUpdate();
     this.args.onContinueButtonClick();
   }
 
   @action
   async handlePlanSelect(plan: PricingPlan) {
     this.args.giftPaymentFlow.pricingPlanId = plan.id;
-    await this.saveGiftPaymentFlowTask.perform();
+    this.args.onGiftPaymentFlowUpdate();
   }
-
-  saveGiftPaymentFlowTask = task({ keepLatest: true }, async (): Promise<void> => {
-    await this.args.giftPaymentFlow.save();
-  });
 }
 
 declare module '@glint/environment-ember-loose/registry' {

--- a/app/components/gift-payment-page/enter-details-step-container.ts
+++ b/app/components/gift-payment-page/enter-details-step-container.ts
@@ -1,7 +1,6 @@
 import Component from '@glimmer/component';
 import { action } from '@ember/object';
 import type GiftPaymentFlowModel from 'codecrafters-frontend/models/gift-payment-flow';
-import { task } from 'ember-concurrency';
 import { tracked } from '@glimmer/tracking';
 
 interface Signature {
@@ -10,6 +9,7 @@ interface Signature {
   Args: {
     giftPaymentFlow: GiftPaymentFlowModel;
     onContinueButtonClick: () => void;
+    onGiftPaymentFlowUpdate: () => void;
   };
 }
 
@@ -40,7 +40,7 @@ Hope you enjoy learning with CodeCrafters.`;
 
     if (this.formInputsAreValid) {
       this.isProcessingContinueButtonClick = true;
-      await this.saveGiftPaymentFlowTask.perform();
+      this.args.onGiftPaymentFlowUpdate();
       this.args.onContinueButtonClick();
     }
   }
@@ -50,7 +50,7 @@ Hope you enjoy learning with CodeCrafters.`;
     this.recomputeFormInputsAreValid();
 
     if (this.formInputsAreValid) {
-      this.saveGiftPaymentFlowTask.perform();
+      this.args.onGiftPaymentFlowUpdate();
     }
   }
 
@@ -58,10 +58,6 @@ Hope you enjoy learning with CodeCrafters.`;
   recomputeFormInputsAreValid() {
     this.formInputsAreValid = this.formElement!.checkValidity();
   }
-
-  saveGiftPaymentFlowTask = task({ keepLatest: true }, async (): Promise<void> => {
-    await this.args.giftPaymentFlow.save();
-  });
 }
 
 declare module '@glint/environment-ember-loose/registry' {

--- a/app/controllers/gifts/buy.ts
+++ b/app/controllers/gifts/buy.ts
@@ -6,6 +6,7 @@ import scrollToTop from 'codecrafters-frontend/utils/scroll-to-top';
 import type Store from '@ember-data/store';
 import type GiftPaymentFlowModel from 'codecrafters-frontend/models/gift-payment-flow';
 import fade from 'ember-animated/transitions/fade';
+import { task } from 'ember-concurrency';
 
 export default class GiftsBuyController extends Controller {
   transition = fade;
@@ -31,9 +32,18 @@ export default class GiftsBuyController extends Controller {
   }
 
   @action
+  handleGiftPaymentFlowUpdate() {
+    this.saveGiftPaymentFlowTask.perform();
+  }
+
+  @action
   handleNavigationItemClick(step: number) {
     if (step === 1 || this.completedSteps.includes(step - 1)) {
       this.currentStep = step;
     }
   }
+
+  saveGiftPaymentFlowTask = task({ keepLatest: true }, async (): Promise<void> => {
+    await this.model.save();
+  });
 }

--- a/app/templates/gifts/buy.hbs
+++ b/app/templates/gifts/buy.hbs
@@ -19,9 +19,17 @@
       <AnimatedContainer class="w-full max-w-xl">
         {{#animated-value this.currentStep use=this.transition duration=200 as |step|}}
           {{#if (eq step 1)}}
-            <GiftPaymentPage::EnterDetailsStepContainer @giftPaymentFlow={{this.model}} @onContinueButtonClick={{this.handleContinueButtonClick}} />
+            <GiftPaymentPage::EnterDetailsStepContainer
+              @giftPaymentFlow={{this.model}}
+              @onContinueButtonClick={{this.handleContinueButtonClick}}
+              @onGiftPaymentFlowUpdate={{this.handleGiftPaymentFlowUpdate}}
+            />
           {{else if (eq step 2)}}
-            <GiftPaymentPage::ChoosePlanStepContainer @giftPaymentFlow={{this.model}} @onContinueButtonClick={{this.handleContinueButtonClick}} />
+            <GiftPaymentPage::ChoosePlanStepContainer
+              @giftPaymentFlow={{this.model}}
+              @onContinueButtonClick={{this.handleContinueButtonClick}}
+              @onGiftPaymentFlowUpdate={{this.handleGiftPaymentFlowUpdate}}
+            />
           {{else if (eq step 3)}}
             <GiftPaymentPage::ConfirmAndPayStepContainer @giftPaymentFlow={{this.model}} @onNavigationItemClick={{this.handleNavigationItemClick}} />
           {{/if}}


### PR DESCRIPTION
Refactor EnterDetailsStepContainer and ChoosePlanStepContainer to remove
embedded saving tasks. Instead, delegate save handling to the parent
controller via a new onGiftPaymentFlowUpdate callback. This simplifies
step containers and centralizes gift payment flow saving in GiftsBuyController.

Modify GiftsBuyController to include saveGiftPaymentFlowTask and
handleGiftPaymentFlowUpdate action, which performs saving when invoked.

Update gift-payment template to pass onGiftPaymentFlowUpdate callback to
step containers. These changes improve separation of concerns and make
the saving process more explicit and manageable.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Move saving from step containers to controller via an onGiftPaymentFlowUpdate callback and wire it through the template.
> 
> - **Gift Payment Flow**
>   - **Components**:
>     - `EnterDetailsStepContainer`, `ChoosePlanStepContainer`: remove internal `ember-concurrency` save tasks; add `onGiftPaymentFlowUpdate` arg; call it on input blur/plan select and before continue.
>   - **Controller**:
>     - `gifts/buy.ts`: add `saveGiftPaymentFlowTask` (keepLatest) and `handleGiftPaymentFlowUpdate` to save `model`.
>   - **Template**:
>     - `app/templates/gifts/buy.hbs`: pass `@onGiftPaymentFlowUpdate={{this.handleGiftPaymentFlowUpdate}}` to both step containers.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d0cdbc5aecbbf9e9f098d9f7ad368a23f4602009. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->