### PR TITLE
Move to apiRequestsVerifier class

### DIFF
--- a/tests/acceptance/course-page/attempt-course-stage-test.js
+++ b/tests/acceptance/course-page/attempt-course-stage-test.js
@@ -1,4 +1,4 @@
-import verifyApiRequests from 'codecrafters-frontend/tests/support/verify-api-requests';
+import ApiRequestsVerifier from 'codecrafters-frontend/tests/support/verify-api-requests';
 import courseOverviewPage from 'codecrafters-frontend/tests/pages/course-overview-page';
 import catalogPage from 'codecrafters-frontend/tests/pages/catalog-page';
 import coursePage from 'codecrafters-frontend/tests/pages/course-page';
@@ -19,6 +19,8 @@ module('Acceptance | course-page | attempt-course-stage', function (hooks) {
     testScenario(this.server);
     signInAsSubscriber(this.owner, this.server);
 
+    const apiRequestsVerifier = new ApiRequestsVerifier(this.server);
+
     let currentUser = this.server.schema.users.first();
     let python = this.server.schema.languages.findBy({ name: 'Python' });
     let redis = this.server.schema.courses.findBy({ slug: 'redis' });
@@ -29,26 +31,27 @@ module('Acceptance | course-page | attempt-course-stage', function (hooks) {
       user: currentUser,
     });
 
-    let expectedRequests = [
-      '/api/v1/repositories', // fetch repositories (catalog page)
-      '/api/v1/courses', // fetch courses (catalog page)
-      '/api/v1/languages', // fetch languages (catalog page)
-      '/api/v1/courses', // fetch course details (course overview page)
-      '/api/v1/repositories', // fetch repositories (course page)
-      '/api/v1/course-leaderboard-entries', // fetch leaderboard entries (course overview page)
-      '/api/v1/courses', // refresh course (course page)
-      '/api/v1/repositories', // fetch repositories (course page)
-      '/api/v1/course-stage-comments', // fetch stage comments (course page)
-      '/api/v1/course-leaderboard-entries', // fetch leaderboard entries (course page)
-    ];
-
     await catalogPage.visit();
     await catalogPage.clickOnCourse('Build your own Redis');
     await courseOverviewPage.clickOnStartCourse();
 
     assert.strictEqual(currentURL(), '/courses/redis/stages/rg2', 'current URL is course page URL');
 
-    assert.ok(verifyApiRequests(this.server, expectedRequests), 'API requests match expected sequence');
+    assert.ok(
+      apiRequestsVerifier.verify([
+        '/api/v1/repositories', // fetch repositories (catalog page)
+        '/api/v1/courses', // fetch courses (catalog page)
+        '/api/v1/languages', // fetch languages (catalog page)
+        '/api/v1/courses', // fetch course details (course overview page)
+        '/api/v1/repositories', // fetch repositories (course page)
+        '/api/v1/course-leaderboard-entries', // fetch leaderboard entries (course overview page)
+        '/api/v1/courses', // refresh course (course page)
+        '/api/v1/repositories', // fetch repositories (course page)
+        '/api/v1/course-stage-comments', // fetch stage comments (course page)
+        '/api/v1/course-leaderboard-entries', // fetch leaderboard entries (course page)
+      ]),
+      'API requests match expected sequence',
+    );
 
     assert.strictEqual(coursePage.header.stepName, 'Respond to PING', 'second stage is active');
     assert.strictEqual(coursePage.testResultsBar.progressIndicatorText, 'Ready to run tests...', 'footer text is waiting for git push');

--- a/tests/acceptance/course-page/resume-course-test.js
+++ b/tests/acceptance/course-page/resume-course-test.js
@@ -1,7 +1,7 @@
 import catalogPage from 'codecrafters-frontend/tests/pages/catalog-page';
 import courseOverviewPage from 'codecrafters-frontend/tests/pages/course-overview-page';
 import testScenario from 'codecrafters-frontend/mirage/scenarios/test';
-import verifyApiRequests from 'codecrafters-frontend/tests/support/verify-api-requests';
+import ApiRequestsVerifier from 'codecrafters-frontend/tests/support/verify-api-requests';
 import { currentURL } from '@ember/test-helpers';
 import { module, test } from 'qunit';
 import { setupAnimationTest } from 'ember-animated/test-support';
@@ -15,6 +15,8 @@ module('Acceptance | course-page | resume-course-test', function (hooks) {
   test('can resume course', async function (assert) {
     testScenario(this.server);
     signIn(this.owner, this.server);
+
+    const apiRequestsVerifier = new ApiRequestsVerifier(this.server);
 
     let currentUser = this.server.schema.users.first();
     let python = this.server.schema.languages.findBy({ name: 'Python' });
@@ -32,19 +34,20 @@ module('Acceptance | course-page | resume-course-test', function (hooks) {
 
     assert.strictEqual(currentURL(), '/courses/redis/stages/rg2', 'current URL is course page URL');
 
-    const expectedRequests = [
-      '/api/v1/repositories', // fetch repositories (catalog page)
-      '/api/v1/courses', // fetch courses (catalog page)
-      '/api/v1/languages', // fetch languages (catalog page)
-      '/api/v1/courses', // fetch course details (course overview page)
-      '/api/v1/repositories', // fetch repositories (course page)
-      '/api/v1/course-leaderboard-entries', // fetch leaderboard entries (course page)
-      '/api/v1/courses', // refresh course (course page)
-      '/api/v1/repositories', // fetch repositories (course page)
-      '/api/v1/course-stage-comments', // fetch stage comments (course page)
-      '/api/v1/course-leaderboard-entries', // fetch leaderboard entries (course page)
-    ];
-
-    assert.ok(verifyApiRequests(this.server, expectedRequests), 'API requests match expected sequence');
+    assert.ok(
+      apiRequestsVerifier.verify([
+        '/api/v1/repositories', // fetch repositories (catalog page)
+        '/api/v1/courses', // fetch courses (catalog page)
+        '/api/v1/languages', // fetch languages (catalog page)
+        '/api/v1/courses', // fetch course details (course overview page)
+        '/api/v1/repositories', // fetch repositories (course page)
+        '/api/v1/course-leaderboard-entries', // fetch leaderboard entries (course page)
+        '/api/v1/courses', // refresh course (course page)
+        '/api/v1/repositories', // fetch repositories (course page)
+        '/api/v1/course-stage-comments', // fetch stage comments (course page)
+        '/api/v1/course-leaderboard-entries', // fetch leaderboard entries (course page)
+      ]),
+      'API requests match expected sequence',
+    );
   });
 });

--- a/tests/acceptance/course-page/switch-repository-test.js
+++ b/tests/acceptance/course-page/switch-repository-test.js
@@ -2,7 +2,7 @@ import catalogPage from 'codecrafters-frontend/tests/pages/catalog-page';
 import courseOverviewPage from 'codecrafters-frontend/tests/pages/course-overview-page';
 import coursePage from 'codecrafters-frontend/tests/pages/course-page';
 import testScenario from 'codecrafters-frontend/mirage/scenarios/test';
-import verifyApiRequests from 'codecrafters-frontend/tests/support/verify-api-requests';
+import ApiRequestsVerifier from 'codecrafters-frontend/tests/support/verify-api-requests';
 import { module, test } from 'qunit';
 import { setupAnimationTest } from 'ember-animated/test-support';
 import { setupApplicationTest } from 'codecrafters-frontend/tests/helpers';
@@ -17,6 +17,8 @@ module('Acceptance | course-page | switch-repository', function (hooks) {
   test('can switch repository', async function (assert) {
     testScenario(this.server);
     signIn(this.owner, this.server);
+
+    const apiRequestsVerifier = new ApiRequestsVerifier(this.server);
 
     const fakeActionCableConsumer = new FakeActionCableConsumer();
     this.owner.register('service:action-cable-consumer', fakeActionCableConsumer, { instantiate: false });
@@ -43,37 +45,28 @@ module('Acceptance | course-page | switch-repository', function (hooks) {
 
     await catalogPage.visit();
 
-    let expectedRequests = [
-      '/api/v1/repositories', // fetch repositories (catalog page)
-      '/api/v1/courses', // fetch courses (catalog page)
-      '/api/v1/languages', // fetch languages (catalog page)
-    ];
-
-    assert.ok(verifyApiRequests(this.server, expectedRequests), 'API requests match expected sequence after visiting catalog page');
+    assert.ok(
+      apiRequestsVerifier.verify([
+        '/api/v1/repositories', // fetch repositories (catalog page)
+        '/api/v1/courses', // fetch courses (catalog page)
+        '/api/v1/languages', // fetch languages (catalog page)
+      ]),
+      'API requests match expected sequence after visiting catalog page',
+    );
 
     await catalogPage.clickOnCourse('Build your own Redis');
 
-    expectedRequests = [
-      '/api/v1/courses', // fetch course details (course overview page)
-      '/api/v1/repositories', // fetch repositories (course overview page)
-      '/api/v1/course-leaderboard-entries', // fetch leaderboard entries (course overview page)
-      '/api/v1/course-leaderboard-entries', // fetch leaderboard entries after subscribed (course overview page)
-    ];
-
-    assert.ok(verifyApiRequests(this.server, expectedRequests), 'API requests match expected sequence after visiting course overview page');
+    assert.ok(
+      apiRequestsVerifier.verify([
+        '/api/v1/courses', // fetch course details (course overview page)
+        '/api/v1/repositories', // fetch repositories (course overview page)
+        '/api/v1/course-leaderboard-entries', // fetch leaderboard entries (course overview page)
+        '/api/v1/course-leaderboard-entries', // fetch leaderboard entries after subscribed (course overview page)
+      ]),
+      'API requests match expected sequence after visiting course overview page',
+    );
 
     await courseOverviewPage.clickOnStartCourse();
-
-    expectedRequests = [
-      '/api/v1/courses', // refresh course (course page)
-      '/api/v1/repositories', // fetch repositories (course page)
-      '/api/v1/course-stage-comments', // fetch stage comments (course page)
-      '/api/v1/course-leaderboard-entries', // fetch leaderboard entries (course page)
-      '/api/v1/repositories', // fetch repositories (course page)
-      '/api/v1/course-leaderboard-entries', // fetch leaderboard entries after subscribed (course page)
-      '/api/v1/repositories', // fetch repositories after subscribed (course page)
-      '/api/v1/course-leaderboard-entries', // fetch leaderboard entries after subscribed (course page)
-    ];
 
     assert.strictEqual(coursePage.repositoryDropdown.activeRepositoryName, goRepository.name, 'repository with last push should be active');
     assert.strictEqual(coursePage.header.stepName, 'Bind to a port');
@@ -81,7 +74,19 @@ module('Acceptance | course-page | switch-repository', function (hooks) {
     fakeActionCableConsumer.sendData('RepositoryChannel', { event: 'updated' });
     fakeActionCableConsumer.sendData('CourseLeaderboardChannel', { event: 'updated' });
     await finishRender();
-    assert.ok(verifyApiRequests(this.server, expectedRequests), 'API requests match expected sequence after polling');
+    assert.ok(
+      apiRequestsVerifier.verify([
+        '/api/v1/courses', // refresh course (course page)
+        '/api/v1/repositories', // fetch repositories (course page)
+        '/api/v1/course-stage-comments', // fetch stage comments (course page)
+        '/api/v1/course-leaderboard-entries', // fetch leaderboard entries (course page)
+        '/api/v1/repositories', // fetch repositories (course page)
+        '/api/v1/course-leaderboard-entries', // fetch leaderboard entries after subscribed (course page)
+        '/api/v1/repositories', // fetch repositories after subscribed (course page)
+        '/api/v1/course-leaderboard-entries', // fetch leaderboard entries after subscribed (course page)
+      ]),
+      'API requests match expected sequence after polling',
+    );
 
     await coursePage.repositoryDropdown.click();
     assert.strictEqual(coursePage.repositoryDropdown.content.nonActiveRepositoryCount, 1, 'non active repositories should be 1');

--- a/tests/acceptance/course-page/try-other-language-test.js
+++ b/tests/acceptance/course-page/try-other-language-test.js
@@ -1,4 +1,4 @@
-import verifyApiRequests from 'codecrafters-frontend/tests/support/verify-api-requests';
+import ApiRequestsVerifier from 'codecrafters-frontend/tests/support/verify-api-requests';
 import coursePage from 'codecrafters-frontend/tests/pages/course-page';
 import catalogPage from 'codecrafters-frontend/tests/pages/catalog-page';
 import testScenario from 'codecrafters-frontend/mirage/scenarios/test';
@@ -19,6 +19,8 @@ module('Acceptance | course-page | try-other-language', function (hooks) {
     testScenario(this.server, ['dummy']);
     signInAsSubscriber(this.owner, this.server);
 
+    const apiRequestsVerifier = new ApiRequestsVerifier(this.server);
+
     const fakeActionCableConsumer = new FakeActionCableConsumer();
     this.owner.register('service:action-cable-consumer', fakeActionCableConsumer, { instantiate: false });
 
@@ -35,27 +37,28 @@ module('Acceptance | course-page | try-other-language', function (hooks) {
       user: currentUser,
     });
 
-    let expectedRequests = [
-      '/api/v1/repositories', // fetch repositories (catalog page)
-      '/api/v1/courses', // fetch courses (catalog page)
-      '/api/v1/languages', // fetch languages (catalog page)
-      '/api/v1/courses', // fetch course details (course overview page)
-      '/api/v1/repositories', // fetch repositories (course overview page)
-      '/api/v1/course-leaderboard-entries', // fetch leaderboard entries (course overview page)
-      '/api/v1/course-leaderboard-entries', // fetch leaderboard entries after subscribed (course overview page)
-      '/api/v1/courses', // refresh course (course page)
-      '/api/v1/repositories', // fetch repositories (course page)
-      '/api/v1/course-stage-comments', // fetch stage comments (course page)
-      '/api/v1/course-leaderboard-entries', // fetch leaderboard entries (course page)
-      '/api/v1/repositories', // fetch repositories after subscribed (course page)
-      '/api/v1/course-leaderboard-entries', // fetch leaderboard entries after subscribed (course page)
-    ];
-
     await catalogPage.visit();
     await catalogPage.clickOnCourse('Build your own Dummy');
     await courseOverviewPage.clickOnStartCourse();
 
-    assert.ok(verifyApiRequests(this.server, expectedRequests), 'API requests match expected sequence');
+    assert.ok(
+      apiRequestsVerifier.verify([
+        '/api/v1/repositories', // fetch repositories (catalog page)
+        '/api/v1/courses', // fetch courses (catalog page)
+        '/api/v1/languages', // fetch languages (catalog page)
+        '/api/v1/courses', // fetch course details (course overview page)
+        '/api/v1/repositories', // fetch repositories (course overview page)
+        '/api/v1/course-leaderboard-entries', // fetch leaderboard entries (course overview page)
+        '/api/v1/course-leaderboard-entries', // fetch leaderboard entries after subscribed (course overview page)
+        '/api/v1/courses', // refresh course (course page)
+        '/api/v1/repositories', // fetch repositories (course page)
+        '/api/v1/course-stage-comments', // fetch stage comments (course page)
+        '/api/v1/course-leaderboard-entries', // fetch leaderboard entries (course page)
+        '/api/v1/repositories', // fetch repositories after subscribed (course page)
+        '/api/v1/course-leaderboard-entries', // fetch leaderboard entries after subscribed (course page)
+      ]),
+      'API requests match expected sequence',
+    );
 
     assert.strictEqual(coursePage.repositoryDropdown.activeRepositoryName, pythonRepository.name, 'repository with last push should be active');
     assert.strictEqual(coursePage.header.stepName, 'The second stage', 'first stage should be active');
@@ -63,33 +66,35 @@ module('Acceptance | course-page | try-other-language', function (hooks) {
     await coursePage.repositoryDropdown.click();
     await coursePage.repositoryDropdown.clickOnAction('Try a different language');
 
-    expectedRequests = [
-      '/api/v1/courses', // refresh course (after try different language)
-      '/api/v1/repositories', // update repositories (after try different language)
-      '/api/v1/course-language-requests', // fetch language requests (after try different language)
-      '/api/v1/languages', // fetch languages (after try different language)
-      '/api/v1/course-leaderboard-entries', // update leaderboard (after try different language)
-      '/api/v1/course-leaderboard-entries', // update leaderboard after subscribed (after try different language)
-    ];
-
-    assert.ok(verifyApiRequests(this.server, expectedRequests), 'API requests match expected sequence after clicking try different language');
+    assert.ok(
+      apiRequestsVerifier.verify([
+        '/api/v1/courses', // refresh course (after try different language)
+        '/api/v1/repositories', // update repositories (after try different language)
+        '/api/v1/course-language-requests', // fetch language requests (after try different language)
+        '/api/v1/languages', // fetch languages (after try different language)
+        '/api/v1/course-leaderboard-entries', // update leaderboard (after try different language)
+        '/api/v1/course-leaderboard-entries', // update leaderboard after subscribed (after try different language)
+      ]),
+      'API requests match expected sequence after clicking try different language',
+    );
     assert.strictEqual(currentURL(), '/courses/dummy/introduction?repo=new');
     assert.strictEqual(coursePage.header.stepName, 'Introduction', 'step name is introduction');
 
     await coursePage.createRepositoryCard.clickOnLanguageButton('Go');
     await animationsSettled();
 
-    expectedRequests = [
-      '/api/v1/repositories', // create repository (after selecting Go)
-      '/api/v1/repositories', // update repositories (after selecting Go)
-      '/api/v1/courses', // refresh course (after selecting Go)
-      '/api/v1/repositories', // update repositories (after selecting Go)
-      '/api/v1/course-leaderboard-entries', // update leaderboard (after selecting Go)
-      '/api/v1/repositories', // update repositories after subscribed (after selecting Go)
-      '/api/v1/course-leaderboard-entries', // update leaderboard after subscribed (after selecting Go)
-    ];
-
-    assert.ok(verifyApiRequests(this.server, expectedRequests), 'API requests match expected sequence after selecting Go language');
+    assert.ok(
+      apiRequestsVerifier.verify([
+        '/api/v1/repositories', // create repository (after selecting Go)
+        '/api/v1/repositories', // update repositories (after selecting Go)
+        '/api/v1/courses', // refresh course (after selecting Go)
+        '/api/v1/repositories', // update repositories (after selecting Go)
+        '/api/v1/course-leaderboard-entries', // update leaderboard (after selecting Go)
+        '/api/v1/repositories', // update repositories after subscribed (after selecting Go)
+        '/api/v1/course-leaderboard-entries', // update leaderboard after subscribed (after selecting Go)
+      ]),
+      'API requests match expected sequence after selecting Go language',
+    );
     assert.strictEqual(coursePage.repositoryDropdown.activeRepositoryName, 'Go', 'Repository name should change');
     assert.strictEqual(currentURL(), '/courses/dummy/introduction?repo=2', 'current URL is course page URL with repo query param');
 
@@ -113,15 +118,16 @@ module('Acceptance | course-page | try-other-language', function (hooks) {
     await finishRender();
     await new Promise((resolve) => setTimeout(resolve, 1000));
 
-    expectedRequests = [
-      '/api/v1/repositories/2', // poll repository status (course page)
-      '/api/v1/repositories/2', // poll repository updates (course page)
-      '/api/v1/repositories/2', // poll repository changes (course page)
-      '/api/v1/repositories', // update repositories (after status change)
-      '/api/v1/course-leaderboard-entries', // update leaderboard (after status change)
-    ];
-
-    assert.ok(verifyApiRequests(this.server, expectedRequests), 'API requests match expected sequence after first poll');
+    assert.ok(
+      apiRequestsVerifier.verify([
+        '/api/v1/repositories/2', // poll repository status (course page)
+        '/api/v1/repositories/2', // poll repository updates (course page)
+        '/api/v1/repositories/2', // poll repository changes (course page)
+        '/api/v1/repositories', // update repositories (after status change)
+        '/api/v1/course-leaderboard-entries', // update leaderboard (after status change)
+      ]),
+      'API requests match expected sequence after first poll',
+    );
 
     assert.ok(coursePage.repositorySetupCard.statusIsComplete, 'current status is complete');
 
@@ -130,12 +136,13 @@ module('Acceptance | course-page | try-other-language', function (hooks) {
     await finishRender();
     await new Promise((resolve) => setTimeout(resolve, 1000));
 
-    expectedRequests = [
-      '/api/v1/repositories', // poll repositories (course page)
-      '/api/v1/course-leaderboard-entries', // poll leaderboard (course page)
-    ];
-
-    assert.ok(verifyApiRequests(this.server, expectedRequests), 'API requests match expected sequence after second poll');
+    assert.ok(
+      apiRequestsVerifier.verify([
+        '/api/v1/repositories', // poll repositories (course page)
+        '/api/v1/course-leaderboard-entries', // poll leaderboard (course page)
+      ]),
+      'API requests match expected sequence after second poll',
+    );
   });
 
   test('can try other language from repository setup page (regression)', async function (assert) {

--- a/tests/support/verify-api-requests.js
+++ b/tests/support/verify-api-requests.js
@@ -1,51 +1,56 @@
-let lastCheckedRequestIndex = 0;
-
-export default function verifyApiRequests(server, expectedPaths) {
-  const requests = server.pretender.handledRequests.slice(lastCheckedRequestIndex);
-
-  // Filter out analytics and current user requests
-  const filteredRequests = requests.filter((request) => {
-    const pathname = new URL(request.url).pathname;
-
-    return (
-      // Triggered on every pageview
-      pathname !== '/api/v1/analytics-events' &&
-      // Triggered on application boot
-      pathname !== '/api/v1/users/current' &&
-      // Triggered when header is rendered
-      !pathname.match(/^\/api\/v1\/users\/[^/]+\/top-language-leaderboard-slugs$/)
-    );
-  });
-
-  const actualPaths = filteredRequests.map((request) => new URL(request.url).pathname);
-
-  // Verify number of requests matches
-  for (let i = 0; i < Math.max(filteredRequests.length, expectedPaths.length); i++) {
-    const expectedPath = expectedPaths[i];
-    const actualPath = actualPaths[i];
-
-    if (actualPath !== expectedPath) {
-      let lines = [];
-
-      for (let j = 0; j < i; j++) {
-        lines.push(`✔ [${j + 1}] ${expectedPaths[j]}`);
-      }
-
-      lines.push(`✗ [${i + 1}] Expected: ${expectedPath ? expectedPath : '<none>'} | Actual: ${actualPath ? actualPath : '<none>'}`);
-
-      for (let j = i + 1; j < Math.max(filteredRequests.length, expectedPaths.length); j++) {
-        lines.push(
-          `   [${j + 1}] Expected: ${expectedPaths[j] ? expectedPaths[j] : '<none>'} | Actual: ${actualPaths[j] ? actualPaths[j] : '<none>'}`,
-        );
-      }
-
-      throw new Error(lines.join('\n'));
-    }
+export default class ApiRequestsVerifier {
+  constructor(server) {
+    this.server = server;
+    this.lastCheckedRequestIndex = 0;
   }
 
-  // Update index to point to the end of all requests (including filtered ones)
-  // This ensures we check incrementally on subsequent calls
-  lastCheckedRequestIndex = server.pretender.handledRequests.length;
+  verify(expectedPaths) {
+    const requests = this.server.pretender.handledRequests.slice(this.lastCheckedRequestIndex);
 
-  return true;
+    // Filter out analytics and current user requests
+    const filteredRequests = requests.filter((request) => {
+      const pathname = new URL(request.url).pathname;
+
+      return (
+        // Triggered on every pageview
+        pathname !== '/api/v1/analytics-events' &&
+        // Triggered on application boot
+        pathname !== '/api/v1/users/current' &&
+        // Triggered when header is rendered
+        !pathname.match(/^\/api\/v1\/users\/[^/]+\/top-language-leaderboard-slugs$/)
+      );
+    });
+
+    const actualPaths = filteredRequests.map((request) => new URL(request.url).pathname);
+
+    // Verify number of requests matches
+    for (let i = 0; i < Math.max(filteredRequests.length, expectedPaths.length); i++) {
+      const expectedPath = expectedPaths[i];
+      const actualPath = actualPaths[i];
+
+      if (actualPath !== expectedPath) {
+        let lines = [];
+
+        for (let j = 0; j < i; j++) {
+          lines.push(`✔ [${j + 1}] ${expectedPaths[j]}`);
+        }
+
+        lines.push(`✗ [${i + 1}] Expected: ${expectedPath ? expectedPath : '<none>'} | Actual: ${actualPath ? actualPath : '<none>'}`);
+
+        for (let j = i + 1; j < Math.max(filteredRequests.length, expectedPaths.length); j++) {
+          lines.push(
+            `   [${j + 1}] Expected: ${expectedPaths[j] ? expectedPaths[j] : '<none>'} | Actual: ${actualPaths[j] ? actualPaths[j] : '<none>'}`,
+          );
+        }
+
+        throw new Error(lines.join('\n'));
+      }
+    }
+
+    // Update index to point to the end of all requests (including filtered ones)
+    // This ensures we check incrementally on subsequent calls
+    this.lastCheckedRequestIndex = this.server.pretender.handledRequests.length;
+
+    return true;
+  }
 }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Refactors the API request verification helper to improve readability and incremental checking across multiple assertions in a test.
> 
> - Introduces `ApiRequestsVerifier` class in `tests/support/verify-api-requests.js` that tracks the last checked request index and filters non-essential requests
> - Updates acceptance tests (`start-course-test.js`, `resume-course-test.js`, `switch-repository-test.js`, `attempt-course-stage-test.js`, `try-other-language-test.js`) to instantiate the verifier and call `verify([...])` per step instead of maintaining cumulative arrays
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bd4a5a9bb7edfb2a878f007942096b75501c7523. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->