### PR TITLE
Remove LeaderboardPoller

### DIFF
--- a/app/components/course-leaderboard/index.hbs
+++ b/app/components/course-leaderboard/index.hbs
@@ -1,4 +1,12 @@
-<div {{did-insert this.handleDidInsert}} {{will-destroy this.handleWillDestroy}} data-test-leaderboard ...attributes>
+<div {{did-insert this.pollLeaderboardTask.perform}} data-test-leaderboard ...attributes>
+  {{#unless this.authenticator.isAnonymous}}
+    <div
+      class="hidden"
+      {{on-action-cable-message this.pollLeaderboardTask.perform channel="CourseLeaderboardChannel" args=(hash course_id=@course.id)}}
+      {{on-visibility-change this.pollLeaderboardTask.perform if="visible"}}
+    />
+  {{/unless}}
+
   {{#if @isCollapsed}}
     <div class="pl-4 mb-3 h-6 flex justify-center items-center">
       {{svg-jar (if this.team "user-group" "globe") class="fill-current text-gray-600 w-5"}}


### PR DESCRIPTION
Refactor LeaderboardPoller to remove inheritance and accept course and team
instances directly, simplifying data fetching logic. Replace manual polling in
CourseLeaderboard component with an ember-concurrency task to handle leaderboard
updates more efficiently and reliably. Remove unused state and polling methods,
and integrate automatic task triggering on ActionCable messages to maintain up-
to-date leaderboard entries. These changes improve code clarity, maintainability,
and responsiveness of leaderboard data.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Streamlines leaderboard updates and removes custom poller lifecycle.
> 
> - Introduces `pollLeaderboardTask` with jitter (except in tests) to fetch entries and manage loading/reloading state
> - `index.hbs` triggers the task on insert and on `CourseLeaderboardChannel` messages and visibility changes (skipped for anonymous users)
> - Removes `handleDidInsert`, `handleWillDestroy`, `startLeaderboardPoller`, `stopLeaderboardPoller`, and `handlePoll` in favor of the task
> - Refactors `LeaderboardPoller` to a simple class that accepts `course` and optional `team` and queries `course.store` directly
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 665085b3be5d3b9744e21c15004236c7dad04c76. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->