### PR TITLE
style: adjust sidebar positioning and remove testimonial margin

### DIFF
--- a/app/templates/track.hbs
+++ b/app/templates/track.hbs
@@ -36,11 +36,11 @@
         <TrackPage::CourseCardList @language={{@model.language}} @courses={{this.sortedCourses}} class="w-full mb-4" />
       </div>
 
-      <div class="hidden lg:block w-80 shrink-0 sticky top-4 ml-6">
+      <div class="hidden lg:block w-80 shrink-0 sticky top-6 ml-6">
         <TrackLeaderboard class="mb-6" @language={{@model.language}} />
 
         {{! TODO: Show testimonials for track instead of courses? }}
-        <div class="ml-4 mr-4">
+        <div>
           {{#each this.testimonials as |testimonial|}}
             <CourseOverviewPage::TestimonialListItem @testimonial={{testimonial}} />
           {{/each}}


### PR DESCRIPTION
Increase the sticky top offset from 4 to 6 for better spacing in the
sidebar on large screens. Remove horizontal margins from the
testimonial container to align its content more consistently with the
overall layout. These changes improve visual balance and layout
consistency on track pages.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Small layout tweaks on the track page to improve spacing/alignment.
> 
> - Increase sidebar sticky offset in `app/templates/track.hbs` from `top-4` to `top-6`
> - Remove horizontal margins from the testimonials container (drop `ml-4 mr-4`) for consistent alignment
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5493410fc498bbbaffed18f2a13f7dfb8560fc00. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->