### PR TITLE
test: remove obsolete feature flag setup in acceptance test

### DIFF
--- a/tests/acceptance/course-page/attempt-course-stage-test.js
+++ b/tests/acceptance/course-page/attempt-course-stage-test.js
@@ -80,9 +80,6 @@ module('Acceptance | course-page | attempt-course-stage', function (hooks) {
     const fakeActionCableConsumer = new FakeActionCableConsumer();
     this.owner.register('service:action-cable-consumer', fakeActionCableConsumer, { instantiate: false });
 
-    // TODO: Remove this once leaderboard isn't behind a feature flag
-    currentUser.update({ featureFlags: { 'should-see-leaderboard': 'test' } });
-
     const go = this.server.schema.languages.findBy({ slug: 'go' });
     const redis = this.server.schema.courses.findBy({ slug: 'redis' });
 


### PR DESCRIPTION
Remove the update of the currentUser feature flag for leaderboard visibility,
as the leaderboard feature is no longer behind a feature flag. This cleans up
the test setup and simplifies test conditions.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Cleans up acceptance test setup by removing an obsolete leaderboard feature flag configuration.
> 
> - Deletes manual `currentUser.update({ featureFlags: { 'should-see-leaderboard': 'test' } })` in `tests/acceptance/course-page/attempt-course-stage-test.js`
> - No behavioral changes to tests; rely on default leaderboard visibility
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 22578b7803441134ea1f44f4f8a19f0d2bedfa2b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->