### PR TITLE
Challenge completion navigation

### DIFF
--- a/app/components/course-page/completed-step-notice.ts
+++ b/app/components/course-page/completed-step-notice.ts
@@ -47,9 +47,7 @@ export default class CompletedStepNotice extends Component<Signature> {
   }
 
   get stepForNextOrActiveStepButton() {
-    return this.nextStep?.type === 'BaseStagesCompletedStep' || this.nextStep?.type === 'CourseCompletedStep'
-      ? this.nextStep
-      : this.activeStep;
+    return this.nextStep?.type === 'BaseStagesCompletedStep' || this.nextStep?.type === 'CourseCompletedStep' ? this.nextStep : this.activeStep;
   }
 
   @action

--- a/app/components/course-page/current-step-complete-modal.ts
+++ b/app/components/course-page/current-step-complete-modal.ts
@@ -30,9 +30,7 @@ export default class CurrentStepCompleteModal extends Component<Signature> {
   }
 
   get stepForNextOrActiveStepButton() {
-    return this.nextStep?.type === 'BaseStagesCompletedStep' || this.nextStep?.type === 'CourseCompletedStep'
-      ? this.nextStep
-      : this.args.activeStep;
+    return this.nextStep?.type === 'BaseStagesCompletedStep' || this.nextStep?.type === 'CourseCompletedStep' ? this.nextStep : this.args.activeStep;
   }
 }
 


### PR DESCRIPTION
This pull request contains changes generated by a Cursor Cloud Agent

<a href="https://cursor.com/background-agent?bcId=bc-91622a1f-f21b-4f35-8ac4-6e19617b870b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-91622a1f-f21b-4f35-8ac4-6e19617b870b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adjusts post-completion navigation to correctly handle course completion.
> 
> - Updates `stepForNextOrActiveStepButton` in `completed-step-notice.ts` and `current-step-complete-modal.ts` to choose `nextStep` when its `type` is `BaseStagesCompletedStep` or `CourseCompletedStep` (previously only `BaseStagesCompletedStep`)
> - Ensures CTAs route to the appropriate completion step instead of falling back to the active step
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7679b8276458efb2fad98abf59de5953c19e03dc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->