### PR TITLE
docs: update development workflow testing instructions

### DIFF
--- a/.cursor/rules/development-workflow.mdc
+++ b/.cursor/rules/development-workflow.mdc
@@ -9,8 +9,8 @@ When you're asked to make changes, follow these rules:
   - You can ignore any `pauseTest()` related failures. These are needed for debugging purposes.
 - Once linting is successful, you can try running tests if there are ones that cover the area you changed.
   - Only run tests using the browser tool.
-  - The browser will already be open with a URL like this: `http://localhost:4200/tests/index.html?moduleId=abcd`
-  - Reload the page and you'll see test results there.
+  - Visit `http://localhost:4200/tests?filter=xyz` to run tests in the browser.
+  - You MUST use the filter query param to filter for the tests you want to run. Do NOT run all tests.
   - You can use the console to check for any errors, you'll also see them printed on the page most of the time.
 - Do NOT run `npm run test`, that's super slow.
 - Do NOT run commands like `npm run build` / `npm run start`.


### PR DESCRIPTION
Clarify test running procedure in development workflow
documentation by specifying the exact URL format to use when
running tests in the browser. Emphasize the requirement to use
the filter query parameter to limit test execution, preventing
running all tests and saving developer time.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Clarifies browser-based test running by specifying the `/tests?filter=` URL and requiring filtered runs, removing prior `index.html?moduleId=` guidance.
> 
> - **Docs** (`.cursor/rules/development-workflow.mdc`):
>   - Specify browser test URL: `http://localhost:4200/tests?filter=xyz`.
>   - Require using the `filter` query param to limit tests; avoid running all tests.
>   - Remove prior `tests/index.html?moduleId=...` and page reload guidance.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit dce2a1b93294cea796dd75a51785a9746ab328e4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->