### PR TITLE
feat(track-leaderboard): add isCollapsed arg for collapse state

### DIFF
--- a/app/components/course-page/right-sidebar.hbs
+++ b/app/components/course-page/right-sidebar.hbs
@@ -13,7 +13,11 @@
     </div>
 
     {{#if this.featureFlags.canViewTrackLeaderboardOnCoursePage}}
-      <TrackLeaderboard @language={{this.languageForTrackLeaderboard}} @nextStagesInContext={{this.nextStagesInContextForTrackLeaderboard}} />
+      <TrackLeaderboard
+        @isCollapsed={{not @isExpanded}}
+        @language={{this.languageForTrackLeaderboard}}
+        @nextStagesInContext={{this.nextStagesInContextForTrackLeaderboard}}
+      />
     {{else}}
       <CourseLeaderboard
         class={{if @isExpanded "-ml-6" "-ml-4"}}

--- a/app/components/track-leaderboard.hbs
+++ b/app/components/track-leaderboard.hbs
@@ -1,5 +1,5 @@
 <div data-test-track-leaderboard {{did-insert this.handleDidInsert}} ...attributes>
-  <div class="flex items-center justify-between mb-2">
+  <div class="items-center justify-between mb-2 ease-out transition-all duration-300 {{if @isCollapsed 'hidden' 'flex'}} ">
     <div class="flex items-center">
       <span class="uppercase text-teal-500 dark:text-teal-600 text-xs font-bold" data-test-leaderboard-title>{{@language.name}} LEADERBOARD</span>
     </div>
@@ -12,24 +12,24 @@
     <div>
       <AnimatedContainer>
         {{#animated-each this.entriesForFirstSectionWithRanks key="entry.user.id" use=this.listTransition as |entryWithRank|}}
-          <TrackLeaderboard::Row @entry={{entryWithRank.entry}} @rank={{entryWithRank.rank}} />
+          <TrackLeaderboard::Row @entry={{entryWithRank.entry}} @rank={{entryWithRank.rank}} @isCollapsed={{@isCollapsed}} />
         {{/animated-each}}
 
         {{#if (gt this.leaderboardEntriesCache.entriesForSecondSectionWithRanks.length 0)}}
           {{! --- other users --- divider }}
           <div class="flex items-center py-1">
             <div class="w-full h-px bg-gray-200 dark:bg-white/5" />
-            <span class="text-xs text-gray-400 dark:text-gray-500 inline-flex px-4 shrink-0">other&nbsp;users</span>
+            <span class="text-xs text-gray-400 dark:text-gray-500 px-4 shrink-0 {{if @isCollapsed 'hidden' 'inline-flex'}}">other&nbsp;users</span>
             <div class="w-full h-px bg-gray-200 dark:bg-white/5" />
           </div>
 
           {{#animated-each this.entriesForSecondSectionWithRanks key="entry.user.id" use=this.listTransition as |entryWithRank|}}
-            <TrackLeaderboard::Row @entry={{entryWithRank.entry}} @rank={{entryWithRank.rank}} />
+            <TrackLeaderboard::Row @entry={{entryWithRank.entry}} @rank={{entryWithRank.rank}} @isCollapsed={{@isCollapsed}} />
           {{/animated-each}}
         {{/if}}
       </AnimatedContainer>
 
-      {{#animated-if (not this.leaderboardEntriesCache.hasEntries)}}
+      {{#animated-if (and (not @isCollapsed) (not this.leaderboardEntriesCache.hasEntries))}}
         <div class="flex py-2 items-center mb-2">
           <div class="text-sm text-gray-500">
             <p>
@@ -39,7 +39,7 @@
         </div>
       {{/animated-if}}
 
-      {{#if this.ctaText}}
+      {{#if (and this.ctaText (not @isCollapsed))}}
         <div class="flex items-center justify-center mt-4">
           <div class="flex items-start gap-1">
             {{svg-jar "information-circle-outline" class="size-5 text-teal-600 dark:text-teal-500"}}
@@ -54,7 +54,7 @@
   {{else}}
     <div>
       {{#each (repeat 10)}}
-        <TrackLeaderboard::SkeletonRow />
+        <TrackLeaderboard::SkeletonRow @isCollapsed={{@isCollapsed}} />
       {{/each}}
     </div>
   {{/if}}

--- a/app/components/track-leaderboard.ts
+++ b/app/components/track-leaderboard.ts
@@ -17,6 +17,7 @@ interface Signature {
   Element: HTMLDivElement;
 
   Args: {
+    isCollapsed: boolean;
     language: LanguageModel;
     nextStagesInContext?: CourseStageModel[];
   };

--- a/app/components/track-leaderboard/row.hbs
+++ b/app/components/track-leaderboard/row.hbs
@@ -12,9 +12,12 @@
 >
   <div class="flex items-center gap-2 min-w-0">
     <AvatarImage @user={{@entry.user}} class="size-8 border border-gray-300 dark:border-gray-700 rounded-sm shrink-0" />
+
     <span
       class="text-xs truncate group-hover/row:underline
-        {{if this.isCurrentUser 'text-teal-600 dark:text-teal-400' 'text-gray-600 dark:text-gray-400'}}"
+        {{if this.isCurrentUser 'text-teal-600 dark:text-teal-400' 'text-gray-600 dark:text-gray-400'}}
+        {{if @isCollapsed 'hidden'}}
+        "
       data-test-username
     >
       {{@entry.user.username}}
@@ -22,7 +25,7 @@
   </div>
 
   {{! 8ch can fit 6-digit ranks (#100000), and 5-digit scores (10000 pts) }}
-  <div class="relative h-4 w-[8ch]">
+  <div class="relative h-4 w-[8ch] {{if @isCollapsed 'hidden'}}">
     <span
       class="absolute top-0 right-0 w-fit text-xs font-medium shrink-0
         {{if this.isCurrentUser 'text-teal-600 dark:text-teal-400' 'text-gray-400 dark:text-gray-500'}}

--- a/app/components/track-leaderboard/row.ts
+++ b/app/components/track-leaderboard/row.ts
@@ -8,6 +8,7 @@ interface Signature {
 
   Args: {
     entry: LeaderboardEntryModel;
+    isCollapsed?: boolean;
     rank: number;
   };
 }

--- a/app/components/track-leaderboard/skeleton-row.hbs
+++ b/app/components/track-leaderboard/skeleton-row.hbs
@@ -1,8 +1,13 @@
 <div class="flex items-center justify-between py-1.5 px-2 -mx-2" ...attributes>
   <div class="flex items-center gap-2">
     <LoadingSkeleton class="size-8 flex-shrink-0" />
-    <LoadingSkeleton class="w-[16ch] text-xs" />
+
+    {{#unless @isCollapsed}}
+      <LoadingSkeleton class="w-[16ch] text-xs" />
+    {{/unless}}
   </div>
 
-  <LoadingSkeleton class="w-[4ch] text-xs" />
+  {{#unless @isCollapsed}}
+    <LoadingSkeleton class="w-[4ch] text-xs" />
+  {{/unless}}
 </div>

--- a/app/components/track-leaderboard/skeleton-row.ts
+++ b/app/components/track-leaderboard/skeleton-row.ts
@@ -2,6 +2,10 @@ import Component from '@glimmer/component';
 
 interface Signature {
   Element: HTMLDivElement;
+
+  Args: {
+    isCollapsed?: boolean;
+  };
 }
 
 export default class TrackLeaderboardSkeletonRow extends Component<Signature> {}

--- a/app/templates/join-track.hbs
+++ b/app/templates/join-track.hbs
@@ -35,7 +35,7 @@
           class="mb-6 w-full bg-github-green-dot-wall"
         />
 
-        <TrackLeaderboard class="mb-6" @language={{@model.language}} />
+        <TrackLeaderboard class="mb-6" @isCollapsed={{false}} @language={{@model.language}} />
 
         {{! TODO: Show testimonials for track instead of courses? }}
         <div>

--- a/app/templates/track.hbs
+++ b/app/templates/track.hbs
@@ -37,7 +37,7 @@
       </div>
 
       <div class="hidden lg:block w-80 shrink-0 sticky top-6 ml-6">
-        <TrackLeaderboard class="mb-6" @language={{@model.language}} />
+        <TrackLeaderboard class="mb-6" @isCollapsed={{false}} @language={{@model.language}} />
 
         {{! TODO: Show testimonials for track instead of courses? }}
         <div>


### PR DESCRIPTION
Add a new boolean argument `isCollapsed` to the TrackLeaderboard
component to allow control over its collapsed state. This change 
enables better UI state management and improves flexibility for 
different display scenarios.

<!-- GitButler Footer Boundary Top -->
---
This is **part 2 of 2 in a stack** made with GitButler:
- <kbd>&nbsp;2&nbsp;</kbd> #3483 👈 
- <kbd>&nbsp;1&nbsp;</kbd> #3482 
<!-- GitButler Footer Boundary Bottom -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds collapsible behavior to `TrackLeaderboard` and wires it through child components.
> 
> - Introduces `@isCollapsed` arg on `TrackLeaderboard`; threads to `TrackLeaderboard::Row` and `TrackLeaderboard::SkeletonRow`
> - Conditionally hides header, "other users" divider, usernames, rank/score, empty state, and CTA when collapsed; adjusts skeleton layout
> - Updates usages to pass `@isCollapsed` in `course-page/right-sidebar.hbs` (derived from `@isExpanded`), `track.hbs`, and `join-track.hbs`
> - Updates component TS signatures to include the new arg
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c12b84bd89ebbb3ff4d16145d9aec2546a73dcab. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->