### PR TITLE
feat(gifts): ensure primaryEmailAddress is loaded for user

### DIFF
--- a/app/routes/gifts/buy.ts
+++ b/app/routes/gifts/buy.ts
@@ -33,6 +33,11 @@ export default class GiftsPayRoute extends BaseRoute {
     if (params.giftPaymentFlowId) {
       return await this.store.findRecord('gift-payment-flow', params.giftPaymentFlowId);
     } else {
+      // Make sure primaryEmailAddress is loaded for current user
+      if (this.authenticator.isAuthenticated) {
+        await this.authenticator.authenticate();
+      }
+
       return this.store.createRecord('gift-payment-flow', {
         pricingPlanId: 'v1-lifetime',
         senderEmailAddress: this.authenticator.currentUser?.primaryEmailAddress,


### PR DESCRIPTION
Add logic to authenticate the user if already authenticated to guarantee
that primaryEmailAddress is available before creating a new gift-payment-flow
record. This change prevents issues where the sender email might be missing
due to incomplete user data loading in the buy gift flow.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Re-authenticates when already authenticated to ensure `currentUser.primaryEmailAddress` is available before creating a `gift-payment-flow` in `app/routes/gifts/buy.ts`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cc9537a848a46104238090ddd09e9d5120e75123. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->