### PR TITLE
feat(track-leaderboard): add personalized CTA based on user progress

### DIFF
--- a/app/components/course-page/right-sidebar.hbs
+++ b/app/components/course-page/right-sidebar.hbs
@@ -13,7 +13,7 @@
     </div>
 
     {{#if this.featureFlags.canViewTrackLeaderboardOnCoursePage}}
-      <TrackLeaderboard @language={{this.languageForTrackLeaderboard}} />
+      <TrackLeaderboard @language={{this.languageForTrackLeaderboard}} @nextStagesInContext={{this.nextStagesInContextForTrackLeaderboard}} />
     {{else}}
       <CourseLeaderboard
         class={{if @isExpanded "-ml-6" "-ml-4"}}

--- a/app/components/course-page/right-sidebar.ts
+++ b/app/components/course-page/right-sidebar.ts
@@ -4,10 +4,13 @@ import FeatureFlagsService from 'codecrafters-frontend/services/feature-flags';
 import PreferredLanguageLeaderboardService from 'codecrafters-frontend/services/preferred-language-leaderboard';
 import RepositoryModel from 'codecrafters-frontend/models/repository';
 import type AuthenticatorService from 'codecrafters-frontend/services/authenticator';
+import type CoursePageStateService from 'codecrafters-frontend/services/course-page-state';
+import type CourseStageModel from 'codecrafters-frontend/models/course-stage';
 import type FeatureSuggestionModel from 'codecrafters-frontend/models/feature-suggestion';
 import type LanguageModel from 'codecrafters-frontend/models/language';
 import type Store from '@ember-data/store';
 import { service } from '@ember/service';
+import type CourseStageStep from 'codecrafters-frontend/utils/course-page-step-list/course-stage-step';
 
 interface Signature {
   Element: HTMLDivElement;
@@ -25,6 +28,7 @@ interface Signature {
 
 export default class CoursePageRightSidebar extends Component<Signature> {
   @service declare authenticator: AuthenticatorService;
+  @service declare coursePageState: CoursePageStateService;
   @service declare preferredLanguageLeaderboard: PreferredLanguageLeaderboardService;
   @service declare store: Store;
   @service declare featureFlags: FeatureFlagsService;
@@ -55,6 +59,25 @@ export default class CoursePageRightSidebar extends Component<Signature> {
     }
 
     return this.args.course.betaOrLiveLanguages[0]!;
+  }
+
+  get nextStagesInContextForTrackLeaderboard(): CourseStageModel[] {
+    if (!this.coursePageState.stepList) {
+      return [];
+    }
+
+    if (this.coursePageState.currentStep.type !== 'CourseStageStep') {
+      return [];
+    }
+
+    if (this.coursePageState.currentStep !== this.coursePageState.activeStep) {
+      return [];
+    }
+
+    return this.coursePageState.stepList
+      .visibleStepsAfter(this.coursePageState.currentStep)
+      .filter((step) => step.type === 'CourseStageStep')
+      .map((step) => (step as CourseStageStep).courseStage);
   }
 
   get visiblePrivateLeaderboardFeatureSuggestion(): FeatureSuggestionModel | null {

--- a/app/components/track-leaderboard.hbs
+++ b/app/components/track-leaderboard.hbs
@@ -30,14 +30,26 @@
       </AnimatedContainer>
 
       {{#animated-if (not this.leaderboardEntriesCache.hasEntries)}}
-        <div class="flex py-2 items-center">
+        <div class="flex py-2 items-center mb-2">
           <div class="text-sm text-gray-500">
-            <p class="mb-2">
+            <p>
               No one has tried this Track recently.
             </p>
           </div>
         </div>
       {{/animated-if}}
+
+      {{#if this.ctaText}}
+        <div class="flex items-center justify-center mt-4">
+          <div class="flex items-start gap-1">
+            {{svg-jar "information-circle-outline" class="size-5 text-teal-600 dark:text-teal-500"}}
+
+            <div class="text-xs text-teal-600 dark:text-teal-500 leading-5">
+              {{this.ctaText}}
+            </div>
+          </div>
+        </div>
+      {{/if}}
     </div>
   {{else}}
     <div>

--- a/app/components/track-leaderboard.ts
+++ b/app/components/track-leaderboard.ts
@@ -1,12 +1,14 @@
 import Component from '@glimmer/component';
+import computeLeaderboardCTA from 'codecrafters-frontend/utils/compute-leaderboard-cta';
 import fade from 'ember-animated/transitions/fade';
 import move from 'ember-animated/motions/move';
 import type AuthenticatorService from 'codecrafters-frontend/services/authenticator';
+import type CourseStageModel from 'codecrafters-frontend/models/course-stage';
 import type LanguageModel from 'codecrafters-frontend/models/language';
 import type LeaderboardEntriesCache from 'codecrafters-frontend/utils/leaderboard-entries-cache';
-import type { LeaderboardEntryWithRank } from 'codecrafters-frontend/utils/leaderboard-entries-cache';
 import type LeaderboardEntriesCacheRegistryService from 'codecrafters-frontend/services/leaderboard-entries-cache-registry';
 import type LeaderboardModel from 'codecrafters-frontend/models/leaderboard';
+import type { LeaderboardEntryWithRank } from 'codecrafters-frontend/utils/leaderboard-entries-cache';
 import { action } from '@ember/object';
 import { fadeIn, fadeOut } from 'ember-animated/motions/opacity';
 import { service } from '@ember/service';
@@ -16,6 +18,7 @@ interface Signature {
 
   Args: {
     language: LanguageModel;
+    nextStagesInContext?: CourseStageModel[];
   };
 }
 
@@ -23,6 +26,18 @@ export default class TrackLeaderboard extends Component<Signature> {
   transition = fade;
   @service declare authenticator: AuthenticatorService;
   @service declare leaderboardEntriesCacheRegistry: LeaderboardEntriesCacheRegistryService;
+
+  get ctaText(): string | null {
+    if (!this.leaderboardEntriesCache.isLoaded || !this.leaderboardEntriesCache.userEntry || !this.leaderboardEntriesCache.userRankCalculation) {
+      return null;
+    }
+
+    return computeLeaderboardCTA(
+      this.leaderboardEntriesCache.userEntry,
+      this.leaderboardEntriesCache.userRankCalculation,
+      this.args.nextStagesInContext || [],
+    );
+  }
 
   get entriesForFirstSectionWithRanks(): LeaderboardEntryWithRank[] {
     if (!this.leaderboardEntriesCache.isLoaded) {

--- a/app/models/leaderboard-rank-calculation.ts
+++ b/app/models/leaderboard-rank-calculation.ts
@@ -8,6 +8,6 @@ export default class LeaderboardRankCalculationModel extends Model {
 
   @attr('date') declare calculatedAt: Date;
   // @ts-expect-error: empty transform not supported
-  @attr('') declare nextRanksWithScores: { rank: number; score: number }[];
+  @attr('') declare nextRanksWithScores?: { rank: number; score: number }[];
   @attr('number') declare rank: number;
 }

--- a/app/utils/course-page-step-list.ts
+++ b/app/utils/course-page-step-list.ts
@@ -128,14 +128,36 @@ export class StepListDefinition {
   }
 
   nextVisibleStepFor(step: StepDefinition): StepDefinition | null {
-    return this.visibleSteps[this.visibleSteps.indexOf(step) + 1] || null;
+    const stepIndex = this.visibleSteps.indexOf(step);
+
+    if (stepIndex === -1) {
+      throw new Error(`Step ${step.type} not found in step list`);
+    }
+
+    return this.visibleSteps[stepIndex + 1] || null;
   }
 
   previousVisibleStepFor(step: StepDefinition): StepDefinition | null {
-    return this.visibleSteps[this.visibleSteps.indexOf(step) - 1] || null;
+    const stepIndex = this.visibleSteps.indexOf(step);
+
+    if (stepIndex === -1) {
+      throw new Error(`Step ${step.type} not found in step list`);
+    }
+
+    return this.visibleSteps[stepIndex - 1] || null;
   }
 
   visibleStepByType(type: StepDefinition['type']): StepDefinition | null {
     return this.visibleSteps.find((step) => step.type === type) || null;
+  }
+
+  visibleStepsAfter(step: StepDefinition): StepDefinition[] {
+    const stepIndex = this.visibleSteps.indexOf(step);
+
+    if (stepIndex === -1) {
+      throw new Error(`Step ${step.type} not found in step list`);
+    }
+
+    return this.visibleSteps.slice(stepIndex + 1);
   }
 }

--- a/app/utils/leaderboard-entries-cache.ts
+++ b/app/utils/leaderboard-entries-cache.ts
@@ -74,6 +74,14 @@ export default class LeaderboardEntriesCache {
     return this.entriesForFirstSectionWithRanks.length > 0;
   }
 
+  get userEntry(): LeaderboardEntryModel | null {
+    return (
+      this._topEntries.find((entry) => entry.user.id === this.authenticator.currentUserId) ||
+      this._surroundingEntries.find((entry) => entry.user.id === this.authenticator.currentUserId) ||
+      null
+    );
+  }
+
   get userRankCalculation(): LeaderboardRankCalculationModel | null {
     return this._userRankCalculation;
   }

--- a/tests/unit/utils/compute-leaderboard-cta-test.ts
+++ b/tests/unit/utils/compute-leaderboard-cta-test.ts
@@ -160,7 +160,7 @@ module('Unit | Utility | compute-leaderboard-cta', function () {
     const result = computeLeaderboardCTA(leaderboardEntry, rankCalculation, []);
 
     // Should show the highest rank (#42) since 1 easy stage achieves all three
-    assert.strictEqual(result, 'Complete 1 easy stages to hit #42');
+    assert.strictEqual(result, 'Complete 1 easy stage to hit #42');
   });
 
   test('ignores ranks below current user rank in nextRanksWithScores', function (assert) {


### PR DESCRIPTION
Introduce a computed property `ctaText` in the track-leaderboard component that
displays a contextual call-to-action message. The message encourages the user to
complete a specific number of stages to improve their leaderboard rank, based on
their current entry and rank calculation.

Add the `userEntry` getter to the leaderboard entries cache to easily access
the current user's leaderboard entry. Use the new `computeLeaderboardCTA` utility
to determine the appropriate message.

Update the template to conditionally render the CTA below the leaderboard
entries, improving user engagement and guidance.

Also add a utility method `visibleStepsAfter` in course-page-step-list to support
future enhancements with step visibility logic.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Adds contextual CTA to `TrackLeaderboard`**
> 
> - Introduces `compute-leaderboard-cta` and `ctaText` in `track-leaderboard` to suggest how many stages to complete to improve rank; updates template to render CTA.
> - Passes `@nextStagesInContext` from `CoursePage::RightSidebar` (via new `nextStagesInContextForTrackLeaderboard`) using `coursePageState.stepList.visibleStepsAfter(...)`.
> - Adds `userEntry` getter and exposes `userRankCalculation` in `leaderboard-entries-cache` to support CTA logic.
> - Makes `leaderboard-rank-calculation.nextRanksWithScores` optional and validates entries; adjusts messaging for singular/plural and limits context to 5 stages.
> - Extends `course-page-step-list` with `visibleStepsAfter` and error checks in next/previous helpers.
> - Updates tests for CTA scenarios and copy; minor UI spacing tweak in `track-leaderboard.hbs`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e37966cdcebb5beb23901a570473ad2244f12cf5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- GitButler Footer Boundary Top -->
---
This is **part 1 of 2 in a stack** made with GitButler:
- <kbd>&nbsp;2&nbsp;</kbd> #3483 
- <kbd>&nbsp;1&nbsp;</kbd> #3482 👈 
<!-- GitButler Footer Boundary Bottom -->

