### PR TITLE
Modal publish link update

### DIFF
--- a/app/components/course-page/configure-github-integration-modal/create-github-repository-step.hbs
+++ b/app/components/course-page/configure-github-integration-modal/create-github-repository-step.hbs
@@ -2,7 +2,7 @@
 <CoursePage::ConfigureGithubIntegrationModal::Step @title="Step 1: Create a GitHub repository">
   <div class="prose dark:prose-invert mb-6">
     <p>
-      <a href="https://github.com/new" target="_blank" rel="noopener noreferrer">Visit this link</a>
+      <a href="https://github.com/new?name={{@recommendedRepositorySlug}}" target="_blank" rel="noopener noreferrer">Visit this link</a>
       and create a new GitHub repository. We suggest naming it
       <code>{{@recommendedRepositoryName}}</code>.
     </p>

--- a/app/components/course-page/configure-github-integration-modal/index.hbs
+++ b/app/components/course-page/configure-github-integration-modal/index.hbs
@@ -66,6 +66,7 @@
     <CoursePage::ConfigureGithubIntegrationModal::CreateGithubRepositoryStep
       @repository={{@repository}}
       @recommendedRepositoryName={{this.recommendedRepositoryName}}
+      @recommendedRepositorySlug={{this.recommendedRepositorySlug}}
     />
 
     {{#if this.githubAppInstallation}}

--- a/app/components/course-page/configure-github-integration-modal/index.js
+++ b/app/components/course-page/configure-github-integration-modal/index.js
@@ -56,8 +56,12 @@ export default class ConfigureGithubIntegrationModal extends Component {
     return this.args.repository.githubRepositorySyncConfiguration;
   }
 
+  get recommendedRepositorySlug() {
+    return `codecrafters-${this.args.repository.course.slug}-${this.args.repository.language.slug}`;
+  }
+
   get recommendedRepositoryName() {
-    return `${this.authenticator.currentUser.githubUsername}/codecrafters-${this.args.repository.course.slug}-${this.args.repository.language.slug}`;
+    return `${this.authenticator.currentUser.githubUsername}/${this.recommendedRepositorySlug}`;
   }
 
   @action


### PR DESCRIPTION
This pull request contains changes generated by a Cursor Cloud Agent

<a href="https://cursor.com/background-agent?bcId=bc-59652968-da55-4523-94a4-7db336f12623"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-59652968-da55-4523-94a4-7db336f12623"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Improves the GitHub publish flow by pre-populating the repository name and centralizing slug logic.
> 
> - Add `recommendedRepositorySlug` getter and use it to build `recommendedRepositoryName`
> - Pass `@recommendedRepositorySlug` to `CreateGithubRepositoryStep`
> - Update link to `https://github.com/new?name={{@recommendedRepositorySlug}}` to prefill the repo name
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1d5e692e58322b1bd369acbf556161cd6b103199. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->