### PR TITLE
Suppress promotional messages from `dotenv` package during `ember build`

### DIFF
--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -1,6 +1,6 @@
 'use strict';
 
-require('dotenv').config();
+require('dotenv').config({ quiet: true });
 
 const EmberApp = require('ember-cli/lib/broccoli/ember-app');
 const config = require('./config/environment')(EmberApp.env());


### PR DESCRIPTION
Related to https://github.com/motdotla/dotenv/issues/922
Follow-up to https://github.com/codecrafters-io/frontend/pull/3135

### Brief

This removes promotional messages generated by `dotenv` extension from the output of `ember build`, `ember start` and other commands 

### Screenshot

<img width="711" height="97" alt="Знімок екрана 2025-12-28 о 14 34 17" src="https://github.com/user-attachments/assets/f92ed8e2-c99a-4680-a8ce-794899db2940" />
<img width="505" height="62" alt="Знімок екрана 2025-12-28 о 14 52 57" src="https://github.com/user-attachments/assets/f6aaef8f-6f2b-48f8-bf5f-48a64ea4215b" />

### Details

Passing `{ quiet: true }` to `dotenv.config()` removes all the distracting output

**Checklist**:

- [x] I've thoroughly self-reviewed my changes
- [x] I've added tests for my changes, unless they affect admin-only areas (or are otherwise not worth testing)
- [x] I've verified any visual changes using Percy (add a commit with `[percy]` in the message to trigger)
