### PR TITLE
feat(track-leaderboard): add leaderboard feature to course page

### DIFF
--- a/app/components/track-leaderboard.hbs
+++ b/app/components/track-leaderboard.hbs
@@ -1,7 +1,7 @@
 <div data-test-track-leaderboard {{did-insert this.handleDidInsert}} ...attributes>
   <div class="flex items-center justify-between mb-2">
     <div class="flex items-center">
-      <span class="uppercase text-teal-500 dark:text-teal-600 text-xs font-bold">{{@language.name}} LEADERBOARD</span>
+      <span class="uppercase text-teal-500 dark:text-teal-600 text-xs font-bold" data-test-leaderboard-title>{{@language.name}} LEADERBOARD</span>
     </div>
     <div>
       {{! Add team dropdown if needed }}

--- a/app/services/feature-flags.ts
+++ b/app/services/feature-flags.ts
@@ -18,6 +18,10 @@ export default class FeatureFlagsService extends Service {
     return !!(this.getFeatureFlagValue('can-view-autofix-flow') === 'test' || this.currentUser?.isStaff);
   }
 
+  get canViewTrackLeaderboardOnCoursePage(): boolean {
+    return !!(this.getFeatureFlagValue('can-view-track-leaderboard-on-course-page') === 'test' || this.currentUser?.isStaff);
+  }
+
   get currentUser(): User | null {
     return this.authenticator.currentUser;
   }

--- a/tests/pages/components/track-leaderboard.ts
+++ b/tests/pages/components/track-leaderboard.ts
@@ -1,0 +1,13 @@
+import { collection, text } from 'ember-cli-page-object';
+
+export default {
+  titleText: text('[data-test-leaderboard-title]'),
+
+  rows: collection('[data-test-leaderboard-row]', {
+    rank: text('[data-test-rank]'),
+    score: text('[data-test-score]'),
+    username: text('[data-test-username]'),
+  }),
+
+  scope: '[data-test-track-leaderboard]',
+};

--- a/tests/pages/course-page.ts
+++ b/tests/pages/course-page.ts
@@ -13,6 +13,7 @@ import SecondStageYourTaskCard from 'codecrafters-frontend/tests/pages/component
 import SetupStepCompleteModal from 'codecrafters-frontend/tests/pages/components/course-page/setup-step-complete-modal';
 import Sidebar from 'codecrafters-frontend/tests/pages/components/course-page/sidebar';
 import TestResultsBar from 'codecrafters-frontend/tests/pages/components/course-page/test-results-bar';
+import TrackLeaderboard from 'codecrafters-frontend/tests/pages/components/track-leaderboard';
 import YourTaskCard from 'codecrafters-frontend/tests/pages/components/course-page/course-stage-step/your-task-card';
 import { clickOnText, clickable, collection, create, isVisible, text, triggerable, visitable } from 'ember-cli-page-object';
 
@@ -162,6 +163,7 @@ export default create({
   repositorySetupCard: RepositorySetupCard,
   sidebar: Sidebar,
   testResultsBar: TestResultsBar,
+  trackLeaderboard: TrackLeaderboard,
 
   testRunnerCard: {
     async clickOnMarkStageAsCompleteButton() {


### PR DESCRIPTION
Add a feature flag to conditionally show the track leaderboard on the
course page for test users and staff. Update the template to include a
test selector for the leaderboard title, and implement a page object
model for interacting with the leaderboard in tests. Integrate the new
page object into the course page test setup to enable testing of the
leaderboard component.

This change enables controlled rollout and testing of the track
leaderboard feature.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Enables controlled rollout and testing of the track leaderboard on the course page.
> 
> - Adds `canViewTrackLeaderboardOnCoursePage()` in `feature-flags.ts` using `can-view-track-leaderboard-on-course-page`
> - Adds `data-test-leaderboard-title` to `track-leaderboard.hbs` title span
> - Introduces `tests/pages/components/track-leaderboard.ts` page object with `titleText` and row accessors
> - Integrates the new page object into `tests/pages/course-page.ts` via import and `trackLeaderboard` property
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d5a8fe9a851107d684bc6cab75120478afd8720e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->