### PR TITLE
feat: add on-visibility-change modifier to handle tab visibility

### DIFF
--- a/app/modifiers/on-visibility-change.ts
+++ b/app/modifiers/on-visibility-change.ts
@@ -1,0 +1,36 @@
+// Invokes a callback when the document visibility changes (tab becomes hidden/visible).
+// Usage: <div {{on-visibility-change this.handleVisibilityChange}}></div>
+import Modifier from 'ember-modifier';
+import { service } from '@ember/service';
+import { registerDestructor } from '@ember/destroyable';
+import type VisibilityService from 'codecrafters-frontend/services/visibility';
+
+interface Signature {
+  Args: {
+    Positional: [(isVisible: boolean) => void];
+  };
+}
+
+function cleanup(instance: OnVisibilityChangeModifier) {
+  if (instance.callbackId) {
+    instance.visibility.deregisterCallback(instance.callbackId);
+  }
+}
+
+export default class OnVisibilityChangeModifier extends Modifier<Signature> {
+  callbackId?: string;
+
+  @service declare visibility: VisibilityService;
+
+  modify(_element: Element, [callback]: [(isVisible: boolean) => void]) {
+    cleanup(this); // Ensure we remove the previous callback if present
+    this.callbackId = this.visibility.registerCallback(callback);
+    registerDestructor(this, cleanup);
+  }
+}
+
+declare module '@glint/environment-ember-loose/registry' {
+  export default interface Registry {
+    'on-visibility-change': typeof OnVisibilityChangeModifier;
+  }
+}


### PR DESCRIPTION
Introduce an Ember modifier that invokes a callback when the document
visibility changes (e.g., when the tab becomes hidden or visible). This
enables components to react to visibility state changes easily by
registering and deregistering callbacks with a central visibility
service, improving code reuse and separation of concerns.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) is generating a summary for commit 22eaf102cf1670bc51fd2c0f64ad78f1c52d6707. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- GitButler Footer Boundary Top -->
---
This is **part 1 of 3 in a stack** made with GitButler:
- <kbd>&nbsp;3&nbsp;</kbd> #3423 
- <kbd>&nbsp;2&nbsp;</kbd> #3422 
- <kbd>&nbsp;1&nbsp;</kbd> #3421 👈 
<!-- GitButler Footer Boundary Bottom -->

