### PR TITLE
feat(course-page): add track leaderboard support and user lang preference

### DIFF
--- a/app/components/course-page/right-sidebar.hbs
+++ b/app/components/course-page/right-sidebar.hbs
@@ -12,13 +12,17 @@
       {{/if}}
     </div>
 
-    <CourseLeaderboard
-      class={{if @isExpanded "-ml-6" "-ml-4"}}
-      @course={{@course}}
-      @activeRepository={{@activeRepository}}
-      @repositories={{@repositories}}
-      @isCollapsed={{not @isExpanded}}
-    />
+    {{#if this.featureFlags.canViewTrackLeaderboardOnCoursePage}}
+      <TrackLeaderboard @language={{this.languageForTrackLeaderboard}} />
+    {{else}}
+      <CourseLeaderboard
+        class={{if @isExpanded "-ml-6" "-ml-4"}}
+        @course={{@course}}
+        @activeRepository={{@activeRepository}}
+        @repositories={{@repositories}}
+        @isCollapsed={{not @isExpanded}}
+      />
+    {{/if}}
 
     {{#if (and @isExpanded this.visiblePrivateLeaderboardFeatureSuggestion)}}
       {{! @glint-expect-error: not ts-ified yet }}

--- a/app/templates/course.hbs
+++ b/app/templates/course.hbs
@@ -89,12 +89,13 @@
       </div>
 
       <CoursePage::RightSidebar
-        @course={{@model.course}}
         @activeRepository={{@model.activeRepository}}
-        @repositories={{@model.repositories}}
+        @course={{@model.course}}
         @isExpanded={{this.leaderboardIsExpanded}}
         @onCollapseButtonClick={{this.handleCollapseLeaderboardButtonClick}}
         @onExpandButtonClick={{this.handleExpandLeaderboardButtonClick}}
+        @repositories={{@model.repositories}}
+        @track={{@model.track}}
         class="pt-6 shrink-0 border-l border-gray-200 dark:border-white/5 bg-gray-50 dark:bg-gray-950 hidden md:block"
       />
     </div>

--- a/app/utils/leaderboard-entries-cache.ts
+++ b/app/utils/leaderboard-entries-cache.ts
@@ -33,7 +33,8 @@ export default class LeaderboardEntriesCache {
     const entries = [...this._topEntries];
 
     if (this._surroundingEntriesOverlapsTopEntries) {
-      entries.push(...this._surroundingEntries);
+      const topUserIds = new Set(this._topEntries.map((e) => e.user.id));
+      entries.push(...this._surroundingEntries.filter((e) => !topUserIds.has(e.user.id)));
     }
 
     return entries.filter((entry) => !entry.isBanned).sort((a, b) => b.score - a.score);

--- a/tests/acceptance/course-page/leaderboard-progress-test.js
+++ b/tests/acceptance/course-page/leaderboard-progress-test.js
@@ -1,0 +1,66 @@
+import FakeActionCableConsumer from 'codecrafters-frontend/tests/support/fake-action-cable-consumer';
+import catalogPage from 'codecrafters-frontend/tests/pages/catalog-page';
+import courseOverviewPage from 'codecrafters-frontend/tests/pages/course-overview-page';
+import coursePage from 'codecrafters-frontend/tests/pages/course-page';
+import finishRender from 'codecrafters-frontend/tests/support/finish-render';
+import testScenario from 'codecrafters-frontend/mirage/scenarios/test';
+import { module, test } from 'qunit';
+import { setupAnimationTest, animationsSettled } from 'ember-animated/test-support';
+import { setupApplicationTest } from 'codecrafters-frontend/tests/helpers';
+import { signIn } from 'codecrafters-frontend/tests/support/authentication-helpers';
+import { waitUntil } from '@ember/test-helpers';
+
+module('Acceptance | course-page | leaderboard-progress', function (hooks) {
+  setupApplicationTest(hooks);
+  setupAnimationTest(hooks);
+
+  test('can complete first stage', async function (assert) {
+    testScenario(this.server, ['dummy']);
+    const currentUser = signIn(this.owner, this.server);
+
+    // TODO: Remove this once track leaderboard is always enabled
+    currentUser.update({ featureFlags: { 'can-view-track-leaderboard-on-course-page': 'test' } });
+
+    const fakeActionCableConsumer = new FakeActionCableConsumer();
+    this.owner.register('service:action-cable-consumer', fakeActionCableConsumer, { instantiate: false });
+
+    const course = this.server.schema.courses.findBy({ slug: 'dummy' });
+    course.update({ releaseStatus: 'live' });
+
+    await catalogPage.visit();
+    await catalogPage.clickOnCourse('Build your own Dummy');
+    await courseOverviewPage.clickOnStartCourse();
+
+    // Fill in questionnaire
+    await coursePage.createRepositoryCard.clickOnLanguageButton('Python');
+    await animationsSettled();
+
+    assert.strictEqual(coursePage.trackLeaderboard.titleText.toUpperCase(), 'PYTHON LEADERBOARD', 'track leaderboard title is shown');
+    assert.strictEqual(coursePage.trackLeaderboard.rows.length, 0, 'no leaderboard rows are shown to start (no users have attempted the track yet)');
+
+    // Fill in questionnaire
+    await coursePage.createRepositoryCard.clickOnOptionButton('Advanced');
+    await animationsSettled();
+    await coursePage.createRepositoryCard.clickOnOptionButton('Every day');
+    await animationsSettled();
+    await coursePage.createRepositoryCard.clickOnOptionButton('Yes please');
+    await animationsSettled();
+    await coursePage.createRepositoryCard.clickOnContinueButton();
+
+    // Succesful first submission
+    this.server.create('submission', 'withSuccessStatus', {
+      repository: this.server.schema.repositories.find(1),
+      courseStage: course.stages.models.find((stage) => stage.position === 1),
+    });
+
+    fakeActionCableConsumer.sendData('RepositoryChannel', { event: 'updated' });
+    fakeActionCableConsumer.sendData('CourseLeaderboardChannel', { event: 'updated' });
+    await finishRender();
+
+    await coursePage.setupStepCompleteModal.clickOnNextButton();
+    await coursePage.testsPassedModal.clickOnActionButton('Mark stage as complete');
+
+    await waitUntil(() => coursePage.currentStepCompleteModal.languageLeaderboardRankSection.rankText === '#1', {}, 'current user is ranked #1');
+    assert.strictEqual(coursePage.trackLeaderboard.rows.length, 1, '1 leaderboard row is shown for the current user');
+  });
+});


### PR DESCRIPTION
Add track property to the right sidebar to enable track-based leaderboard
display alongside repositories. Implement logic to select language for the
leaderboard using active repository language, then track slug, then user
preferred languages, and fall back to course languages if none match.

This allows personalized leaderboard views and prepares for enabling track
leaderboard feature flags with improved language resolution.

Add acceptance test to verify leaderboard progress and interactions tied to
track leaderboard feature.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Enables a track-based leaderboard on the course page, gated by a feature flag, with robust language selection.
> 
> - Conditionally renders `TrackLeaderboard` (feature flag `canViewTrackLeaderboardOnCoursePage`), falls back to `CourseLeaderboard`
> - Right sidebar now accepts `@track` and computes `languageForTrackLeaderboard` using: active repo language → track slug → user preferred languages → first course language
> - Passes `@model.track` to `CoursePage::RightSidebar` in `course.hbs`
> - De-duplicates overlapping entries in `leaderboard-entries-cache` when merging top and surrounding entries
> - Adds acceptance test (`leaderboard-progress-test`) validating track leaderboard rendering and rank updates
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 95a91e6e509a16bafe00025e528e2b75456c2896. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->