### PR TITLE
fix(redeem-gift-page): update expiry label to clarify timing

### DIFF
--- a/app/components/redeem-gift-page/gift-card.hbs
+++ b/app/components/redeem-gift-page/gift-card.hbs
@@ -44,7 +44,7 @@
 
   <div class="bg-gray-950 border-t border-white/10 w-full">
     <div class="text-gray-400 text-xxs font-medium tracking-wide text-center text-balance p-2 uppercase">
-      Expiry:
+      Redeem before
       {{this.expiryDateText}}
     </div>
   </div>


### PR DESCRIPTION
Change the gift card expiry label from "Expiry:" to "Redeem before"
to make it clearer to users that the date indicates the deadline
for redeeming the gift card rather than a simple expiry date. This
improves user understanding and reduces confusion during redemption.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Update gift card footer label from `Expiry:` to `Redeem before` in `app/components/redeem-gift-page/gift-card.hbs`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6d10fa3edc0a5c075d2601aa2259ec08d0652042. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->