### PR TITLE
feat(course-overview): prioritize current language in language list

### DIFF
--- a/app/components/course-overview-page/header.hbs
+++ b/app/components/course-overview-page/header.hbs
@@ -23,10 +23,9 @@
         {{/if}}
 
         <div class="flex items-center flex-wrap gap-2 grow">
-          {{#each @course.betaOrLiveLanguages as |supportedLanguage|}}
+          {{#each this.orderedSupportedLanguages as |supportedLanguage|}}
             <div class="flex">
-              <img alt="{{@course.slug}}" src={{supportedLanguage.tealLogoUrl}} class="h-6 dark:opacity-90" />
-
+              <LanguageLogo @language={{supportedLanguage}} @variant="gray" class="h-6 dark:brightness-90" />
               <EmberTooltip @text={{supportedLanguage.name}} />
             </div>
           {{/each}}

--- a/app/components/course-overview-page/header.ts
+++ b/app/components/course-overview-page/header.ts
@@ -15,7 +15,21 @@ interface Signature {
   };
 }
 
-export default class CourseOverviewPageHeader extends Component<Signature> {}
+export default class CourseOverviewPageHeader extends Component<Signature> {
+  get orderedSupportedLanguages(): LanguageModel[] {
+    return this.args.course.betaOrLiveLanguages.sort((a, b) => {
+      if (a.slug === this.args.language?.slug) {
+        return -1;
+      }
+
+      if (b.slug === this.args.language?.slug) {
+        return 1;
+      }
+
+      return a.name.localeCompare(b.name);
+    });
+  }
+}
 
 declare module '@glint/environment-ember-loose/registry' {
   export default interface Registry {


### PR DESCRIPTION
Replace direct usage of betaOrLiveLanguages with an orderedSupportedLanguages
computed property that sorts languages to show the current language first,
followed by others in alphabetical order. Also switch from using img tags for
language logos to a LanguageLogo component with consistent styling. These
changes improve user experience by highlighting the active language and
standardize language logo rendering.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Highlights the user’s current language in the course header and standardizes language logo rendering.
> 
> - Adds `orderedSupportedLanguages` getter in `header.ts` to sort `betaOrLiveLanguages` with the current `@language` first, then others alphabetically
> - Updates `header.hbs` to iterate over `this.orderedSupportedLanguages` and replace `<img>` usage with `LanguageLogo` (`@variant="gray"`) for consistent styling and tooltips
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 85f5c563729a29c80971405f94c02f01bda1e739. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->