### PR TITLE
feat(course-page): auto-scroll current step into view

### DIFF
--- a/app/components/course-page/step-list-item.hbs
+++ b/app/components/course-page/step-list-item.hbs
@@ -3,8 +3,10 @@
   @models={{@step.routeParams.models}}
   class="flex items-start gap-x-2 py-1.5
     {{if @isCurrent 'bg-gray-300/50 dark:bg-gray-900' 'hover:bg-gray-300/50 dark:hover:bg-gray-900'}}
-    px-3 rounded-sm"
+    px-3 rounded-sm scroll-mt-20"
   data-test-step-list-item
+  {{! @glint-expect-error modifier helper types aren't right? }}
+  {{(if @isCurrent (modifier "scroll-into-view" block="start"))}}
 >
   {{#if (eq @step.status "complete")}}
     <div class="rounded-full w-6 h-6 border flex items-center justify-center shrink-0 bg-teal-500 border-teal-500 dark:bg-teal-500/40">


### PR DESCRIPTION
Add scroll margin and conditional scroll-into-view modifier to step list
item to improve navigation experience. This ensures the current step is
automatically scrolled into view with proper offset, enhancing usability
when navigating lengthy step lists.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Improves step navigation by auto-scrolling the current item into view with appropriate offset.
> 
> - In `app/components/course-page/step-list-item.hbs`, adds `scroll-mt-20` to the link class for top offset
> - Conditionally applies `modifier "scroll-into-view"` when `@isCurrent`, scrolling to block="start"
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c97d5bb52a100d24416c7ff9788015ff6a5a9741. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->