### PR TITLE
feat(leaderboard): add latestScoreUpdate relation and model

### DIFF
--- a/app/components/leaderboard-page/entries-table/row.hbs
+++ b/app/components/leaderboard-page/entries-table/row.hbs
@@ -80,11 +80,11 @@
 
   <LeaderboardPage::EntriesTable::RowCell>
     <div class="flex items-center justify-end">
-      {{!-- {{#if (eq @entry.score 142)}}
+      {{#if @entry.latestScoreUpdate.wasTriggeredInPastMonth}}
         <span class="inline-block align-middle text-teal-500 triangle-up mr-1.5" aria-hidden="true">
-          <EmberTooltip @text="Increased from 139 to 142 in the past month" />
+          <EmberTooltip @text="Increased in the past month" />
         </span>
-      {{/if}} --}}
+      {{/if}}
 
       {{!-- {{#if (eq @entry.score 99)}}
         <span class="inline-block align-middle text-red-500 triangle-down mr-1.5" aria-hidden="true">

--- a/app/components/leaderboard-page/entries-table/row.ts
+++ b/app/components/leaderboard-page/entries-table/row.ts
@@ -13,7 +13,7 @@ interface Signature {
   };
 }
 
-const MAX_VISIBLE_COURSES = 7;
+const MAX_VISIBLE_COURSES = 3;
 
 export default class LeaderboardPageEntriesTableRow extends Component<Signature> {
   @service declare authenticator: AuthenticatorService;

--- a/app/models/leaderboard-entry.ts
+++ b/app/models/leaderboard-entry.ts
@@ -1,12 +1,14 @@
 import Model, { attr, belongsTo } from '@ember-data/model';
 import type AffiliateLinkModel from './affiliate-link';
 import type LeaderboardModel from './leaderboard';
+import type LeaderboardScoreUpdateModel from './leaderboard-score-update';
 import type UserModel from './user';
 import CourseModel from './course';
 
 export default class LeaderboardEntryModel extends Model {
   @belongsTo('affiliate-link', { async: false, inverse: null }) declare affiliateLink: AffiliateLinkModel | null;
   @belongsTo('leaderboard', { async: false, inverse: 'entries' }) declare leaderboard: LeaderboardModel;
+  @belongsTo('leaderboard-score-update', { async: false, inverse: null }) declare latestScoreUpdate: LeaderboardScoreUpdateModel | null;
   @belongsTo('user', { async: false, inverse: null }) declare user: UserModel;
 
   @attr('boolean') declare isBanned: boolean;

--- a/app/models/leaderboard-score-update.ts
+++ b/app/models/leaderboard-score-update.ts
@@ -1,0 +1,18 @@
+import Model, { attr } from '@ember-data/model';
+
+export default class LeaderboardScoreUpdateModel extends Model {
+  @attr('number') declare delta: number;
+  @attr('string') declare description: string;
+
+  // @ts-expect-error: empty transform not supported
+  @attr('') declare relatedCourseSlugs: string[];
+
+  // @ts-expect-error: empty transform not supported
+  @attr('') declare relatedLanguageSlugs: string[];
+
+  @attr('date') declare triggeredAt: Date;
+
+  get wasTriggeredInPastMonth(): boolean {
+    return this.triggeredAt > new Date(Date.now() - 30 * 24 * 60 * 60 * 1000);
+  }
+}

--- a/app/utils/leaderboard-entries-cache.ts
+++ b/app/utils/leaderboard-entries-cache.ts
@@ -85,7 +85,7 @@ export default class LeaderboardEntriesCache {
     }
 
     return (await this.store.query('leaderboard-entry', {
-      include: 'affiliate-link,affiliate-link.user,leaderboard,user',
+      include: 'affiliate-link,affiliate-link.user,leaderboard,latest-score-update,user',
       leaderboard_id: this.leaderboard.id,
       user_id: this.authenticator.currentUserId, // Only used in tests since mirage doesn't have auth context
       filter_type: 'around_me',
@@ -95,7 +95,7 @@ export default class LeaderboardEntriesCache {
   @action
   async _fetchTopEntries(): Promise<LeaderboardEntryModel[]> {
     return (await this.store.query('leaderboard-entry', {
-      include: 'affiliate-link,affiliate-link.user,leaderboard,user',
+      include: 'affiliate-link,affiliate-link.user,leaderboard,latest-score-update,user',
       leaderboard_id: this.leaderboard.id,
       filter_type: 'top',
     })) as unknown as LeaderboardEntryModel[];


### PR DESCRIPTION
Introduce a new LeaderboardScoreUpdate model to track incremental score
changes with metadata such as delta, description, related courses and
languages, and the timestamp of the update.

Add a latestScoreUpdate belongsTo relationship to LeaderboardEntry to
associate each entry with its most recent score update.

This enhancement enables better tracking and representation of score
changes over time on leaderboard entries.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds score update tracking and surfaces recent improvements in the leaderboard UI.
> 
> - Introduces `LeaderboardScoreUpdate` model (`delta`, `description`, `relatedCourseSlugs`, `relatedLanguageSlugs`, `triggeredAt`, `wasTriggeredInPastMonth`)
> - Adds `latestScoreUpdate` `belongsTo` on `LeaderboardEntry` and includes it in store queries in `leaderboard-entries-cache.ts`
> - Updates row UI (`entries-table/row.hbs`) to show an upward indicator with tooltip when `latestScoreUpdate.wasTriggeredInPastMonth`
> - Reduces visible course logos in rows by setting `MAX_VISIBLE_COURSES` to `3`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7ad358e8a7776873009168d0f259ad14347088aa. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->