### PR TITLE
Deprecated challenge visibility

### DIFF
--- a/app/controllers/catalog.ts
+++ b/app/controllers/catalog.ts
@@ -13,10 +13,6 @@ export default class CatalogController extends Controller {
   @service declare authenticator: AuthenticatorService;
 
   get courses() {
-    if (this.authenticator.currentUser && this.authenticator.currentUser.isStaff) {
-      return this.model.courses;
-    }
-
     return this.model.courses.filter((course) => this.shouldDisplayCourse(course));
   }
 

--- a/tests/acceptance/view-courses-test.js
+++ b/tests/acceptance/view-courses-test.js
@@ -64,9 +64,9 @@ module('Acceptance | view-courses', function (hooks) {
     signInAsStaff(this.owner, this.server);
 
     await catalogPage.visit();
-    assert.strictEqual(catalogPage.courseCards.length, 6, 'expected 6 course cards to be present');
+    assert.strictEqual(catalogPage.courseCards.length, 5, 'expected 5 course cards to be present (deprecated courses are hidden)');
 
-    assert.ok(catalogPage.courseCards[4].hasAlphaLabel, 'alpha challenges should have alpha label');
+    assert.ok(catalogPage.courseCardByName('Build your own Dummy').hasAlphaLabel, 'alpha challenges should have alpha label');
   });
 
   test('it renders with progress if user has started a course', async function (assert) {


### PR DESCRIPTION
This pull request contains changes generated by a Cursor Cloud Agent

<a href="https://cursor.com/background-agent?bcId=bc-49849ee5-03c1-455e-bb37-5f4a55e26032"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-49849ee5-03c1-455e-bb37-5f4a55e26032"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Strengthens catalog visibility rules and applies them uniformly.
> 
> - `CatalogController.courses`: always filters via `shouldDisplayCourse` (removes staff bypass)
> - `shouldDisplayCourse`: hides `deprecated` or `private` courses unless user has a repository; shows `alpha` only to staff or course authors; otherwise shows course
> - Updates acceptance tests: staff view expects fewer cards (deprecated hidden) and asserts alpha badge by course name
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 11d21a49e0078cdb1ef3492b8a60e8a7a04ea01d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->