### PR TITLE
feat(leaderboard): refactor polling and use ember-concurrency task

### DIFF
--- a/app/components/course-leaderboard/index.hbs
+++ b/app/components/course-leaderboard/index.hbs
@@ -1,4 +1,12 @@
-<div {{did-insert this.handleDidInsert}} {{will-destroy this.handleWillDestroy}} data-test-leaderboard ...attributes>
+<div {{did-insert this.pollLeaderboardTask.perform}} data-test-leaderboard ...attributes>
+  {{#unless this.authenticator.isAnonymous}}
+    <div
+      class="hidden"
+      {{on-action-cable-message this.pollLeaderboardTask.perform channel="CourseLeaderboardChannel" args=(hash course_id=@course.id)}}
+      {{on-visibility-change this.pollLeaderboardTask.perform if="visible"}}
+    />
+  {{/unless}}
+
   {{#if @isCollapsed}}
     <div class="pl-4 mb-3 h-6 flex justify-center items-center">
       {{svg-jar (if this.team "user-group" "globe") class="fill-current text-gray-600 w-5"}}


### PR DESCRIPTION
Refactor LeaderboardPoller to remove inheritance and accept course and team
instances directly, simplifying data fetching logic. Replace manual polling in
CourseLeaderboard component with an ember-concurrency task to handle leaderboard
updates more efficiently and reliably. Remove unused state and polling methods,
and integrate automatic task triggering on ActionCable messages to maintain up-
to-date leaderboard entries. These changes improve code clarity, maintainability,
and responsiveness of leaderboard data.

<!-- GitButler Footer Boundary Top -->
---
This is **part 2 of 3 in a stack** made with GitButler:
- <kbd>&nbsp;3&nbsp;</kbd> #3423 
- <kbd>&nbsp;2&nbsp;</kbd> #3422 👈 
- <kbd>&nbsp;1&nbsp;</kbd> #3421 
<!-- GitButler Footer Boundary Bottom -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Replaces manual polling with an ember-concurrency task and simplifies the poller for clearer, more reliable leaderboard updates.
> 
> - Introduces `pollLeaderboardTask` in `CourseLeaderboard` and triggers it on `did-insert`, ActionCable messages, and visibility changes; removes old start/stop poller logic and related state
> - Refactors `LeaderboardPoller` to a plain class that takes `course` and optional `team` and queries via `course.store` (no inheritance/jitter there); jitter now handled in the task
> - Cleans up component state and keeps existing animations/merging logic intact
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3da43b071516111929c65ec772dc4724506bb9f2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->