### PR TITLE
Modal publish link update

### DIFF
--- a/app/components/course-page/configure-github-integration-modal/create-github-repository-step.hbs
+++ b/app/components/course-page/configure-github-integration-modal/create-github-repository-step.hbs
@@ -2,7 +2,7 @@
 <CoursePage::ConfigureGithubIntegrationModal::Step @title="Step 1: Create a GitHub repository">
   <div class="prose dark:prose-invert mb-6">
     <p>
-      <a href="https://github.com/new?name={{@recommendedRepositoryName}}" target="_blank" rel="noopener noreferrer">Visit this link</a>
+      <a href="https://github.com/new?name={{@recommendedRepositoryNameWithoutOwner}}" target="_blank" rel="noopener noreferrer">Visit this link</a>
       and create a new GitHub repository. We suggest naming it
       <code>{{@recommendedRepositoryName}}</code>.
     </p>

--- a/app/components/course-page/configure-github-integration-modal/index.hbs
+++ b/app/components/course-page/configure-github-integration-modal/index.hbs
@@ -66,6 +66,7 @@
     <CoursePage::ConfigureGithubIntegrationModal::CreateGithubRepositoryStep
       @repository={{@repository}}
       @recommendedRepositoryName={{this.recommendedRepositoryName}}
+      @recommendedRepositoryNameWithoutOwner={{this.recommendedRepositoryNameWithoutOwner}}
     />
 
     {{#if this.githubAppInstallation}}

--- a/app/components/course-page/configure-github-integration-modal/index.js
+++ b/app/components/course-page/configure-github-integration-modal/index.js
@@ -57,7 +57,11 @@ export default class ConfigureGithubIntegrationModal extends Component {
   }
 
   get recommendedRepositoryName() {
-    return `${this.authenticator.currentUser.githubUsername}/codecrafters-${this.args.repository.course.slug}-${this.args.repository.language.slug}`;
+    return `${this.authenticator.currentUser.githubUsername}/${this.recommendedRepositoryNameWithoutOwner}`;
+  }
+
+  get recommendedRepositoryNameWithoutOwner() {
+    return `codecrafters-${this.args.repository.course.slug}-${this.args.repository.language.slug}`;
   }
 
   @action


### PR DESCRIPTION
This pull request contains changes generated by a Cursor Cloud Agent

<a href="https://cursor.com/background-agent?bcId=bc-43ef2498-ce86-4a07-aa64-7ea15840f015"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-43ef2498-ce86-4a07-aa64-7ea15840f015"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Improves the GitHub publish flow by pre-filling the repository name and simplifying name derivation.
> 
> - Updates `CreateGithubRepositoryStep` link to `https://github.com/new?name={{@recommendedRepositoryNameWithoutOwner}}` so the repo name is prepopulated
> - Passes `@recommendedRepositoryNameWithoutOwner` from modal (`index.hbs`)
> - Adds `recommendedRepositoryNameWithoutOwner` getter and refactors `recommendedRepositoryName` to compose from it (`index.js`)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cb1358ea2abd38e5bbc73af4a3137c9aad0fc843. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->