### PR TITLE
fix(style): update dark mode border hover color in concept group section

### DIFF
--- a/app/components/track-page/primer-concept-group-section/index.hbs
+++ b/app/components/track-page/primer-concept-group-section/index.hbs
@@ -10,7 +10,7 @@
     class="border-b border-gray-200 dark:border-white/5 pb-1 mb-4 flex items-center gap-2
       {{unless
         this.conceptListIsExpanded
-        'group-hover/concept-group-section:border-gray-300 dark:group-hover/concept-group-section:border-gray-600'
+        'group-hover/concept-group-section:border-gray-300 dark:group-hover/concept-group-section:border-white/10'
       }}"
   >
     <div class="text-2xl font-semibold text-gray-900 dark:text-gray-200">


### PR DESCRIPTION
Change the dark mode border hover color from gray-600 to white at 10% 
opacity in the primer concept group section to improve visual consistency 
and enhance readability during hover states.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Refines dark-mode hover styling for clarity and consistency.
> 
> - In `primer-concept-group-section/index.hbs`, changes `dark:group-hover/concept-group-section:border-gray-600` to `dark:group-hover/concept-group-section:border-white/10` on the section header border
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b162bd144e701bee44cba085ea1074716287a36f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->