### PR TITLE
Fix submission logs scrolling to bottom on every `ActionCable` event

### DIFF
--- a/app/components/submission-logs-preview.ts
+++ b/app/components/submission-logs-preview.ts
@@ -15,6 +15,8 @@ interface Signature {
 export default class SubmissionLogsPreview extends Component<Signature> {
   @tracked isLoadingLogs = false;
 
+  #lastRenderedLogFileContents: string | null | undefined;
+
   get evaluation() {
     return this.args.submission.evaluations[0];
   }
@@ -49,8 +51,12 @@ export default class SubmissionLogsPreview extends Component<Signature> {
     }
   }
 
+  @action
   handleDidUpdateLogs(element: HTMLElement) {
-    element.scrollTop = element.scrollHeight;
+    if (this.#lastRenderedLogFileContents !== this.evaluation?.logsFileContents) {
+      this.#lastRenderedLogFileContents = this.evaluation?.logsFileContents;
+      element.scrollTop = element.scrollHeight;
+    }
   }
 }
 


### PR DESCRIPTION
Closes #2128

### Brief

This fixes submission logs viewer scrolling to the bottom every time `ActionCable` receives data.

### Details

Only scroll the logs to bottom when their contents have changed (and not on any other related ember-data updates).

### Demo

https://github.com/user-attachments/assets/5efcaeff-fd00-485d-9e64-bd4bc9b4572d

### Checklist

- [x] I've thoroughly self-reviewed my changes
- [x] I've added tests for my changes, unless they affect admin-only areas (or are otherwise not worth testing)
- [x] I've verified any visual changes using Percy (add a commit with `[percy]` in the message to trigger)
