### PR TITLE
style: update dark mode border colors for better contrast

### DIFF
--- a/app/components/track-page/primer-concept-group-section/index.hbs
+++ b/app/components/track-page/primer-concept-group-section/index.hbs
@@ -7,7 +7,7 @@
   data-test-primer-concept-group-section
 >
   <div
-    class="border-b border-gray-200 dark:border-gray-700 pb-1 mb-4 flex items-center gap-2
+    class="border-b border-gray-200 dark:border-white/5 pb-1 mb-4 flex items-center gap-2
       {{unless
         this.conceptListIsExpanded
         'group-hover/concept-group-section:border-gray-300 dark:group-hover/concept-group-section:border-gray-600'

--- a/app/templates/track.hbs
+++ b/app/templates/track.hbs
@@ -18,7 +18,7 @@
           />
         {{/if}}
 
-        <div class="border-b border-gray-200 dark:border-gray-700 pb-1 mb-4 flex">
+        <div class="border-b border-gray-200 dark:border-white/5 pb-1 mb-4 flex">
           <div class="text-2xl font-semibold text-gray-900 dark:text-gray-200">
             {{@model.language.name}}
             Challenges


### PR DESCRIPTION
Change dark mode border colors from gray-700 to white with 5% opacity
to improve visual contrast and consistency across components in the
track header and primer concept group section. This enhances readability
and aligns with the updated design guidelines.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates dark-mode border styling for improved contrast and consistency.
> 
> - In `track.hbs`, change Challenges section header border to `dark:border-white/5`
> - In `track-page/primer-concept-group-section/index.hbs`, change section header border to `dark:border-white/5`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cf222236621849ee42ceda9652503e5380ae8918. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->