### PR TITLE
feat(gifts): rename giftMessage to senderMessage and enhance UI

### DIFF
--- a/app/models/membership-gift.ts
+++ b/app/models/membership-gift.ts
@@ -8,7 +8,7 @@ export default class MembershipGiftModel extends Model {
 
   @attr('date') declare claimedAt: Date | null;
   @attr('date') declare purchasedAt: Date;
-  @attr('string') declare giftMessage: string;
+  @attr('string') declare senderMessage: string;
   @attr('number') declare validityInDays: number;
   @attr('string') declare secretToken: string;
 

--- a/app/templates/gifts/manage.hbs
+++ b/app/templates/gifts/manage.hbs
@@ -1,3 +1,41 @@
-<h1>
-  Manage Gift
-</h1>
+<div class="container mx-auto lg:max-w-(--breakpoint-xl) px-4 py-16">
+  <div class="flex flex-col justify-center items-center mb-20">
+    <div class="w-20 h-20 mb-2">
+      <RiveAnimation @src="/assets/animations/checkmark_icon.riv" />
+    </div>
+
+    <h1 class="text-3xl sm:text-4xl leading-10 text-gradient-to-b from-white to-gray-300 font-bold mb-12 text-pretty text-center">
+      Gift Purchased!
+    </h1>
+
+    <div
+      class="flex flex-col items-center gap-4 border border-teal-500 dark:border-teal-500/50 bg-teal-50 dark:bg-teal-950/30 rounded-sm shadow-xs p-10 mb-12"
+      data-test-share-gift-container
+    >
+      <span class="flex gap-2 items-center text-gray-700 dark:text-gray-300">
+        {{!-- {{svg-jar "gift" class="w-5 text-teal-500"}} --}}
+        Here's a link to share with the recipient.
+      </span>
+
+      <CopyableCode @code={{"https://codecrafters.io/gifts/redeem"}} @onCopyButtonClick={{this.handleCopyButtonClick}} @backgroundColor="white" />
+    </div>
+
+    <div class="text-gray-500 uppercase text-xs font-medium tracking-wide mb-6 text-center">
+      Gift preview:
+    </div>
+
+    <RedeemGiftPage::GiftCard />
+
+    {{#if @model.senderMessage}}
+      <div class="px-4 py-2 mb-6 flex flex-col items-center max-w-3xs sm:max-w-xs" data-test-gift-message-container>
+        <div class="text-gray-500 uppercase text-xs font-medium tracking-wide mb-6 text-center">
+          Message from sender:
+        </div>
+
+        <div
+          class="text-gray-100 font-(family-name:--font-cursive) text-2xl sm:text-3xl whitespace-pre-wrap text-center text-pretty"
+        >{{@model.senderMessage}}</div>
+      </div>
+    {{/if}}
+  </div>
+</div>

--- a/app/templates/gifts/redeem.hbs
+++ b/app/templates/gifts/redeem.hbs
@@ -7,7 +7,7 @@
 
       <RedeemGiftPage::GiftCard />
 
-      {{#if @model.giftMessage}}
+      {{#if @model.senderMessage}}
         <div class="px-4 py-2 mb-6 flex flex-col items-center max-w-3xs sm:max-w-xs" data-test-gift-message-container>
           <div class="text-gray-500 uppercase text-xs font-medium tracking-wide mb-6 text-center">
             Message from sender:
@@ -15,7 +15,7 @@
 
           <div
             class="text-gray-100 font-(family-name:--font-cursive) text-2xl sm:text-3xl whitespace-pre-wrap text-center text-pretty"
-          >{{@model.giftMessage}}</div>
+          >{{@model.senderMessage}}</div>
         </div>
       {{/if}}
 

--- a/mirage/factories/membership-gift.js
+++ b/mirage/factories/membership-gift.js
@@ -7,7 +7,7 @@ export default Factory.extend({
     return `mgmt_${Math.random().toString(36).substring(7)}`;
   },
 
-  giftMessage: 'Happy Birthday! Enjoy your CodeCrafters membership.',
+  senderMessage: 'Happy Birthday! Enjoy your CodeCrafters membership.',
 
   purchasedAt() {
     return new Date();

--- a/tests/acceptance/manage-gift-page/view-test.js
+++ b/tests/acceptance/manage-gift-page/view-test.js
@@ -15,7 +15,7 @@ module('Acceptance | manage-gift-page | view', function (hooks) {
     const membershipGift = this.server.schema.membershipGifts.create({
       managementToken: 'valid-token',
       secretToken: 'xyz',
-      giftMessage: 'Happy Birthday! Enjoy your CodeCrafters membership.',
+      senderMessage: 'Happy Birthday! Enjoy your CodeCrafters membership.',
       validityInDays: 365,
       purchasedAt: new Date(),
       claimedAt: null,

--- a/tests/acceptance/redeem-gift-page/redeem-test.js
+++ b/tests/acceptance/redeem-gift-page/redeem-test.js
@@ -15,7 +15,7 @@ module('Acceptance | redeem-gift-page | redeem', function (hooks) {
 
     this.server.schema.membershipGifts.create({
       secretToken: 'xyz',
-      giftMessage: 'Happy Birthday! Enjoy your CodeCrafters membership.',
+      senderMessage: 'Happy Birthday! Enjoy your CodeCrafters membership.',
       validityInDays: 365,
       purchasedAt: new Date(),
       claimedAt: null,
@@ -35,7 +35,7 @@ module('Acceptance | redeem-gift-page | redeem', function (hooks) {
 
     this.server.schema.membershipGifts.create({
       secretToken: 'xyz',
-      giftMessage: 'Happy Birthday! Enjoy your CodeCrafters membership.',
+      senderMessage: 'Happy Birthday! Enjoy your CodeCrafters membership.',
       validityInDays: 365,
       purchasedAt: new Date(),
       claimedAt: null,
@@ -58,7 +58,7 @@ module('Acceptance | redeem-gift-page | redeem', function (hooks) {
 
     this.server.schema.membershipGifts.create({
       secretToken: 'xyz',
-      giftMessage: 'Happy Birthday! Enjoy your CodeCrafters membership.',
+      senderMessage: 'Happy Birthday! Enjoy your CodeCrafters membership.',
       validityInDays: 365,
       purchasedAt: new Date(),
     });

--- a/tests/acceptance/redeem-gift-page/view-test.js
+++ b/tests/acceptance/redeem-gift-page/view-test.js
@@ -14,7 +14,7 @@ module('Acceptance | redeem-gift-page | view', function (hooks) {
   test('displays gift details', async function (assert) {
     this.server.schema.membershipGifts.create({
       secretToken: 'xyz',
-      giftMessage: 'Happy Birthday! Enjoy your CodeCrafters membership.\n\n— Paul',
+      senderMessage: 'Happy Birthday! Enjoy your CodeCrafters membership.\n\n— Paul',
       validityInDays: 365,
       purchasedAt: new Date(),
       claimedAt: null,


### PR DESCRIPTION
Rename giftMessage attribute to senderMessage across models, tests,
factories, and templates to better reflect its purpose. Update all test
fixtures accordingly. Add a new "Gift Purchased!" confirmation UI on
the manage gift page, including a shareable link and gift preview with
sender message. Improve styling and user feedback for gift management.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Renames `giftMessage` to `senderMessage` across codebase and adds a new post-purchase manage page with share link, gift preview, and optional sender message.
> 
> - **Gifts model and data**:
>   - Rename `giftMessage` -> `senderMessage` in `app/models/membership-gift.ts` and `mirage/factories/membership-gift.js`.
> - **Templates/UI**:
>   - Update `app/templates/gifts/redeem.hbs` to read `@model.senderMessage`.
>   - Add/manage page UI in `app/templates/gifts/manage.hbs`:
>     - Confirmation header, shareable link (`CopyableCode`), gift preview (`RedeemGiftPage::GiftCard`), and optional sender message block.
> - **Tests**:
>   - Update acceptance tests to use `senderMessage` in `tests/acceptance/*` and assert sender message display on redeem page.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 74842b01141ca3389fbad91665dba4a84f88f4b7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->