### PR TITLE
refactor(loading-skeleton): simplify component and update usage

### DIFF
--- a/app/components/leaderboard-page/entries-table/skeleton-row.hbs
+++ b/app/components/leaderboard-page/entries-table/skeleton-row.hbs
@@ -8,18 +8,12 @@
   <LeaderboardPage::EntriesTable::RowCell>
     <div class="flex items-center justify-between gap-x-6">
       <div class="flex items-center gap-1.5">
-        <div class="flex-shrink-0 flex h-6 w-6">
-          <LoadingSkeleton @isCircle={{true}} />
-        </div>
-        <div class="text-xs font-mono max-w-[12ch] sm:max-w-[16ch] truncate">
-          <LoadingSkeleton @width={{60}} />
-        </div>
+        <LoadingSkeleton @isCircle={{true}} class="size-6 flex-shrink-0" />
+        <LoadingSkeleton class="w-[12ch] sm:w-[16ch] text-xs" />
       </div>
       <div class="hidden md:flex items-center gap-1.5 flex-shrink-0 opacity-25 group-hover/table-row:opacity-100">
         {{#each (repeat 6)}}
-          <div class="flex h-4 w-4">
-            <LoadingSkeleton @isCircle={{true}} />
-          </div>
+          <LoadingSkeleton class="w-4 flex-shrink-0" />
         {{/each}}
       </div>
     </div>
@@ -27,7 +21,8 @@
 
   <LeaderboardPage::EntriesTable::RowCell class="hidden md:table-cell">
     <div class="flex items-center justify-end gap-2">
-      <LoadingSkeleton @width={{20}} />
+      <LoadingSkeleton class="w-[3ch] text-xs" />
+
       <span class="text-gray-400 dark:text-gray-500 text-xs font-mono">
         stages
       </span>
@@ -36,7 +31,8 @@
 
   <LeaderboardPage::EntriesTable::RowCell>
     <div class="flex items-center justify-end gap-2">
-      <LoadingSkeleton @width={{20}} />
+      <LoadingSkeleton class="w-[4ch] text-xs" />
+
       <span class="text-gray-400 dark:text-gray-500 text-xs font-mono">
         pts
       </span>

--- a/app/components/loading-skeleton.hbs
+++ b/app/components/loading-skeleton.hbs
@@ -1,6 +1,2 @@
-<div
-  class="bg-gray-200 dark:bg-gray-900 animate-pulse {{if @isCircle 'rounded-full' 'rounded-sm h-4'}}"
-  style={{html-safe this.widthStyle}}
-  ...attributes
->
+<div class="bg-gray-200 dark:bg-white/20 animate-pulse {{if @isCircle 'rounded-full' 'rounded-sm h-[1em]'}}" ...attributes>
 </div>

--- a/app/components/loading-skeleton.ts
+++ b/app/components/loading-skeleton.ts
@@ -5,21 +5,10 @@ interface Signature {
 
   Args: {
     isCircle?: boolean;
-    width?: 'full' | number;
   };
 }
 
-export default class LoadingSkeleton extends Component<Signature> {
-  get widthStyle(): string {
-    if (this.args.width === 'full') {
-      return 'width: 100%;';
-    } else if (this.args.width) {
-      return `width: ${this.args.width}px;`;
-    } else {
-      return 'width: 100%;';
-    }
-  }
-}
+export default class LoadingSkeleton extends Component<Signature> {}
 
 declare module '@glint/environment-ember-loose/registry' {
   export default interface Registry {


### PR DESCRIPTION
Remove width argument and related style logic from LoadingSkeleton to 
simplify the component. Replace width prop with utility CSS classes 
for sizing and styling in skeleton-row template.

Update all LoadingSkeleton instances to use consistent TailwindCSS 
classes for width, height, and border radius, improving maintainability 
and flexibility across different loading placeholders. Adjust colors 
and dimensions for better visual consistency in light and dark modes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Refactors `LoadingSkeleton` to be purely presentational and sized via utility classes, then updates leaderboard skeleton row usage accordingly.
> 
> - Removes `width` arg and `widthStyle` logic from `loading-skeleton.ts`; component now only accepts `@isCircle`
> - Simplifies `loading-skeleton.hbs` with Tailwind classes, sets default height via `h-[1em]`, and tweaks dark mode color to `dark:bg-white/20`
> - Replaces inline width props with class-based sizing in `leaderboard-page/entries-table/skeleton-row.hbs` (e.g., `size-6`, `w-[12ch]`, `w-4`, `w-[3ch]`, `w-[4ch]`) and minor text size adjustments
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f54938561ca771dd7d9f2cad241558c231d77e34. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->