### PR TITLE
feat(pay): add regional discount fetching and display

### DIFF
--- a/app/controllers/pay.ts
+++ b/app/controllers/pay.ts
@@ -1,19 +1,25 @@
-import { inject as service } from '@ember/service';
 import Controller from '@ember/controller';
-import { action } from '@ember/object';
-import { tracked } from '@glimmer/tracking';
+import testimonialsData from 'codecrafters-frontend/utils/testimonials-data';
 import type AnalyticsEventTrackerService from 'codecrafters-frontend/services/analytics-event-tracker';
 import type AuthenticatorService from 'codecrafters-frontend/services/authenticator';
-import type MonthlyChallengeBannerService from 'codecrafters-frontend/services/monthly-challenge-banner';
-import type RouterService from '@ember/routing/router-service';
-import type { ModelType } from 'codecrafters-frontend/routes/pay';
-import type PromotionalDiscountModel from 'codecrafters-frontend/models/promotional-discount';
 import type FeatureFlagsService from 'codecrafters-frontend/services/feature-flags';
-import testimonialsData from 'codecrafters-frontend/utils/testimonials-data';
-import type { Testimonial } from 'codecrafters-frontend/utils/testimonials-data';
+import type MonthlyChallengeBannerService from 'codecrafters-frontend/services/monthly-challenge-banner';
+import type PromotionalDiscountModel from 'codecrafters-frontend/models/promotional-discount';
+import type RegionalDiscountModel from 'codecrafters-frontend/models/regional-discount';
+import type RouterService from '@ember/routing/router-service';
+import type Store from '@ember-data/store';
 import type { FeatureDescription } from 'codecrafters-frontend/components/pay-page/pricing-plan-card';
+import type { ModelType } from 'codecrafters-frontend/routes/pay';
+import type { Testimonial } from 'codecrafters-frontend/utils/testimonials-data';
+import { action } from '@ember/object';
+import { inject as service } from '@ember/service';
+import { tracked } from '@glimmer/tracking';
+import { waitFor } from '@ember/test-waiters';
+import fade from 'ember-animated/transitions/fade';
 
 export default class PayController extends Controller {
+  fade = fade;
+
   declare model: ModelType;
 
   @service declare analyticsEventTracker: AnalyticsEventTrackerService;
@@ -21,8 +27,10 @@ export default class PayController extends Controller {
   @service declare featureFlags: FeatureFlagsService;
   @service declare monthlyChallengeBanner: MonthlyChallengeBannerService;
   @service declare router: RouterService;
+  @service declare store: Store;
 
   @tracked chooseMembershipPlanModalIsOpen = false;
+  @tracked regionalDiscount: RegionalDiscountModel | null = null;
 
   get activeDiscountForYearlyPlan(): PromotionalDiscountModel | null {
     return this.user?.activeDiscountForYearlyPlan || null;
@@ -67,6 +75,12 @@ export default class PayController extends Controller {
 
   get user() {
     return this.authenticator.currentUser;
+  }
+
+  @action
+  @waitFor
+  async handleDidInsertContainer() {
+    this.regionalDiscount = await this.store.createRecord('regional-discount').fetchCurrent();
   }
 
   @action

--- a/app/routes/pay.ts
+++ b/app/routes/pay.ts
@@ -1,7 +1,6 @@
 import type Store from '@ember-data/store';
 import { inject as service } from '@ember/service';
 import type CourseModel from 'codecrafters-frontend/models/course';
-import type RegionalDiscountModel from 'codecrafters-frontend/models/regional-discount';
 import type AuthenticatorService from 'codecrafters-frontend/services/authenticator';
 import BaseRoute from 'codecrafters-frontend/utils/base-route';
 import RouteInfoMetadata, { RouteColorScheme } from 'codecrafters-frontend/utils/route-info-metadata';
@@ -9,7 +8,6 @@ import scrollToTop from 'codecrafters-frontend/utils/scroll-to-top';
 
 export type ModelType = {
   courses: CourseModel[];
-  regionalDiscount: RegionalDiscountModel | null;
 };
 
 export default class PayRoute extends BaseRoute {
@@ -35,7 +33,6 @@ export default class PayRoute extends BaseRoute {
 
     return {
       courses: await this.store.findAll('course'), // For testimonials
-      regionalDiscount: await this.store.createRecord('regional-discount').fetchCurrent(),
     };
   }
 }

--- a/app/templates/pay.hbs
+++ b/app/templates/pay.hbs
@@ -1,6 +1,6 @@
 {{page-title "Pay"}}
 
-<div class="container mx-auto xl:max-w-(--breakpoint-xl) py-12 md:py-16 px-3 md:px-6">
+<div class="container mx-auto xl:max-w-(--breakpoint-xl) py-12 md:py-16 px-3 md:px-6" {{did-insert this.handleDidInsertContainer}}>
   <div class="flex flex-col items-center justify-center">
     <h1 class="text-2xl font-bold text-gray-700 dark:text-gray-300 md:text-3xl max-w-2xl text-center text-pretty">
       The highest ROI investment you can make
@@ -17,9 +17,16 @@
       <PayPage::Stage2CompletionDiscountNotice @discount={{this.activeDiscountForYearlyPlan}} class="mt-8" />
     {{/if}}
 
-    {{#if @model.regionalDiscount}}
-      <PayPage::RegionalDiscountNotice @regionalDiscount={{@model.regionalDiscount}} class="mt-8" />
-    {{/if}}
+    <AnimatedContainer>
+      {{#animated-if this.regionalDiscount use=this.fade duration=300}}
+        {{! Extra if convinces typescript that this.regionalDiscount is not null }}
+        {{#if this.regionalDiscount}}
+          <PayPage::RegionalDiscountNotice @regionalDiscount={{this.regionalDiscount}} class="mt-8" />
+        {{/if}}
+      {{else}}
+        <div class="w-full" />
+      {{/animated-if}}
+    </AnimatedContainer>
 
     <div class="grid grid-cols-1 lg:grid-cols-3 gap-x-8 gap-y-8 mt-12 w-full max-w-(--breakpoint-lg)">
       <PayPage::PricingPlanCard
@@ -102,7 +109,7 @@
       {{! @glint-expect-error mut not ts-ified yet }}
       @onClose={{fn (mut this.chooseMembershipPlanModalIsOpen) false}}
       @activeDiscountForYearlyPlan={{this.activeDiscountForYearlyPlan}}
-      @regionalDiscount={{@model.regionalDiscount}}
+      @regionalDiscount={{this.regionalDiscount}}
     />
   </ModalBackdrop>
 {{/if}}


### PR DESCRIPTION
Fetch the current regional discount record on pay page container insertion
and track it in the controller. Update the template to show the regional
discount notice using the tracked discount data instead of relying on the
model's property. This enables dynamic fetching and display of regional
discounts without requiring a full route model refresh.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Move regional discount fetching to the controller on container insert, animate its display, and update template to use the tracked discount instead of the route model.
> 
> - **Pay Page**
>   - **Controller (`app/controllers/pay.ts`)**:
>     - Fetches current `regional-discount` on container insert via `handleDidInsertContainer` (`@action`, `@waitFor`) and tracks it with `@tracked regionalDiscount`.
>     - Adds `fade` transition (from `ember-animated`) for use in template.
>     - Injects `store` service to retrieve discount.
>   - **Template (`app/templates/pay.hbs`)**:
>     - Triggers fetch with `{{did-insert this.handleDidInsertContainer}}`.
>     - Replaces model-based rendering with animated, controller-tracked `this.regionalDiscount` using `AnimatedContainer` and `animated-if`.
>     - Passes `@regionalDiscount={{this.regionalDiscount}}` to `ChooseMembershipPlanModal`.
>   - **Route (`app/routes/pay.ts`)**:
>     - Removes `regionalDiscount` from `ModelType` and from the `model()` return value.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bc6dc2490fbec92e1e213d3a637fd6ef7b2a2fa5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->