### PR TITLE
style(join-track): adjust sidebar spacing and layout

### DIFF
--- a/app/templates/join-track.hbs
+++ b/app/templates/join-track.hbs
@@ -27,18 +27,18 @@
         <TrackPage::CourseCardList @language={{@model.language}} @courses={{this.sortedCourses}} class="w-full mb-4" />
       </div>
 
-      <div class="hidden lg:block w-80 shrink-0 sticky top-4 ml-2">
+      <div class="hidden lg:block w-80 shrink-0 sticky top-6 ml-6">
         <AffiliateLinkPage::AcceptReferralContainer
           @affiliateLink={{this.model.affiliateLink}}
           @language={{this.model.language}}
           @verticalSize="compact"
-          class="mb-6 ml-2 w-full bg-github-green-dot-wall"
+          class="mb-6 w-full bg-github-green-dot-wall"
         />
 
         <TrackLeaderboard class="mb-6" @language={{@model.language}} />
 
         {{! TODO: Show testimonials for track instead of courses? }}
-        <div class="ml-4 mr-4">
+        <div>
           {{#each this.testimonials as |testimonial|}}
             <CourseOverviewPage::TestimonialListItem @testimonial={{testimonial}} />
           {{/each}}


### PR DESCRIPTION
Update the sticky sidebar container to use top-6 and increase left margin
to ml-6 for better alignment and spacing on large screens. Remove the
left margin from the AcceptReferralContainer component to reduce unnecessary
horizontal padding. Also, eliminate horizontal margins around the testimonials
wrapper to unify the layout and prevent extra space on the sides.

These changes improve visual consistency and alignment of sidebar elements
within the join track page for a cleaner user interface.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Improves sidebar layout and visual alignment on the `join-track` page for large screens.
> 
> - Increase sticky sidebar offset and left margin (`top-6`, `ml-6`) on the sidebar container
> - Remove unnecessary left margin from `AffiliateLinkPage::AcceptReferralContainer` within the sidebar
> - Remove horizontal margins from the testimonials wrapper to unify sidebar spacing
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bdd9cf6e0bafa9282c2e052f4bff1dcb3482aad4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->