### PR TITLE
fix(base-button): add active state styles when enabled

### DIFF
--- a/app/components/base-button.hbs
+++ b/app/components/base-button.hbs
@@ -10,7 +10,7 @@
     {{if this.sizeIsSmall 'text-sm'}}
     {{if this.sizeIsRegular 'text-base'}}
     {{if this.sizeIsLarge 'text-lg'}}
-    {{if @isDisabled 'cursor-not-allowed opacity-40' 'active:scale-[0.985] transition-transform duration-75 ease-out'}}"
+    {{if @isDisabled 'cursor-not-allowed opacity-40' 'active:scale-99 transition-transform duration-75 ease-out'}}"
   ...attributes
 >
   {{yield}}

--- a/app/components/base-link-button.hbs
+++ b/app/components/base-link-button.hbs
@@ -4,16 +4,16 @@
   @query={{this.query}}
   target={{if @shouldOpenInNewTab "_blank"}}
   class="inline-block border
-    {{if this.sizeIsExtraSmall 'px-2 py-1'}}
-    {{if this.sizeIsSmall 'px-3 py-1.5'}}
+    {{if this.sizeIsExtraSmall 'px-1.5 py-1'}}
+    {{if this.sizeIsSmall 'px-2 py-1.5'}}
     {{if this.sizeIsRegular 'px-3 py-2'}}
     {{if this.sizeIsLarge 'px-4 py-3'}}
-    rounded-sm shadow-xs
-    {{if this.sizeIsExtraSmall 'text-xs font-semibold'}}
-    {{if this.sizeIsSmall 'text-sm font-semibold'}}
-    {{if this.sizeIsRegular 'text-base font-semibold'}}
-    {{if this.sizeIsLarge 'text-lg font-bold'}}
-    {{if @isDisabled 'cursor-not-allowed opacity-25'}}"
+    rounded-sm shadow-xs font-semibold
+    {{if this.sizeIsExtraSmall 'text-xs'}}
+    {{if this.sizeIsSmall 'text-sm'}}
+    {{if this.sizeIsRegular 'text-base'}}
+    {{if this.sizeIsLarge 'text-lg'}}
+    {{if @isDisabled 'cursor-not-allowed opacity-40' 'active:scale-99 transition-transform duration-75 ease-out'}}"
   ...attributes
 >
   {{yield}}


### PR DESCRIPTION
Add active state styles including a slight scale transform and
transition effects for better visual feedback on button press.
Remove these styles when the button is disabled to prevent
interaction cues. This improves user experience by clearly
indicating button interactivity.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds active press-state animation when enabled and normalizes padding/typography and disabled styling for buttons.
> 
> - **Components**
>   - `app/components/base-button.hbs`
>     - Add active press-state (`active:scale-99` + transition) when not disabled.
>   - `app/components/base-link-button.hbs`
>     - Add active press-state (`active:scale-99` + transition) when not disabled.
>     - Tweak padding for extra-small/small sizes (`px-1.5 py-1`, `px-2 py-1.5`).
>     - Normalize typography: use `font-semibold` with size-specific `text-*` classes.
>     - Update disabled styling to `opacity-40` with `cursor-not-allowed`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a57356ba670d889807d3d66a3481c4f0c9ed694d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->