### PR TITLE
feat(gifts): scroll to top on buy route activation

### DIFF
--- a/app/routes/gifts/buy.ts
+++ b/app/routes/gifts/buy.ts
@@ -6,6 +6,7 @@ import type Store from '@ember-data/store';
 import type AuthenticatorService from 'codecrafters-frontend/services/authenticator';
 import type MetaDataService from 'codecrafters-frontend/services/meta-data';
 import { inject as service } from '@ember/service';
+import scrollToTop from 'codecrafters-frontend/utils/scroll-to-top';
 
 export type ModelType = GiftPaymentFlowModel;
 
@@ -15,6 +16,10 @@ export default class GiftsPayRoute extends BaseRoute {
   @service declare metaData: MetaDataService;
 
   previousMetaImageUrl: string | undefined;
+
+  activate() {
+    scrollToTop();
+  }
 
   afterModel(): void {
     this.previousMetaImageUrl = this.metaData.imageUrl;

--- a/app/templates/pay.hbs
+++ b/app/templates/pay.hbs
@@ -66,9 +66,9 @@
       />
     </div>
 
-    <LinkTo @route="refer" class="font-medium mt-16 text-sm text-gray-700 dark:text-gray-300 hover:underline">
+    <LinkTo @route="gifts.buy" class="font-medium mt-16 text-sm text-gray-700 dark:text-gray-300 hover:underline">
       {{! template-lint-disable no-whitespace-for-layout }}
-      🎁&nbsp;&nbsp;Refer friends to get free weeks →
+      🎁&nbsp;&nbsp;Gift a membership →
     </LinkTo>
 
     {{#unless this.monthlyChallengeBanner.isOutdated}}


### PR DESCRIPTION
Add scrollToTop utility call in the buy route's activate hook to ensure
the page resets scroll position when entering the gift purchase flow.

Update the pay template to change the referral link to direct users to
the gift purchase route with updated text, improving user navigation and
clarity around gifting options.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Add scroll-to-top on gifts buy route and update Pay page link to direct users to the gift purchase flow with new text.
> 
> - **Frontend**:
>   - **Route `app/routes/gifts/buy.ts`**: Add `activate()` hook calling `scrollToTop()` to reset scroll on entry.
>   - **Template `app/templates/pay.hbs`**: Update CTA link from `refer` to `gifts.buy` and change text to “Gift a membership →”.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 599b950d726e262db6805390e9e2e76b465e0d47. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->