### PR TITLE
fix(tests): reduce default test timeout when Percy is disabled

### DIFF
--- a/tests/test-helper.js
+++ b/tests/test-helper.js
@@ -44,6 +44,6 @@ QUnit.done(async function () {
   await sendCoverage();
 });
 
-QUnit.config.testTimeout = config.x.percyIsEnabled ? 20000 : 5000;
+QUnit.config.testTimeout = config.x.percyIsEnabled ? 20000 : 3000;
 
 startEmberExam();


### PR DESCRIPTION
Decrease QUnit test timeout from 5000ms to 3000ms for cases 
when Percy is not enabled. This speeds up test runs by avoiding
unnecessary wait time while maintaining sufficient timeout for
test stability.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Reduces default QUnit timeout to speed up local/CI tests without Percy.
> 
> - In `tests/test-helper.js`, updates `QUnit.config.testTimeout` to `config.x.percyIsEnabled ? 20000 : 3000` (from 5000).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d6967814cd516d739ec98058805ac4fc78679f87. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->