### PR TITLE
test: rename and update leaderboard entry creation utils

### DIFF
--- a/mirage/utils/create-language-leaderboard-entries.js
+++ b/mirage/utils/create-language-leaderboard-entries.js
@@ -6,7 +6,7 @@ function findOrCreateUser(server, username, attrs = {}) {
   );
 }
 
-export default function createTrackLeaderboardEntries(server, languageSlug) {
+export default function createLanguageLeaderboardEntries(server, languageSlug) {
   // eslint-disable-next-line ember/no-array-prototype-extensions
   const language = server.schema.languages.findBy({ slug: languageSlug });
   const leaderboard = language.leaderboard || server.create('leaderboard', { language });

--- a/tests/acceptance/track-page/view-track-test.js
+++ b/tests/acceptance/track-page/view-track-test.js
@@ -1,4 +1,4 @@
-import createTrackLeaderboardEntries from 'codecrafters-frontend/mirage/utils/create-track-leaderboard-entries';
+import createLanguageLeaderboardEntries from 'codecrafters-frontend/mirage/utils/create-language-leaderboard-entries';
 import percySnapshot from '@percy/ember';
 import testScenario from 'codecrafters-frontend/mirage/scenarios/test';
 import catalogPage from 'codecrafters-frontend/tests/pages/catalog-page';
@@ -17,8 +17,8 @@ module('Acceptance | track-page | view-track', function (hooks) {
   hooks.beforeEach(function () {
     testScenario(this.server);
 
-    createTrackLeaderboardEntries(this.server, 'go', 'redis');
-    createTrackLeaderboardEntries(this.server, 'rust', 'redis');
+    createLanguageLeaderboardEntries(this.server, 'go', 'redis');
+    createLanguageLeaderboardEntries(this.server, 'rust', 'redis');
 
     const tcpOverviewConcept = createConceptFromFixture(this.server, tcpOverview);
     const networkProtocolsConcept = createConceptFromFixture(this.server, networkProtocols);


### PR DESCRIPTION
Replace createTrackLeaderboardEntries with createLanguageLeaderboardEntries in
acceptance tests and Mirage utils. This change improves accuracy by reflecting
that leaderboard entries are associated with languages rather than tracks. It
also clarifies the codebase and aligns function names with their actual purpose.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Rename util and update tests**
> 
> - Replace `createTrackLeaderboardEntries` with `createLanguageLeaderboardEntries` that looks up a `language` by `slug`, ensures a `leaderboard`, and seeds three `leaderboard-entry` records with predefined users and scores
> - Update `tests/acceptance/track-page/view-track-test.js` to import and call `createLanguageLeaderboardEntries` for `go` and `rust`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 64b372b0ce524388000e2171be9044632fc7c913. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->