### PR TITLE
feat(gift-card): display dynamic membership gift details

### DIFF
--- a/app/components/redeem-gift-page/gift-card.hbs
+++ b/app/components/redeem-gift-page/gift-card.hbs
@@ -33,7 +33,7 @@
     </span>
 
     <span class="text-gradient-to-b from-white to-gray-300 text-2xl leading-9 font-bold">
-      3 months
+      {{this.validityPeriodText}}
     </span>
 
     <span class="text-gradient-to-b from-gray-400 to-gray-500 leading-5 uppercase text-xs font-medium tracking-wide text-center text-balance mt-0.5">
@@ -43,7 +43,8 @@
 
   <div class="bg-gray-950 border-t border-white/10 w-full">
     <div class="text-gray-400 text-xxs font-medium tracking-wide text-center text-balance p-2 uppercase">
-      Expiry: 25 JUL '26
+      Expiry:
+      {{this.expiryDateText}}
     </div>
   </div>
 </div>

--- a/app/components/redeem-gift-page/gift-card.ts
+++ b/app/components/redeem-gift-page/gift-card.ts
@@ -1,12 +1,46 @@
 import Component from '@glimmer/component';
 import logoImage from '/assets/images/logo/logomark-color.svg';
+import type MembershipGiftModel from 'codecrafters-frontend/models/membership-gift';
 
 interface Signature {
   Element: HTMLDivElement;
+
+  Args: {
+    membershipGift: MembershipGiftModel;
+  };
 }
 
 export default class RedeemGiftPageGiftCard extends Component<Signature> {
   logoImage = logoImage;
+
+  get expiryDateText(): string {
+    const purchasedAt = this.args.membershipGift.purchasedAt;
+    const validityInDays = this.args.membershipGift.validityInDays;
+
+    const expiryDate = new Date(purchasedAt);
+    expiryDate.setDate(expiryDate.getDate() + validityInDays);
+
+    const months = ['JAN', 'FEB', 'MAR', 'APR', 'MAY', 'JUN', 'JUL', 'AUG', 'SEP', 'OCT', 'NOV', 'DEC'];
+    const day = expiryDate.getDate();
+    const month = months[expiryDate.getMonth()];
+    const year = expiryDate.getFullYear().toString().slice(-2);
+
+    return `${day} ${month} '${year}`;
+  }
+
+  get validityPeriodText(): string {
+    const days = this.args.membershipGift.validityInDays;
+    const months = Math.floor(days / 30);
+    const years = Math.floor(days / 365);
+
+    if (years >= 1) {
+      return years === 1 ? '1 year' : `${years} years`;
+    } else if (months >= 1) {
+      return months === 1 ? '1 month' : `${months} months`;
+    } else {
+      return days === 1 ? '1 day' : `${days} days`;
+    }
+  }
 }
 
 declare module '@glint/environment-ember-loose/registry' {

--- a/app/templates/gifts/manage.hbs
+++ b/app/templates/gifts/manage.hbs
@@ -24,7 +24,7 @@
       Gift preview:
     </div>
 
-    <RedeemGiftPage::GiftCard />
+    <RedeemGiftPage::GiftCard @membershipGift={{@model}} />
 
     {{#if @model.senderMessage}}
       <div class="px-4 py-2 mb-6 flex flex-col items-center max-w-3xs sm:max-w-xs" data-test-gift-message-container>

--- a/app/templates/gifts/redeem.hbs
+++ b/app/templates/gifts/redeem.hbs
@@ -5,7 +5,7 @@
         Redeem Gift Card
       </h1>
 
-      <RedeemGiftPage::GiftCard />
+      <RedeemGiftPage::GiftCard @membershipGift={{@model}} />
 
       {{#if @model.senderMessage}}
         <div class="px-4 py-2 mb-6 flex flex-col items-center max-w-3xs sm:max-w-xs" data-test-gift-message-container>


### PR DESCRIPTION
Pass membershipGift model to GiftCard component in redeem and manage
templates to enable dynamic rendering. Calculate and show validity period
and expiry date based on membershipGift data, replacing static values.

This improves accuracy and user experience by reflecting real gift info.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Gift card now receives `membershipGift` and displays computed validity period and expiry date instead of static placeholders.
> 
> - **UI Component: `app/components/redeem-gift-page/gift-card.*`**
>   - Accepts `@membershipGift` arg (typed to `MembershipGiftModel`).
>   - Adds computed getters `validityPeriodText` and `expiryDateText` (derived from `purchasedAt` and `validityInDays`).
>   - HBS updated to display `{{this.validityPeriodText}}` and `{{this.expiryDateText}}` instead of hardcoded values.
> - **Templates**
>   - `app/templates/gifts/redeem.hbs`: pass `@model` as `@membershipGift` to `RedeemGiftPage::GiftCard`.
>   - `app/templates/gifts/manage.hbs`: pass `@model` as `@membershipGift` to `RedeemGiftPage::GiftCard`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cfedc869246a2f07d4e18464296faccf31dec254. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->