### PR TITLE
test(pages): add rankText accessor to languageLeaderboardRankSection

### DIFF
--- a/app/components/course-page/current-step-complete-modal/language-leaderboard-rank-section.hbs
+++ b/app/components/course-page/current-step-complete-modal/language-leaderboard-rank-section.hbs
@@ -17,7 +17,7 @@
     </span>
 
     <AnimatedContainer>
-      <div class="flex items-center w-full justify-center">
+      <div class="flex items-center w-full justify-center" data-test-rank>
         {{#animated-if this.refreshRankTask.isRunning use=this.transition duration=300}}
           <b
             class="text-2xl text-teal-600 dark:text-teal-400 border-b border-teal-600 dark:border-teal-400 group-hover:text-teal-500 border-dashed animate-pulse"

--- a/tests/pages/course-page.ts
+++ b/tests/pages/course-page.ts
@@ -70,7 +70,10 @@ export default create({
     clickOnNextOrActiveStepButton: clickable('[data-test-next-or-active-step-button]'),
     clickOnViewInstructionsButton: clickable('[data-test-view-instructions-button]'),
     completionMessage: text('[data-test-completion-message]'),
-    languageLeaderboardRankSection: { scope: '[data-test-language-leaderboard-rank-section]' },
+    languageLeaderboardRankSection: {
+      rankText: text('[data-test-rank]'),
+      scope: '[data-test-language-leaderboard-rank-section]',
+    },
     nextOrActiveStepButton: { scope: '[data-test-next-or-active-step-button]' },
     scope: '[data-test-current-step-complete-modal]',
   },


### PR DESCRIPTION
Expose rankText property in the languageLeaderboardRankSection page object
to enable tests to access and assert on the leaderboard rank text directly.

refactor(language-leaderboard-rank-section): add data-test-rank attribute

Add data-test-rank attribute to the rank container for easier and more precise
targeting in UI tests, improving test reliability and readability.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Improves testability of the language leaderboard rank display.
> 
> - Add `data-test-rank` to the rank container in `language-leaderboard-rank-section.hbs`
> - Expose `languageLeaderboardRankSection.rankText` in `tests/pages/course-page.ts` to read the displayed rank
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7e7cd141083644eaaa1b2e2c37f618d4beb7d8f0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->