### PR TITLE
feat(data): include leaderboard in language configurations for courses

### DIFF
--- a/app/routes/catalog.ts
+++ b/app/routes/catalog.ts
@@ -37,7 +37,7 @@ export default class CatalogRoute extends BaseRoute {
     }
 
     modelPromises.courses = this.store.findAll('course', {
-      include: 'extensions,stages,language-configurations.language',
+      include: 'extensions,stages,language-configurations.language.leaderboard',
     }) as unknown as Promise<CourseModel[]>;
 
     // Resources required by the track page

--- a/app/routes/course-admin.ts
+++ b/app/routes/course-admin.ts
@@ -28,7 +28,7 @@ export default class CourseAdminRoute extends BaseRoute {
 
   async model(params: { course_slug: string }): Promise<ModelType> {
     const courses = await this.store.findAll('course', {
-      include: 'extensions,stages,language-configurations.language',
+      include: 'extensions,stages,language-configurations.language.leaderboard',
     });
 
     return {

--- a/app/routes/course-overview.ts
+++ b/app/routes/course-overview.ts
@@ -52,7 +52,7 @@ export default class CourseOverviewRoute extends BaseRoute {
   async #findCourse(slug: string) {
     return (
       await this.store.findAll('course', {
-        include: 'extensions,stages,language-configurations.language',
+        include: 'extensions,stages,language-configurations.language.leaderboard',
       })
     ).find((item) => item.slug === slug);
   }

--- a/app/routes/join-course.ts
+++ b/app/routes/join-course.ts
@@ -51,7 +51,7 @@ export default class JoinCourseRoute extends BaseRoute {
     const affiliateLink = affiliateLinks[0]!; // afterModel handles the case where this is undefined
 
     const courses = await this.store.findAll('course', {
-      include: 'extensions,stages,language-configurations.language',
+      include: 'extensions,stages,language-configurations.language.leaderboard',
     });
 
     const course = courses.find((item) => item.slug === params.course_slug);

--- a/app/routes/join-track.ts
+++ b/app/routes/join-track.ts
@@ -53,7 +53,7 @@ export default class JoinTrackRoute extends BaseRoute {
 
     // Make sure we have all courses loaded to display
     const courses = (await this.store.findAll('course', {
-      include: 'extensions,stages,language-configurations.language',
+      include: 'extensions,stages,language-configurations.language.leaderboard',
     })) as unknown as CourseModel[];
 
     const language = this.store.peekAll('language').find((item) => item.slug === params.track_slug) as LanguageModel;

--- a/app/routes/leaderboard.ts
+++ b/app/routes/leaderboard.ts
@@ -25,7 +25,7 @@ export default class LeaderboardRoute extends BaseRoute {
 
   async model(params: { language_slug: string }): Promise<ModelType> {
     (await this.store.findAll('course', {
-      include: 'extensions,stages,language-configurations.language',
+      include: 'extensions,stages,language-configurations.language.leaderboard',
     })) as unknown as CourseModel[];
 
     const languages = (await this.store.findAll('language', {

--- a/app/routes/track.ts
+++ b/app/routes/track.ts
@@ -42,7 +42,7 @@ export default class TrackRoute extends BaseRoute {
   // TODO: Handle missing language?
   async model(params: { track_slug: string }): Promise<ModelType> {
     const courses = (await this.store.findAll('course', {
-      include: 'extensions,stages,language-configurations.language',
+      include: 'extensions,stages,language-configurations.language.leaderboard',
     })) as unknown as CourseModel[];
 
     (await this.store.findAll('language', {


### PR DESCRIPTION
Update data fetching in multiple routes to include the leaderboard 
relationship within language-configurations of courses. This enhances 
the loaded course data with leaderboard details, enabling richer UI 
features and providing users with more comprehensive progress and 
ranking information.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Loads leaderboard data alongside course language configurations across key routes.
> 
> - Update `findAll('course')` includes to `extensions,stages,language-configurations.language.leaderboard` in `catalog`, `course-admin`, `course-overview`, `join-course`, `join-track`, `leaderboard`, and `track`
> - No other logic changes
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 471970119f946fec63d5e6990db94896844167ba. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->