### PR TITLE
Challenge completion navigation

### DIFF
--- a/app/components/course-page/completed-step-notice.ts
+++ b/app/components/course-page/completed-step-notice.ts
@@ -47,7 +47,11 @@ export default class CompletedStepNotice extends Component<Signature> {
   }
 
   get stepForNextOrActiveStepButton() {
-    return this.nextStep?.type === 'BaseStagesCompletedStep' ? this.nextStep : this.activeStep;
+    if (this.nextStep?.type === 'BaseStagesCompletedStep' || this.nextStep?.type === 'CourseCompletedStep') {
+      return this.nextStep;
+    }
+
+    return this.activeStep;
   }
 
   @action

--- a/app/components/course-page/current-step-complete-modal.ts
+++ b/app/components/course-page/current-step-complete-modal.ts
@@ -30,7 +30,11 @@ export default class CurrentStepCompleteModal extends Component<Signature> {
   }
 
   get stepForNextOrActiveStepButton() {
-    return this.nextStep?.type === 'BaseStagesCompletedStep' ? this.nextStep : this.args.activeStep;
+    if (this.nextStep?.type === 'BaseStagesCompletedStep' || this.nextStep?.type === 'CourseCompletedStep') {
+      return this.nextStep;
+    }
+
+    return this.args.activeStep;
   }
 }
 


### PR DESCRIPTION
This pull request contains changes generated by a Cursor Cloud Agent

<a href="https://cursor.com/background-agent?bcId=bc-28300de1-e04c-4b0e-936c-5119b4c84426"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-28300de1-e04c-4b0e-936c-5119b4c84426"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensures completion flows navigate to the appropriate next step when a course is fully completed.
> 
> - In `completed-step-notice.ts` and `current-step-complete-modal.ts`, `stepForNextOrActiveStepButton` now prefers `nextStep` when its `type` is `BaseStagesCompletedStep` or `CourseCompletedStep`; otherwise falls back to the active step.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c89bcfe01724cfc249f6923848887c428856554a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->