### PR TITLE
fix: update dark mode border colors in leaderboard table

### DIFF
--- a/app/components/leaderboard-page/entries-table/filler-row.hbs
+++ b/app/components/leaderboard-page/entries-table/filler-row.hbs
@@ -1,5 +1,5 @@
 <tr class="bg-gray-50 dark:bg-gray-900">
-  <td colspan="4" class="px-4 py-3 whitespace-nowrap border border-gray-200 dark:border-gray-700 text-center">
+  <td colspan="4" class="px-4 py-3 whitespace-nowrap border border-gray-200 dark:border-white/5 text-center">
     <div class="text-xs text-gray-500 dark:text-gray-400">
       {{@text}}
     </div>

--- a/app/components/leaderboard-page/entries-table/header-row-cell.hbs
+++ b/app/components/leaderboard-page/entries-table/header-row-cell.hbs
@@ -1,4 +1,4 @@
-<th scope="col" class="font-normal px-4 py-3 border border-gray-200 dark:border-gray-700" ...attributes>
+<th scope="col" class="font-normal px-4 py-3 border border-gray-200 dark:border-white/5" ...attributes>
   <div class="flex items-center gap-1 {{if (eq @alignment 'left') 'justify-start' 'justify-end'}}">
     <span class="text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">
       {{@title}}

--- a/app/components/leaderboard-page/entries-table/row-cell.hbs
+++ b/app/components/leaderboard-page/entries-table/row-cell.hbs
@@ -1,3 +1,3 @@
-<td class="px-4 py-2 whitespace-nowrap border border-gray-200 dark:border-gray-700" ...attributes>
+<td class="px-4 py-2 whitespace-nowrap border border-gray-200 dark:border-white/5" ...attributes>
   {{yield}}
 </td>


### PR DESCRIPTION
Change border colors in table cells, header cells, and filler rows to use
a lighter opacity in dark mode (dark:border-white/5) instead of the darker
gray-700 shade. This improves visual consistency and readability in dark
mode by providing subtler borders on the leaderboard page.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adjusts dark-mode table borders on the leaderboard for improved contrast consistency.
> 
> - Replace `dark:border-gray-700` with `dark:border-white/5` in `header-row-cell.hbs`, `row-cell.hbs`, and `filler-row.hbs`
> - Affects header cells, data cells, and filler row borders only; no logic changes
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bc35eecf5d3ae167bc158717319accdae14f3d0d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->