### PR TITLE
feat: update leaderboard logic on course stage completion

### DIFF
--- a/mirage/factories/course-stage-completion.js
+++ b/mirage/factories/course-stage-completion.js
@@ -5,7 +5,7 @@ export default Factory.extend({
   completedAt: () => new Date(),
 
   afterCreate(courseStageCompletion, server) {
-    let leaderboardEntry = server.schema.courseLeaderboardEntries.findOrCreateBy({
+    let courseLeaderboardEntry = server.schema.courseLeaderboardEntries.findOrCreateBy({
       userId: courseStageCompletion.repository.user.id,
       languageId: courseStageCompletion.repository.language.id,
     });
@@ -17,12 +17,36 @@ export default Factory.extend({
       .map((model) => model.courseStage.slug)
       .filter((slug, index, array) => array.indexOf(slug) === index);
 
-    leaderboardEntry.update({
+    courseLeaderboardEntry.update({
       lastAttemptAt: courseStageCompletion.completedAt,
       currentCourseStage: nextStage || courseStageCompletion.courseStage,
       status: nextStage ? 'idle' : 'completed',
       completedStageSlugs: completedStageSlugs,
     });
+
+    // Also create/update the track leaderboard entry (language leaderboard)
+    const language = courseStageCompletion.repository.language;
+    const languageLeaderboard = language.leaderboard;
+
+    if (languageLeaderboard) {
+      const user = courseStageCompletion.repository.user;
+      let trackLeaderboardEntry = server.schema.leaderboardEntries
+        .all()
+        .models.find((entry) => entry.user.id === user.id && entry.leaderboard.id === languageLeaderboard.id);
+
+      if (!trackLeaderboardEntry) {
+        server.create('leaderboard-entry', {
+          leaderboard: languageLeaderboard,
+          user: user,
+          score: 1,
+          isBanned: false,
+        });
+      } else {
+        trackLeaderboardEntry.update({
+          score: trackLeaderboardEntry.score + 1,
+        });
+      }
+    }
 
     syncRepositoryStageLists(server, courseStageCompletion.repository);
   },

--- a/mirage/handlers/course-stage-completions.js
+++ b/mirage/handlers/course-stage-completions.js
@@ -1,8 +1,9 @@
 export default function (server) {
-  server.post('/course-stage-completions', function (schema) {
+  server.post('/course-stage-completions', function () {
     const attrs = this.normalizedRequestAttrs();
     attrs.completedAt = new Date();
 
-    return schema.courseStageCompletions.create(attrs);
+    // Use server.create() instead of schema.create() to trigger factory's afterCreate hook
+    return server.create('course-stage-completion', attrs);
   });
 }


### PR DESCRIPTION
Refactor variable naming for clarity in course leaderboard entry.
Enhance afterCreate hook to also create or update language leaderboard
entries, incrementing user score per language. Change POST handler to
use server.create() instead of schema.create() ensuring afterCreate
hooks are triggered. These improvements maintain consistent leaderboard
state across course and language levels after a stage completion.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensures leaderboard state updates at both course and language levels when a stage is completed.
> 
> - Extend `afterCreate` in `course-stage-completion` factory to create/update language (`leaderboard`) entries and increment user score per completion
> - Continue updating course leaderboard entry; rename `leaderboardEntry` to `courseLeaderboardEntry` for clarity
> - Change `POST /course-stage-completions` handler to use `server.create('course-stage-completion', ...)` so factory `afterCreate` runs
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9eecc9432da28b6b931f9010d05481de2f04ee4c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->