### PR TITLE
feat(course-next): add new course-next route with model and UI

### DIFF
--- a/app/router.ts
+++ b/app/router.ts
@@ -62,6 +62,11 @@ Router.map(function () {
     this.route('completed');
   });
 
+  // Experimental, testing a new UI
+  this.route('course-next', { path: '/courses-next/:course_slug' }, function () {
+    // Add extra routes here are required
+  });
+
   this.route('course-overview', { path: '/courses/:course_slug/overview' }); // TODO: Add dark mode support
   this.route('debug');
   this.route('gifts.buy', { path: '/gifts/buy' });

--- a/app/routes/course-next/index.ts
+++ b/app/routes/course-next/index.ts
@@ -1,0 +1,29 @@
+import BaseRoute from 'codecrafters-frontend/utils/base-route';
+import RouteInfoMetadata, { RouteColorScheme } from 'codecrafters-frontend/utils/route-info-metadata';
+import type CourseModel from 'codecrafters-frontend/models/course';
+import type Store from '@ember-data/store';
+import { service } from '@ember/service';
+
+export interface ModelType {
+  course: CourseModel;
+}
+
+export default class CourseNextIndexRoute extends BaseRoute {
+  @service declare store: Store;
+
+  buildRouteInfoMetadata() {
+    return new RouteInfoMetadata({ colorScheme: RouteColorScheme.Both });
+  }
+
+  async model(): Promise<ModelType> {
+    const courses = await this.store.findAll('course', {
+      include: 'extensions,stages,language-configurations.language',
+    });
+
+    const courseSlug = (this.paramsFor('course-next')! as { course_slug: string }).course_slug;
+
+    return {
+      course: courses.find((course) => course.slug === courseSlug),
+    };
+  }
+}

--- a/app/services/layout.ts
+++ b/app/services/layout.ts
@@ -12,7 +12,8 @@ export default class LayoutService extends Service {
     if (
       this.router.currentRouteName === 'course' ||
       this.router.currentRouteName.startsWith('course.') ||
-      this.router.currentRouteName.startsWith('course-admin')
+      this.router.currentRouteName.startsWith('course-admin') ||
+      this.router.currentRouteName.startsWith('course-next')
     ) {
       return false;
     } else {

--- a/app/templates/course-next/index.hbs
+++ b/app/templates/course-next/index.hbs
@@ -1,0 +1,11 @@
+<div class="py-3 px-3 md:px-6 border-b border-white/5">
+  <div class="flex items-center gap-2">
+    <CourseLogo @course={{@model.course}} class="size-8 brightness-90" />
+  </div>
+</div>
+
+<div class="container mx-auto lg:max-w-(--breakpoint-lg) px-3 md:px-6 pt-12 pb-32">
+  <h1 class="text-4xl font-semibold text-gradient-to-b from-white to-gray-300 leading-10">
+    {{@model.course.name}}
+  </h1>
+</div>


### PR DESCRIPTION
Introduce an experimental 'course-next' route with dynamic course slug
parameter and a corresponding model that fetches course data including
extensions, stages, and language configurations. Add a basic UI template
to display course logo and name. Update layout service to recognize the
new route and adjust layout behavior accordingly. This sets groundwork for
testing a new course UI.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces an experimental course view and basic UI.
> 
> - Adds `course-next` route at `/courses-next/:course_slug` in `router.ts`
> - Implements `CourseNextIndexRoute` to load the selected `course` (including `extensions`, `stages`, and `language-configurations.language`) and sets route color scheme to `Both`
> - Adds `course-next/index.hbs` to display `CourseLogo` and `course.name`
> - Updates `layout` service to hide header/footer for `course-next` routes
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e93f8e2eb78e3616947a41ae3b37477ce0a593ef. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->