### PR TITLE
feat(gifts): add "Buy another gift" button to manage page

### DIFF
--- a/app/components/primary-link-button.hbs
+++ b/app/components/primary-link-button.hbs
@@ -1,9 +1,10 @@
 <BaseLinkButton
-  @route={{@route}}
-  @models={{@models}}
   @model={{@model}}
-  @size={{@size}}
+  @models={{@models}}
   @query={{@query}}
+  @route={{@route}}
+  @shouldOpenInNewTab={{@shouldOpenInNewTab}}
+  @size={{@size}}
   class="bg-teal-500 dark:bg-teal-900 hover:bg-teal-600 dark:hover:bg-teal-800 dark:border-teal-700 dark:hover:border-teal-600 border-teal-500 hover:border-teal-600 text-white dark:text-teal-50 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-teal-500"
   ...attributes
 >

--- a/app/templates/gifts/manage.hbs
+++ b/app/templates/gifts/manage.hbs
@@ -9,7 +9,7 @@
     </h1>
 
     <div
-      class="flex flex-col items-center gap-4 w-full max-w-md border border-teal-500 dark:border-teal-500/50 bg-teal-50 dark:bg-teal-950/30 rounded-sm shadow-xs py-10 px-4 sm:px-10 mb-12"
+      class="flex flex-col items-center gap-4 w-full max-w-md border border-teal-500 dark:border-teal-500/50 bg-teal-50 dark:bg-teal-950/30 rounded-sm shadow-xs py-10 px-4 sm:px-10 mb-6"
       data-test-share-gift-container
     >
       <span class="text-gray-700 dark:text-gray-300 text-center text-balance">
@@ -18,6 +18,10 @@
 
       <CopyableCode @code={{@model.gift.redeemUrl}} @onCopyButtonClick={{this.handleCopyButtonClick}} @backgroundColor="white" />
     </div>
+
+    <PrimaryLinkButton @route="gifts.buy" @shouldOpenInNewTab={{true}} class="mb-12">
+      Buy another gift →
+    </PrimaryLinkButton>
 
     <RedeemGiftPage::GiftMessage @membershipGift={{@model.gift}} @managementToken={{@model.managementToken}} @isEditable={{true}} class="mb-12" />
 


### PR DESCRIPTION
Reduce bottom margin of gift container for better spacing and add a 
PrimaryLinkButton on the manage gift page that links to the gift purchase 
route and opens in a new tab. Refactor PrimaryLinkButton to accept and 
pass the shouldOpenInNewTab argument to support this new behavior. These 
changes improve user flow by making it easier to purchase additional gifts.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a "Buy another gift" button on the manage page that opens `gifts.buy` in a new tab and updates `PrimaryLinkButton` to forward `@shouldOpenInNewTab`; tweaks spacing.
> 
> - **Gifts manage page (`app/templates/gifts/manage.hbs`)**
>   - Add `PrimaryLinkButton` linking to `gifts.buy` that opens in a new tab ("Buy another gift →").
>   - Reduce bottom margin on the share container from `mb-12` to `mb-6`.
> - **Component (`app/components/primary-link-button.hbs`)**
>   - Forward `@shouldOpenInNewTab` to `BaseLinkButton`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5b5b8f36bac847a6391c81ebca7b697a5638cf64. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->