### PR TITLE
feat(gifts): prefill sender email on gift payment creation

### DIFF
--- a/app/routes/gifts/buy.ts
+++ b/app/routes/gifts/buy.ts
@@ -2,12 +2,14 @@ import BaseRoute from 'codecrafters-frontend/utils/base-route';
 import RouteInfoMetadata, { RouteColorScheme } from 'codecrafters-frontend/utils/route-info-metadata';
 import type GiftPaymentFlowModel from 'codecrafters-frontend/models/gift-payment-flow';
 import type Store from '@ember-data/store';
+import type AuthenticatorService from 'codecrafters-frontend/services/authenticator';
 import { inject as service } from '@ember/service';
 
 export type ModelType = GiftPaymentFlowModel;
 
 export default class GiftsPayRoute extends BaseRoute {
   @service declare store: Store;
+  @service declare authenticator: AuthenticatorService;
 
   buildRouteInfoMetadata() {
     return new RouteInfoMetadata({ allowsAnonymousAccess: true, colorScheme: RouteColorScheme.Both });
@@ -17,7 +19,10 @@ export default class GiftsPayRoute extends BaseRoute {
     if (params.giftPaymentFlowId) {
       return await this.store.findRecord('gift-payment-flow', params.giftPaymentFlowId);
     } else {
-      return this.store.createRecord('gift-payment-flow', { pricingPlanId: 'v1-lifetime' });
+      return this.store.createRecord('gift-payment-flow', {
+        pricingPlanId: 'v1-lifetime',
+        senderEmailAddress: this.authenticator.currentUser?.primaryEmailAddress,
+      });
     }
   }
 }


### PR DESCRIPTION
Inject the authenticator service to access the current user and
prefill the senderEmailAddress on new gift payment flow records.
This improves user experience by auto-populating sender details
when creating a gift purchase, reducing manual input.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Prefills sender email on new gift-payment-flow creation by injecting the authenticator service and using the current user's primary email.
> 
> - **Routes (`app/routes/gifts/buy.ts`)**:
>   - Injects `authenticator` service to access `currentUser`.
>   - Prefills `senderEmailAddress` when creating `gift-payment-flow` records using `currentUser.primaryEmailAddress`.
>   - Retains existing fetch behavior when `giftPaymentFlowId` is provided.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ee309a1fa925df3be74491d0c2eacf11fbb803ea. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->