### PR TITLE
refactor(leaderboard-entry): replace skeleton divs with LoadingSkeleton

### DIFF
--- a/app/components/leaderboard-entry.hbs
+++ b/app/components/leaderboard-entry.hbs
@@ -8,7 +8,7 @@
   <div class="flex items-center min-w-0">
     <div class="{{unless @isCollapsed 'mr-2'}} shrink-0">
       {{#if this.isSkeleton}}
-        <div class="w-8 h-8 bg-gray-200 dark:bg-gray-900 rounded-sm"></div>
+        <LoadingSkeleton class="size-8" />
       {{else}}
         {{! additional if clause to satisfy glint }}
         {{#if @user}}
@@ -22,7 +22,7 @@
 
     {{#unless @isCollapsed}}
       {{#if this.isSkeleton}}
-        <span class="text-xs inline-block rounded-sm bg-gray-200 dark:bg-gray-900 mr-2">{{#each (repeat 30)}}&nbsp;{{/each}}</span>
+        <LoadingSkeleton class="w-[12ch] text-xs mr-2" />
       {{else}}
         <span
           class="text-xs text-gray-600 dark:text-gray-400 group-hover/leaderboard-entry:underline mr-2 shrink truncate"
@@ -43,7 +43,7 @@
         data-test-progress-text
       >
         {{#if this.isSkeleton}}
-          <span class="inline-block bg-gray-200 dark:bg-gray-900">{{#each (repeat 6)}}&nbsp;{{/each}}</span>
+          <LoadingSkeleton class="w-[6ch] text-xs" />
         {{else}}
           {{@progressNumerator}}
           /
@@ -51,7 +51,7 @@
         {{/if}}
       </span>
       {{#if this.isSkeleton}}
-        <div class="w-12 h-3.5 rounded-sm bg-gray-200 dark:bg-gray-900" />
+        <LoadingSkeleton class="w-12 h-3.5" />
       {{else}}
         <div
           class="w-12 h-3.5 rounded-sm flex overflow-hidden border group-hover/leaderboard-entry:bg-white dark:group-hover/leaderboard-entry:bg-gray-900 transition-all

--- a/app/components/loading-skeleton.hbs
+++ b/app/components/loading-skeleton.hbs
@@ -1,2 +1,2 @@
-<div class="bg-gray-200 dark:bg-white/20 animate-pulse {{if @isCircle 'rounded-full' 'rounded-sm h-[1em]'}}" ...attributes>
+<div class="bg-gray-200 dark:bg-white/20 animate-pulse {{if @isCircle 'rounded-full' 'rounded-sm min-h-[1em]'}}" ...attributes>
 </div>


### PR DESCRIPTION
Replace multiple repetitive skeleton placeholder divs and spans
with a reusable LoadingSkeleton component to improve consistency
and maintainability of loading states.

fix(loading-skeleton): adjust styling for min height consistency

Update the LoadingSkeleton component to use min-height instead of
fixed height to better accommodate varying content sizes and ensure
visual consistency across themes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Consolidates loading placeholders for consistency and maintainability.
> 
> - Replaces inline skeleton `div`/`span` markup in `leaderboard-entry.hbs` with `LoadingSkeleton` for avatar, username, progress text, and progress bar
> - Tweaks classes on usages (e.g., `size-8`, `w-[12ch]`, `w-[6ch]`, `w-12 h-3.5`) for clearer sizing during loading states
> - Updates `loading-skeleton.hbs` to use `min-h-[1em]` instead of fixed height to better accommodate varying content and themes
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9fc9a09e30a62d7ab2c6190ab913748d7473bf36. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->