### PR TITLE
style: reduce border opacity for dark mode elements

### DIFF
--- a/app/components/gift-payment-page/confirm-and-pay-step-container.hbs
+++ b/app/components/gift-payment-page/confirm-and-pay-step-container.hbs
@@ -23,7 +23,7 @@
     </ul>
   </div>
 
-  <div class="h-px bg-gray-100 dark:bg-white/10 mt-6 mb-6"></div>
+  <div class="h-px bg-gray-100 dark:bg-white/5 mt-6 mb-6"></div>
 
   <div class="flex gap-4 justify-between items-stretch sm:items-center flex-col-reverse sm:flex-row">
     {{#if this.errorMessage}}

--- a/app/components/gift-payment-page/enter-details-step-container.hbs
+++ b/app/components/gift-payment-page/enter-details-step-container.hbs
@@ -12,7 +12,7 @@
       />
     </GiftPaymentPage::GiftDetailsForm::Section>
 
-    <div class="h-px bg-gray-100 dark:bg-white/10 mt-6 mb-6"></div>
+    <div class="h-px bg-gray-100 dark:bg-white/5 mt-6 mb-6"></div>
 
     <GiftPaymentPage::GiftDetailsForm::Section @title="Gift Message" @description="Optional. You can edit this later.">
       <Textarea
@@ -25,7 +25,7 @@
       />
     </GiftPaymentPage::GiftDetailsForm::Section>
 
-    <div class="h-px bg-gray-100 dark:bg-white/10 mt-6 mb-6"></div>
+    <div class="h-px bg-gray-100 dark:bg-white/5 mt-6 mb-6"></div>
 
     <div class="flex gap-4 justify-between items-stretch sm:items-center flex-col-reverse sm:flex-row">
       <div class="text-xs text-gray-500 dark:text-gray-400">

--- a/app/components/gift-payment-page/step-container.hbs
+++ b/app/components/gift-payment-page/step-container.hbs
@@ -1,6 +1,6 @@
-<div class="w-full max-w-xl bg-white dark:bg-gray-925 border border-gray-200 dark:border-white/10 rounded-sm p-6" ...attributes>
+<div class="w-full max-w-xl bg-white dark:bg-gray-925 border border-gray-200 dark:border-white/5 rounded-sm p-6" ...attributes>
   <div class="text-gray-700 dark:text-gray-300 font-bold mb-1 uppercase">{{@title}}</div>
-  <div class="h-px bg-gray-100 dark:bg-white/10 mt-2 mb-6"></div>
+  <div class="h-px bg-gray-100 dark:bg-white/5 mt-2 mb-6"></div>
 
   {{yield}}
 </div>


### PR DESCRIPTION
Decrease the opacity of border colors in dark mode for input fields,
textarea, plan selection, and containers from 10% to 5%. This change
improves visual subtlety and enhances the overall dark theme aesthetics
by making borders less prominent and reducing visual noise.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Lowers dark-mode border/divider opacity from 10% to 5% across gift payment step containers and section separators.
> 
> - **Gift Payment Page (dark mode)**:
>   - Reduce border/divider opacity from `white/10` to `white/5`:
>     - `app/components/gift-payment-page/step-container.hbs`: container `border` and section divider.
>     - `app/components/gift-payment-page/enter-details-step-container.hbs`: section dividers.
>     - `app/components/gift-payment-page/confirm-and-pay-step-container.hbs`: section divider.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e9f4b1466b29c3bb5cb38b18aa80761ca91c1bd5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->