### PR TITLE
refactor(language-leaderboard): move user rank loading to cache service

### DIFF
--- a/app/components/course-page/current-step-complete-modal/language-leaderboard-rank-section.hbs
+++ b/app/components/course-page/current-step-complete-modal/language-leaderboard-rank-section.hbs
@@ -18,19 +18,20 @@
 
     <AnimatedContainer>
       <div class="flex items-center w-full justify-center">
-        {{#animated-if (eq this.userRankCalculation null) use=this.transition duration=300}}
+        {{#animated-if this.refreshRankTask.isRunning use=this.transition duration=300}}
           <b
             class="text-2xl text-teal-600 dark:text-teal-400 border-b border-teal-600 dark:border-teal-400 group-hover:text-teal-500 border-dashed animate-pulse"
           >
             # ⋯
           </b>
         {{else}}
-          <b class="text-2xl text-teal-600 dark:text-teal-400 border-b border-teal-600 dark:border-teal-400 group-hover:text-teal-500 border-dashed">
-            {{! If condition prevents type errors w/ userRankCalculation being nullable }}
-            {{#if this.userRankCalculation}}
-              #{{format-number this.userRankCalculation.rank}}
-            {{/if}}
-          </b>
+          {{#if this.userRank}}
+            <b
+              class="text-2xl text-teal-600 dark:text-teal-400 border-b border-teal-600 dark:border-teal-400 group-hover:text-teal-500 border-dashed"
+            >
+              #{{format-number this.userRank}}
+            </b>
+          {{/if}}
         {{/animated-if}}
       </div>
     </AnimatedContainer>

--- a/app/services/course-stage-completion.ts
+++ b/app/services/course-stage-completion.ts
@@ -19,8 +19,13 @@ export default class CourseStageCompletionService extends Service {
       })
       .save();
 
-    await repository.refreshStateFromServer();
-    await this.authenticator.syncCurrentUser();
+    await Promise.all([
+      // Ensure repository state is up to date
+      repository.refreshStateFromServer(),
+
+      // Ensure things like promotional discounts are updated
+      this.authenticator.syncCurrentUser(),
+    ]);
   });
 }
 

--- a/app/utils/leaderboard-entries-cache.ts
+++ b/app/utils/leaderboard-entries-cache.ts
@@ -73,6 +73,10 @@ export default class LeaderboardEntriesCache {
     return this.entriesForFirstSectionWithRanks.length > 0;
   }
 
+  get userRankCalculation(): LeaderboardRankCalculationModel | null {
+    return this._userRankCalculation;
+  }
+
   @action
   async loadOrRefresh() {
     await this._loadEntriesTask.perform();


### PR DESCRIPTION
Replace direct store usage for user rank calculation with a cached 
leaderboardEntriesCacheRegistry service to centralize leaderboard data 
management and improve data reuse.

Update component to trigger rank refresh on construction and use a new 
refreshRankTask to load data via the cache. Adjust template to show a 
loading state based on task status rather than null checks.

Add userRankCalculation getter to leaderboard-entries-cache utility for 
easier access to rank data.

concurrent(course-stage-completion): run refresh operations in parallel

Change repository refresh and user sync calls to run concurrently using 
Promise.all for improved efficiency during course stage completion.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Centralizes leaderboard rank data and streamlines loading, while improving post-completion refresh efficiency.
> 
> - Replace direct rank calculation fetches with `leaderboardEntriesCacheRegistry` and a `refreshRankTask`; compute `userRank` from cache in the component
> - Update template to show loading via `refreshRankTask.isRunning` and render rank when available
> - Expose `userRankCalculation` via a new getter in `leaderboard-entries-cache`
> - Run repository state refresh and current-user sync concurrently using `Promise.all` in `course-stage-completion`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cd64bb3c916aad756e02913643830cab29d7a5c7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->