### PR TITLE
fix(ui): replace custom error box with Alert component in payment history

### DIFF
--- a/app/components/settings/billing-page/payment-history-section.hbs
+++ b/app/components/settings/billing-page/payment-history-section.hbs
@@ -5,14 +5,14 @@
       <span class="ml-3 text-gray-700 dark:text-gray-200">Loading payments...</span>
     </div>
   {{else if this.errorMessage}}
-    <div class="bg-red-50 dark:bg-red-900 border border-red-200 dark:border-red-400 rounded-md p-4">
-      <div class="flex gap-3">
+    <Alert @color="red">
+      <div class="flex gap-1.5">
         <div class="shrink-0">
-          {{svg-jar "x-circle" class="h-5 w-5 text-red-700 dark:text-red-300"}}
+          {{svg-jar "x-circle" class="h-5 w-5 text-red-700 dark:text-red-200"}}
         </div>
         <p class="text-sm text-red-700 dark:text-red-300">{{this.errorMessage}}</p>
       </div>
-    </div>
+    </Alert>
   {{else if (gt this.charges.length 0)}}
     <div>
       <div class="grid grid-cols-3 gap-y-3">

--- a/app/components/settings/billing-page/status-pill.hbs
+++ b/app/components/settings/billing-page/status-pill.hbs
@@ -1,9 +1,9 @@
 <div
   class="inline-flex items-center gap-2 rounded-full px-2 py-1 border
-    {{if (eq @color 'green') 'bg-teal-50 border border-teal-500 dark:bg-teal-950 dark:border-teal-400'}}
-    {{if (eq @color 'red') 'bg-red-50 border border-red-500 dark:bg-red-950 dark:border-red-400'}}
-    {{if (eq @color 'yellow') 'bg-yellow-50 border border-yellow-500 dark:bg-yellow-950 dark:border-yellow-400'}}
-    {{if (eq @color 'gray') 'bg-gray-50 border border-gray-300 dark:bg-gray-900 dark:border-gray-600'}}"
+    {{if (eq @color 'green') 'bg-teal-50 border border-teal-500 dark:bg-teal-950 dark:border-teal-400/50'}}
+    {{if (eq @color 'red') 'bg-red-50 border border-red-500 dark:bg-red-950 dark:border-red-400/50'}}
+    {{if (eq @color 'yellow') 'bg-yellow-50 border border-yellow-500 dark:bg-yellow-950 dark:border-yellow-400/50'}}
+    {{if (eq @color 'gray') 'bg-gray-50 border border-gray-300 dark:bg-gray-900 dark:border-gray-400/50'}}"
   ...attributes
 >
   <StaticDot @color={{@color}} @size="large" />


### PR DESCRIPTION
Refactor the error message display in PaymentHistorySection to use the
shared Alert component for better consistency and maintainability. Adjust
spacing and icon color to match design guidelines. This improves UI
uniformity and code reuse across the app.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Replace custom error box with shared `Alert` in payment history and reduce dark border intensity in `StatusPill`.
> 
> - **Billing > Payment History**:
>   - Replace custom error container with shared `Alert @color="red"`.
>   - Tweak spacing (`gap-1.5`) and icon text color (`dark:text-red-200`).
> - **UI > StatusPill**:
>   - Reduce dark border intensity to `...-400/50` for `green`, `red`, `yellow`, and `gray` variants.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0dbcb77b9b8968aa13399cc8f5b76d0f796250c4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->