### PR TITLE
refactor(leaderboard): optimize entry loading order for sync

### DIFF
--- a/app/utils/leaderboard-entries-cache.ts
+++ b/app/utils/leaderboard-entries-cache.ts
@@ -133,14 +133,12 @@ export default class LeaderboardEntriesCache {
   }
 
   _loadEntriesTask = task({ restartable: true }, async () => {
-    const [topEntries, surroundingEntries, userRankCalculation] = await Promise.all([
-      this._fetchTopEntries(),
-      this._fetchSurroundingEntries(),
-      this._fetchUserRankCalculation(),
-    ]);
+    // Fetch user rank calculation first since it syncs leaderboard entries for current user
+    const userRankCalculation = await this._fetchUserRankCalculation();
+    const [topEntries, surroundingEntries] = await Promise.all([this._fetchTopEntries(), this._fetchSurroundingEntries()]);
 
-    this._topEntries = topEntries;
     this._surroundingEntries = surroundingEntries;
+    this._topEntries = topEntries;
     this._userRankCalculation = userRankCalculation;
     this.isLoaded = true;
   });


### PR DESCRIPTION
Load user rank calculation first to sync current user leaderboard
entries before fetching top and surrounding entries in parallel.
This ensures data consistency and improves update logic.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Optimizes leaderboard loading by ensuring the current user's rank/entries are synced before fetching visible lists.
> 
> - Fetches `userRankCalculation` first in `_loadEntriesTask` to sync current user data
> - Then fetches `top` and `surrounding` entries in parallel
> - Minor reorder of assignments: sets `_surroundingEntries` before `_topEntries`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3ca3df30eda40124ef9771ef04cca91bf2fc9b29. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->