### PR TITLE
feat(course-page): extract right sidebar to reusable component

### DIFF
--- a/app/components/course-page/right-sidebar.hbs
+++ b/app/components/course-page/right-sidebar.hbs
@@ -1,0 +1,28 @@
+<div class="group {{if @isExpanded 'w-64 xl:w-80'}}" ...attributes>
+  <div class="sticky top-16 z-11 {{if @isExpanded 'px-6' 'px-4'}}">
+    <div
+      class="opacity-0 group-hover:opacity-100 absolute top-6 -left-3.5 z-10"
+      {{on "click" (if @isExpanded @onCollapseButtonClick @onExpandButtonClick)}}
+      role="button"
+    >
+      {{#if @isExpanded}}
+        <CoursePage::CollapseLeaderboardButton data-test-collapse-leaderboard-button />
+      {{else}}
+        <CoursePage::ExpandLeaderboardButton data-test-expand-leaderboard-button />
+      {{/if}}
+    </div>
+
+    <CourseLeaderboard
+      class={{if @isExpanded "-ml-6" "-ml-4"}}
+      @course={{@course}}
+      @activeRepository={{@activeRepository}}
+      @repositories={{@repositories}}
+      @isCollapsed={{not @isExpanded}}
+    />
+
+    {{#if (and @isExpanded this.visiblePrivateLeaderboardFeatureSuggestion)}}
+      {{! @glint-expect-error: not ts-ified yet }}
+      <PrivateLeaderboardFeatureSuggestion @featureSuggestion={{this.visiblePrivateLeaderboardFeatureSuggestion}} class="mt-6" />
+    {{/if}}
+  </div>
+</div>

--- a/app/components/course-page/right-sidebar.ts
+++ b/app/components/course-page/right-sidebar.ts
@@ -1,0 +1,43 @@
+import Component from '@glimmer/component';
+import CourseModel from 'codecrafters-frontend/models/course';
+import RepositoryModel from 'codecrafters-frontend/models/repository';
+import type FeatureSuggestionModel from 'codecrafters-frontend/models/feature-suggestion';
+import type AuthenticatorService from 'codecrafters-frontend/services/authenticator';
+import { service } from '@ember/service';
+import FeatureFlagsService from 'codecrafters-frontend/services/feature-flags';
+
+interface Signature {
+  Element: HTMLDivElement;
+
+  Args: {
+    course: CourseModel;
+    activeRepository: RepositoryModel;
+    repositories: RepositoryModel[];
+    isExpanded: boolean;
+    onCollapseButtonClick: () => void;
+    onExpandButtonClick: () => void;
+  };
+}
+
+export default class CoursePageRightSidebar extends Component<Signature> {
+  @service declare authenticator: AuthenticatorService;
+  @service declare featureFlags: FeatureFlagsService;
+
+  get currentUser() {
+    return this.authenticator.currentUser;
+  }
+
+  get visiblePrivateLeaderboardFeatureSuggestion(): FeatureSuggestionModel | null {
+    if (!this.currentUser || this.currentUser.isTeamMember) {
+      return null;
+    }
+
+    return this.currentUser.featureSuggestions.filter((item) => item.featureIsPrivateLeaderboard).filter((item) => !item.isDismissed)[0] || null;
+  }
+}
+
+declare module '@glint/environment-ember-loose/registry' {
+  export default interface Registry {
+    'CoursePage::RightSidebar': typeof CoursePageRightSidebar;
+  }
+}

--- a/app/controllers/course.ts
+++ b/app/controllers/course.ts
@@ -52,14 +52,6 @@ export default class CourseController extends Controller {
     return this.repo;
   }
 
-  get visiblePrivateLeaderboardFeatureSuggestion() {
-    if (!this.currentUser || this.currentUser.isTeamMember) {
-      return null;
-    }
-
-    return this.currentUser.featureSuggestions.filter((item) => item.featureIsPrivateLeaderboard).filter((item) => !item.isDismissed)[0];
-  }
-
   @action
   handleCollapseLeaderboardButtonClick() {
     this.leaderboardIsExpanded = !this.leaderboardIsExpanded;

--- a/app/templates/course.hbs
+++ b/app/templates/course.hbs
@@ -88,39 +88,15 @@
         {{outlet}}
       </div>
 
-      <div
-        class="{{if this.leaderboardIsExpanded 'w-64 xl:w-80 pr-6' 'pr-4'}}
-          pt-6 shrink-0 border-l border-gray-200 dark:border-white/5 bg-gray-50 dark:bg-gray-950 hidden md:block group"
-      >
-        <div class="sticky top-14 z-11">
-          {{#if this.leaderboardIsExpanded}}
-            <CoursePage::CollapseLeaderboardButton
-              class="opacity-0 group-hover:opacity-100 absolute top-6 -left-3.5 z-10"
-              {{on "click" this.handleCollapseLeaderboardButtonClick}}
-              data-test-collapse-leaderboard-button
-            />
-          {{else}}
-            <CoursePage::ExpandLeaderboardButton
-              class="opacity-0 group-hover:opacity-100 absolute top-6 -left-3.5 z-10"
-              {{on "click" this.handleExpandLeaderboardButtonClick}}
-              data-test-expand-leaderboard-button
-            />
-          {{/if}}
-
-          <CourseLeaderboard
-            class="sticky top-14"
-            @course={{@model.course}}
-            @activeRepository={{@model.activeRepository}}
-            @repositories={{@model.repositories}}
-            @isCollapsed={{not this.leaderboardIsExpanded}}
-          />
-
-          {{#if (and this.leaderboardIsExpanded this.visiblePrivateLeaderboardFeatureSuggestion)}}
-            {{! @glint-expect-error: not ts-ified yet }}
-            <PrivateLeaderboardFeatureSuggestion @featureSuggestion={{this.visiblePrivateLeaderboardFeatureSuggestion}} class="ml-4 mt-6" />
-          {{/if}}
-        </div>
-      </div>
+      <CoursePage::RightSidebar
+        @course={{@model.course}}
+        @activeRepository={{@model.activeRepository}}
+        @repositories={{@model.repositories}}
+        @isExpanded={{this.leaderboardIsExpanded}}
+        @onCollapseButtonClick={{this.handleCollapseLeaderboardButtonClick}}
+        @onExpandButtonClick={{this.handleExpandLeaderboardButtonClick}}
+        class="pt-6 shrink-0 border-l border-gray-200 dark:border-white/5 bg-gray-50 dark:bg-gray-950 hidden md:block"
+      />
     </div>
   </div>
 


### PR DESCRIPTION
Move the leaderboard sidebar and its controls into a new 
CoursePage::RightSidebar component. This consolidates markup 
and logic, improving maintainability and reducing duplication 
in the course template. The sidebar toggles expansion state 
and conditionally shows a private leaderboard feature 
suggestion based on the current user's permissions.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces a reusable right sidebar component for the course page, consolidating leaderboard UI and related logic.
> 
> - Adds `CoursePage::RightSidebar` (`right-sidebar.hbs` + `.ts`) encapsulating expand/collapse controls, `CourseLeaderboard`, and conditional `PrivateLeaderboardFeatureSuggestion` visibility
> - Removes `visiblePrivateLeaderboardFeatureSuggestion` getter from `course` controller; logic now lives in the component
> - Replaces inline sidebar markup in `app/templates/course.hbs` with `<CoursePage::RightSidebar ...>` and wires existing expand/collapse actions and data (@course, @activeRepository, @repositories)
> - Minor layout tweaks (sticky offset, padding/margins) preserved within the component
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f1bdb35ea61de0eff47358fc855796296f145140. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->