### PR TITLE
Refactor visible steps logic to include current step's course stage.

### DIFF
--- a/app/components/course-page/right-sidebar.ts
+++ b/app/components/course-page/right-sidebar.ts
@@ -74,10 +74,13 @@ export default class CoursePageRightSidebar extends Component<Signature> {
       return [];
     }
 
-    return this.coursePageState.stepList
-      .visibleStepsAfter(this.coursePageState.currentStep)
-      .filter((step) => step.type === 'CourseStageStep')
-      .map((step) => (step as CourseStageStep).courseStage);
+    return [
+      this.coursePageState.currentStepAsCourseStageStep.courseStage,
+      ...this.coursePageState.stepList
+        .visibleStepsAfter(this.coursePageState.currentStep)
+        .filter((step) => step.type === 'CourseStageStep')
+        .map((step) => (step as CourseStageStep).courseStage),
+    ];
   }
 
   get visiblePrivateLeaderboardFeatureSuggestion(): FeatureSuggestionModel | null {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Updates `nextStagesInContextForTrackLeaderboard` to include the current step's `courseStage` before subsequent visible `CourseStageStep`s, affecting the stages shown in the track leaderboard context.
> 
> - Applies only when `stepList` exists, the current step is a `CourseStageStep`, and it matches the active step
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 26aa55b28dc9557ef42166c6c1ac2372fcdc92ce. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->