### PR TITLE
fix(ui): simplify dark mode toggle label styling

### DIFF
--- a/app/components/dark-mode-toggle.hbs
+++ b/app/components/dark-mode-toggle.hbs
@@ -7,8 +7,7 @@
     <input id="option-{{preference}}" class="sr-only" type="radio" value="{{preference}}" checked={{eq this.currentPreference preference}} />
     <label
       for="option-{{preference}}"
-      class="flex rounded-full cursor-pointer border group
-        {{if (eq @size 'small') 'p-1' 'p-1.5'}}
+      class="flex rounded-full cursor-pointer border group p-1.5
         {{if (eq preferenceIndex 1) '-mx-1' ''}}
         {{if (eq this.currentPreference preference) 'bg-gray-200 dark:bg-gray-700/70'}}
         {{if (eq this.currentPreference preference) 'border-gray-200 dark:border-gray-900' 'border-transparent'}}"


### PR DESCRIPTION
Replace conditional padding logic with a single fixed padding value to  
streamline class management and improve consistency. Remove redundant  
classes to make the component styles easier to maintain and ensure  
uniform spacing for all toggle options.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Replaces size-based conditional padding on the dark-mode toggle label with a fixed `p-1.5`, removing the `@size`-dependent logic.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0026cf05bd3d2291a0ac32ce1d1b5f8be4675955. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->