### PR TITLE
chore(vscode): add `start`, `start:fastboot`, `inspect:eslint` to `vscode/tasks.json`

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -21,5 +21,11 @@
       "script": "start",
       "problemMatcher": [],
     },
+    {
+      "label": "npm: start:fastboot",
+      "type": "npm",
+      "script": "start:fastboot",
+      "problemMatcher": [],
+    },
   ]
 }


### PR DESCRIPTION
### Brief

This adds `start`, `start:fastboot`, and `inspect:eslint` to `vscode/tasks.json`, in order to fix the "Restart Running Task" command.

### Details

Without these tasks present in `tasks.json`, using the command terminates the running task, but doesn't restart it.

### Screenshots

<img width="287" height="91" alt="Знімок екрана 2025-12-22 о 18 22 51" src="https://github.com/user-attachments/assets/5868ef92-e36f-4efa-bf89-1495e8b350f3" />
<img width="204" height="84" alt="Знімок екрана 2025-12-22 о 18 23 00" src="https://github.com/user-attachments/assets/6154c421-57ee-427f-8b32-642db220328c" />


### Checklist

- [x] I've thoroughly self-reviewed my changes
- [x] I've added tests for my changes, unless they affect admin-only areas (or are otherwise not worth testing)
- [x] I've verified any visual changes using Percy (add a commit with `[percy]` in the message to trigger)
