### PR TITLE
fix(ui): remove uppercase style from gift card subtitle

### DIFF
--- a/app/components/redeem-gift-page/gift-card.hbs
+++ b/app/components/redeem-gift-page/gift-card.hbs
@@ -29,7 +29,7 @@
       CodeCrafters
     </span>
 
-    <span class="text-gradient-to-b from-gray-400 to-gray-500 leading-5 uppercase text-sm font-medium tracking-wide text-center text-balance mb-6">
+    <span class="text-gradient-to-b from-gray-400 to-gray-500 leading-5 text-sm font-medium tracking-wide text-center text-balance mb-6">
       Train your engineering skills like a pro athlete
     </span>
 


### PR DESCRIPTION
Remove the uppercase text transformation on the gift card subtitle to
improve readability and maintain consistent styling across the page.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Removes the `uppercase` text style from the gift card subtitle in `app/components/redeem-gift-page/gift-card.hbs` to render it in normal case.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 15e8a27919118a3c368c47ab15d41d16423913cc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->