### PR TITLE
Stop shell instructions video reloading on every ActionCable data event

### DIFF
--- a/app/components/course-page/course-stage-step/first-stage-your-task-card/index.hbs
+++ b/app/components/course-page/course-stage-step/first-stage-your-task-card/index.hbs
@@ -16,9 +16,21 @@
       {{markdown-to-html this.instructionsMarkdown}}
     </div>
 
-    {{#if this.videoEmbedHtml}}
+    {{#if @currentStep.courseStage.course.isShell}}
       <div class="mb-8 max-w-3xl rounded-xl overflow-hidden">
-        {{html-safe this.videoEmbedHtml}}
+
+        {{! template-lint-disable no-inline-styles }}
+        <div style="left: 0; width: 100%; height: 0; position: relative; padding-bottom: 56.25%;">
+          <iframe
+            src="https://www.loom.com/embed/63531adfeb6242eeaff9171bc1211947?hide_title=true&hideEmbedTopBar=true&hide_owner=true"
+            style="top: 0; left: 0; width: 100%; height: 100%; position: absolute; border: 0;"
+            allowfullscreen
+            scrolling="no"
+            allow="encrypted-media *;"
+            title="Instructions"
+          />
+        </div>
+
       </div>
     {{/if}}
 

--- a/app/components/course-page/course-stage-step/first-stage-your-task-card/index.ts
+++ b/app/components/course-page/course-stage-step/first-stage-your-task-card/index.ts
@@ -82,21 +82,6 @@ export default class FirstStageYourTaskCard extends Component<Signature> {
     );
   }
 
-  get videoEmbedHtml() {
-    if (this.args.currentStep.courseStage.course.isShell) {
-      return `
-           <div style="left: 0; width: 100%; height: 0; position: relative; padding-bottom: 56.25%;"><iframe
-          src="https://www.loom.com/embed/63531adfeb6242eeaff9171bc1211947?hide_title=true&hideEmbedTopBar=true&hide_owner=true"
-          style="top: 0; left: 0; width: 100%; height: 100%; position: absolute; border: 0;"
-          allowfullscreen
-          scrolling="no"
-          allow="encrypted-media *;"
-        ></iframe></div>`;
-    } else {
-      return null;
-    }
-  }
-
   @action
   handleViewLogsButtonClick() {
     this.coursePageState.testResultsBarIsExpanded = true;


### PR DESCRIPTION
Closes #3318 

### Brief

This fixes the video on the Print a prompt Shell course stage reloading every time `ActionCable` receives some data.

### Details

Fixed by moving the video embed HTML code from the component _getter_ into the template.

### After

<img width="683" height="726" alt="Знімок екрана 2025-12-06 о 13 21 36" src="https://github.com/user-attachments/assets/007917bf-a102-49a0-b77f-2cc58a7b5734" />

### Before

https://github.com/user-attachments/assets/9d60fa2c-18f0-4efa-9123-3cd7e2fa8b0f

### Checklist

- [x] I've thoroughly self-reviewed my changes
- [x] I've added tests for my changes, unless they affect admin-only areas (or are otherwise not worth testing)
- [x] I've verified any visual changes using Percy (add a commit with `[percy]` in the message to trigger)
