### PR TITLE
ci: increase test parallelism and upgrade runner hardware

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ concurrency:
 
 jobs:
   test:
-    runs-on: depot-ubuntu-24.04-16
+    runs-on: depot-ubuntu-24.04-32
     # Use cheaper machines for dependabot if we're low on namespace credits
     # runs-on: ${{ github.actor == 'dependabot[bot]' && 'namespace-profile-frontend-light' || 'namespace-profile-frontend' }}
     permissions: write-all
@@ -66,7 +66,7 @@ jobs:
           PERCY_TOKEN: ${{secrets.PERCY_TOKEN}}
           STRIPE_PUBLISHABLE_KEY: "dummy"
 
-      - run: npx percy exec --quiet -- npx ember exam --silent --reporter=xunit --parallel=16 --load-balance --preserve-test-name --path dist | tee test-results.xml
+      - run: npx percy exec --quiet -- npx ember exam --silent --reporter=xunit --parallel=32 --load-balance --preserve-test-name --path dist | tee test-results.xml
         env:
           COVERAGE: true
           PERCY_ENABLE: ${{steps.compute_percy_enable.outputs.percy_enable || '0'}}


### PR DESCRIPTION
Increase test job parallelism from 16 to 32 to speed up test 
execution. Update the CI runner machine to depot-ubuntu-24.04-32 
to support the higher parallel workload. These changes improve 
test efficiency and reduce overall CI time.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Speeds up CI tests by increasing parallelism and provisioning a larger runner.
> 
> - Upgrades GitHub Actions runner to `depot-ubuntu-24.04-32` in `.github/workflows/test.yml`
> - Doubles Ember test parallelism from `--parallel=16` to `--parallel=32` in the test step
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b44014691b8eb39dcad96d5c8d1ef17e0be7c918. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->