### PR TITLE
fix(leaderboard): improve surrounding entries visibility logic

### DIFF
--- a/app/components/leaderboard-page/entries-table.hbs
+++ b/app/components/leaderboard-page/entries-table.hbs
@@ -11,14 +11,14 @@
               <LeaderboardPage::EntriesTable::SkeletonRow @rankText={{concat "#" rank}} />
             {{/each}}
           {{else}}
-            {{#each this.sortedTopEntries as |entry index|}}
+            {{#each this.sortedEntriesForFirstSection as |entry index|}}
               <LeaderboardPage::EntriesTable::Row @entry={{entry}} @rankText={{concat "#" (add index 1)}} />
             {{/each}}
 
-            {{#if this.shouldShowSurroundingEntries}}
+            {{#if (gt this.sortedEntriesForSecondSectionWithRanks.length 0)}}
               <LeaderboardPage::EntriesTable::FillerRow @text="... other users ..." />
 
-              {{#each this.sortedSurroundingEntriesWithRanks as |entryWithRank|}}
+              {{#each this.sortedEntriesForSecondSectionWithRanks as |entryWithRank|}}
                 <LeaderboardPage::EntriesTable::Row @entry={{entryWithRank.entry}} @rankText={{concat "#" entryWithRank.rank}} />
               {{/each}}
             {{/if}}

--- a/app/components/leaderboard-page/entries-table.ts
+++ b/app/components/leaderboard-page/entries-table.ts
@@ -22,35 +22,45 @@ export default class LeaderboardPageEntriesTable extends Component<Signature> {
   @service declare authenticator: AuthenticatorService;
   @service declare store: Store;
 
+  get entriesForFirstSection() {
+    const entries = [...this.args.topEntries];
+
+    if (this.surroundingEntriesOverlapsTopEntries) {
+      entries.push(...this.args.surroundingEntries);
+    }
+
+    return entries;
+  }
+
   get hasEntries() {
     return this.args.topEntries.length > 0;
   }
 
-  get shouldShowSurroundingEntries(): boolean {
-    return this.args.surroundingEntries.length > 0 && !this.surroundingEntriesOverlapsTopEntries;
+  get sortedEntriesForFirstSection() {
+    return this.entriesForFirstSection.filter((entry) => !entry.isBanned).sort((a, b) => b.score - a.score);
   }
 
-  get sortedSurroundingEntries() {
+  get sortedEntriesForSecondSection() {
+    if (this.surroundingEntriesOverlapsTopEntries) {
+      return [];
+    }
+
     return this.args.surroundingEntries.filter((entry) => !entry.isBanned).sort((a, b) => b.score - a.score);
   }
 
-  get sortedSurroundingEntriesWithRanks() {
-    return this.sortedSurroundingEntries.map((entry, index) => ({
+  get sortedEntriesForSecondSectionWithRanks() {
+    return this.sortedEntriesForSecondSection.map((entry, index) => ({
       entry: entry,
-      rank: this.args.userRankCalculation!.rank + (index - this.userEntryIndexInSurroundingEntries),
+      rank: this.args.userRankCalculation!.rank + (index - this.userEntryIndexInSecondSection),
     }));
-  }
-
-  get sortedTopEntries() {
-    return this.args.topEntries.filter((entry) => !entry.isBanned).sort((a, b) => b.score - a.score);
   }
 
   get surroundingEntriesOverlapsTopEntries(): boolean {
     return this.args.surroundingEntries.some((entry) => this.args.topEntries.map((e) => e.user.id).includes(entry.user.id));
   }
 
-  get userEntryIndexInSurroundingEntries() {
-    return this.sortedSurroundingEntries.findIndex((entry) => entry.user.id === this.authenticator.currentUserId);
+  get userEntryIndexInSecondSection() {
+    return this.sortedEntriesForSecondSection.findIndex((entry) => entry.user.id === this.authenticator.currentUserId);
   }
 
   get userIsInTopLeaderboardEntries(): boolean {


### PR DESCRIPTION
Update shouldShowSurroundingEntries to check for overlap with top
entries instead of user-in-top condition. Add surroundingEntriesOverlapsTopEntries
getter to determine if any surrounding entries appear in top entries.
Filter banned entries in sortedTopEntries to exclude them from display.

These changes ensure the leaderboard accurately displays surrounding
entries without duplication or overlap with top entries.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Refines how leaderboard entries are segmented and rendered to avoid duplicates when surrounding entries overlap with top entries.
> 
> - Adds `entriesForFirstSection`, `sortedEntriesForFirstSection`, and `sortedEntriesForSecondSection(WithRanks)`; removes previous surrounding/top-specific getters
> - Introduces `surroundingEntriesOverlapsTopEntries` to merge surrounding entries into the first section when overlapping and hide the second section
> - Filters banned entries and sorts both sections by score; recalculates second-section ranks relative to `userRankCalculation`
> - Updates template to use new getters and conditionally render the second section and filler row
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 224cec89c9b94f6f572c43078a22e0cdaa1c4aa7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->