### PR TITLE
feat(components): add SecondaryLinkButton component for styled links

### DIFF
--- a/app/components/secondary-link-button.hbs
+++ b/app/components/secondary-link-button.hbs
@@ -1,0 +1,13 @@
+<BaseLinkButton
+  @model={{@model}}
+  @models={{@models}}
+  @query={{@query}}
+  @route={{@route}}
+  @shouldOpenInNewTab={{@shouldOpenInNewTab}}
+  @size={{@size}}
+  @isDisabled={{@isDisabled}}
+  class="border-teal-500 hover:border-teal-600 dark:hover:border-teal-400 text-teal-500 hover:text-teal-600 dark:hover:text-teal-400"
+  ...attributes
+>
+  {{yield}}
+</BaseLinkButton>

--- a/app/components/secondary-link-button.ts
+++ b/app/components/secondary-link-button.ts
@@ -1,0 +1,20 @@
+import Component from '@glimmer/component';
+import { type BaseLinkButtonSignature } from './base-link-button';
+
+interface Signature {
+  Element: HTMLAnchorElement;
+
+  Args: BaseLinkButtonSignature['Args'];
+
+  Blocks: {
+    default: [];
+  };
+}
+
+export default class SecondaryLinkButton extends Component<Signature> {}
+
+declare module '@glint/environment-ember-loose/registry' {
+  export default interface Registry {
+    SecondaryLinkButton: typeof SecondaryLinkButton;
+  }
+}


### PR DESCRIPTION
Create SecondaryLinkButton as a wrapper around BaseLinkButton with 
teal border and text styles for secondary actions. It accepts the same 
arguments as BaseLinkButton and yields content, enabling consistent 
styling and behavior for secondary link buttons across the app.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduce `SecondaryLinkButton` that wraps `BaseLinkButton`, forwards all args, and applies teal secondary link styles.
> 
> - **Components**
>   - Add `app/components/secondary-link-button.hbs` wrapping `BaseLinkButton`, forwarding all args/attributes and yielding content.
>   - Apply teal border/text hover styles for secondary actions.
> - **Types/Registry**
>   - Add `app/components/secondary-link-button.ts` with signature based on `BaseLinkButtonSignature` and `HTMLAnchorElement`.
>   - Register `SecondaryLinkButton` in Glint environment registry.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5c9381a157ea5473221ce0aa53f4c419d301dd47. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->