### PR TITLE
feat(course-overview): support checking course start with language

### DIFF
--- a/app/components/course-overview-page/start-course-button.ts
+++ b/app/components/course-overview-page/start-course-button.ts
@@ -19,7 +19,15 @@ export default class CourseOverviewStartCourseButton extends Component<Signature
   @service declare authenticator: AuthenticatorService;
 
   get currentUserHasStartedCourse() {
-    return this.authenticator.currentUser && this.authenticator.currentUser.hasStartedCourse(this.args.course);
+    if (!this.authenticator.currentUser) {
+      return false;
+    }
+
+    if (this.args.language) {
+      return this.authenticator.currentUser.hasStartedCourseUsingLanguage(this.args.course, this.args.language);
+    } else {
+      return this.authenticator.currentUser.hasStartedCourse(this.args.course);
+    }
   }
 
   get currentUserIsAnonymous() {

--- a/app/models/user.ts
+++ b/app/models/user.ts
@@ -16,7 +16,8 @@ import GitHubAppInstallationModel from 'codecrafters-frontend/models/github-app-
 import InstitutionMembershipGrantApplicationModel from 'codecrafters-frontend/models/institution-membership-grant-application';
 import InstitutionMembershipGrantModel from 'codecrafters-frontend/models/institution-membership-grant';
 import InvoiceModel from 'codecrafters-frontend/models/invoice';
-import LeaderboardRankCalculationModel from './leaderboard-rank-calculation';
+import LanguageModel from 'codecrafters-frontend/models/language';
+import LeaderboardRankCalculationModel from 'codecrafters-frontend/models/leaderboard-rank-calculation';
 import Model, { attr, hasMany } from '@ember-data/model';
 import PromotionalDiscountModel from 'codecrafters-frontend/models/promotional-discount';
 import ReferralActivationModel from 'codecrafters-frontend/models/referral-activation';
@@ -239,6 +240,15 @@ export default class UserModel extends Model {
 
   hasStartedCourse(course: CourseModel) {
     return this.repositories.filter((item) => !item.isNew).filter((item) => item.course === course).length > 0;
+  }
+
+  hasStartedCourseUsingLanguage(course: CourseModel, language: LanguageModel) {
+    return (
+      this.repositories
+        .filter((item) => !item.isNew)
+        .filter((item) => item.course === course)
+        .filter((item) => item.language === language).length > 0
+    );
   }
 
   isCourseAuthor(course: CourseModel) {


### PR DESCRIPTION
Update start-course-button to check if the current user has started
a course using a specified language. Return false if there is no
current user. This enables conditional UI behavior based on language
context when determining course progress.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Enables language-specific course-start detection and safer handling when no user is authenticated.
> 
> - Update `start-course-button` to return `false` when no `currentUser`, and to check `hasStartedCourseUsingLanguage(course, language)` when `language` is provided, otherwise fall back to `hasStartedCourse(course)`
> - Add `UserModel.hasStartedCourseUsingLanguage(course, language)` and import `LanguageModel` to support filtering repositories by both course and language
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ccf1a20ddbdb42d210e8f7361c8bc779da1db5e4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->