### PR TITLE
Update condition to check for FastBoot before processing queryParams['r']

### DIFF
--- a/app/utils/base-route.ts
+++ b/app/utils/base-route.ts
@@ -49,7 +49,7 @@ export default class BaseRoute extends Route {
 
     const queryParams = transition.to?.queryParams;
 
-    if (queryParams && queryParams['r'] && /^\d[a-zA-Z][a-zA-Z]$/.test(queryParams['r'])) {
+    if (!this.fastboot.isFastBoot && queryParams && queryParams['r'] && /^\d[a-zA-Z][a-zA-Z]$/.test(queryParams['r'])) {
       // @ts-expect-error utmCampaignIdTracker service not typed
       this.utmCampaignIdTracker.setCampaignId(queryParams['r']);
       delete queryParams['r'];


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Only process the `r` query param for campaign tracking in the browser, skipping it in FastBoot.
> 
> - **Routing utils (`app/utils/base-route.ts`)**:
>   - Guard handling of `queryParams['r']` (UTM campaign ID tracking) with `!this.fastboot.isFastBoot`, ensuring it runs only in the browser and not in FastBoot.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6adc403681bb57fe6957d64867b0d3ec27491bfc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->