### PR TITLE
refactor(repository-poller): reorder included resources and remove redundant return

### DIFF
--- a/app/utils/repository-poller.ts
+++ b/app/utils/repository-poller.ts
@@ -5,19 +5,18 @@ export default class RepositoryPoller extends Poller {
   declare model: RepositoryModel;
 
   static defaultIncludedResources = [
-    'language',
-    'language.leaderboard',
-    'extension-activations',
-    'extension-activations.extension',
-    'extension-activations.repository',
     'course',
-    'course.extensions',
-    'user',
     'course-stage-completions',
     'course-stage-completions.course-stage',
     'course-stage-feedback-submissions',
     'course-stage-feedback-submissions.course-stage',
+    'course.extensions',
+    'extension-activations',
+    'extension-activations.extension',
+    'extension-activations.repository',
     'github-repository-sync-configurations',
+    'language',
+    'language.leaderboard',
     'last-submission',
     'last-submission.autofix-requests',
     // 'last-submission.autofix-requests.submission', // Hardcoded on backend to be included, doesn't seem to make a difference?
@@ -27,10 +26,11 @@ export default class RepositoryPoller extends Poller {
     'stage-list',
     'stage-list.items',
     'stage-list.items.stage',
+    'user',
   ].join(',');
 
   async doPoll() {
-    return await this.store.query('repository', {
+    await this.store.query('repository', {
       course_id: this.model.course.id,
       include: RepositoryPoller.defaultIncludedResources,
     });


### PR DESCRIPTION
Rearrange the defaultIncludedResources array for better readability and
consistency. Remove the redundant return statement in doPoll to simplify
the async function, as the returned Promise is not used. These changes
improve code clarity without affecting functionality.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Refactors `RepositoryPoller` for clarity without changing behavior.
> 
> - Reorders `defaultIncludedResources` for readability and consistency (adds/moves `course.extensions`, `extension-activations*`, `language*`, `user` within the joined list)
> - Simplifies `doPoll()` by removing the redundant `return` and just `await`ing `store.query`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 831240fd14b572380523899568777fb6d291a99b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->