### PR TITLE
fix(tests): correct index display in API request verification

### DIFF
--- a/tests/support/verify-api-requests.js
+++ b/tests/support/verify-api-requests.js
@@ -26,13 +26,15 @@ export default function verifyApiRequests(server, expectedPaths) {
       let lines = [];
 
       for (let j = 0; j < i; j++) {
-        lines.push(`✔ [${j}] ${expectedPaths[j]}`);
+        lines.push(`✔ [${j + 1}] ${expectedPaths[j]}`);
       }
 
-      lines.push(`✗ [${i}] Expected: ${expectedPath ? expectedPath : '<none>'} | Actual: ${actualPath ? actualPath : '<none>'}`);
+      lines.push(`✗ [${i + 1}] Expected: ${expectedPath ? expectedPath : '<none>'} | Actual: ${actualPath ? actualPath : '<none>'}`);
 
       for (let j = i + 1; j < Math.max(filteredRequests.length, expectedPaths.length); j++) {
-        lines.push(`   [${j}] Expected: ${expectedPaths[j] ? expectedPaths[j] : '<none>'} | Actual: ${actualPaths[j] ? actualPaths[j] : '<none>'}`);
+        lines.push(
+          `   [${j + 1}] Expected: ${expectedPaths[j] ? expectedPaths[j] : '<none>'} | Actual: ${actualPaths[j] ? actualPaths[j] : '<none>'}`,
+        );
       }
 
       throw new Error(lines.join('\n'));


### PR DESCRIPTION
Adjust the displayed indices in verify-api-requests.js to be
1-based instead of 0-based for clearer and more intuitive test
output. This improves readability when comparing expected and
actual API request paths during test failures.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Improves readability of test failure messages in the API request verifier.
> 
> - Updates `tests/support/verify-api-requests.js` to display 1-based indices for matched, mismatched, and subsequent expected/actual lines
> - No changes to request filtering or comparison logic; only output formatting is affected
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 37b7b7a702339c7421f47cdd037f1ebbf3cef7f9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->