### PR TITLE
feat(leaderboard): enhance leaderboard data handling and UI

### DIFF
--- a/app/routes/catalog.ts
+++ b/app/routes/catalog.ts
@@ -42,7 +42,7 @@ export default class CatalogRoute extends BaseRoute {
 
     // Resources required by the track page
     modelPromises._languages = this.store.findAll('language', {
-      include: 'primer-concept-group,primer-concept-group.author,primer-concept-group.concepts,primer-concept-group.concepts.author',
+      include: 'leaderboard,primer-concept-group,primer-concept-group.author,primer-concept-group.concepts,primer-concept-group.concepts.author',
     }) as unknown as Promise<LanguageModel[]>;
 
     return RSVPHash(modelPromises) as Promise<ModelType>;

--- a/app/routes/track.ts
+++ b/app/routes/track.ts
@@ -46,7 +46,7 @@ export default class TrackRoute extends BaseRoute {
     })) as unknown as CourseModel[];
 
     (await this.store.findAll('language', {
-      include: 'primer-concept-group,primer-concept-group.author,primer-concept-group.concepts,primer-concept-group.concepts.author',
+      include: 'leaderboard,primer-concept-group,primer-concept-group.author,primer-concept-group.concepts,primer-concept-group.concepts.author',
     })) as unknown as LanguageModel[];
 
     const language = this.store.peekAll('language').find((language) => language.slug === params.track_slug)!;


### PR DESCRIPTION
Refactor leaderboard fetching and sorting logic to use the new
'leaderboard-entry' model filtered by leaderboard ID and banned status.
Update language query to include leaderboard relations for consistent data.

Revamp leaderboard component template to display entries with ranks,
support multiple sections, and improve empty state messaging from
"no recent activity" to "no one has completed any stages yet" for clarity.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Preloads leaderboard data by expanding `language` includes.
> 
> - Update `app/routes/catalog.ts` and `app/routes/track.ts` to include `leaderboard` in `this.store.findAll('language', { include: ... })`.
> - Ensures `language` models fetched for catalog/track have `leaderboard` relationship available alongside existing primer concept relations.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b58efcad4af1ab3f5ab8b7f97a7f540d35584a89. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->