### PR TITLE
ci: enforce strict patch coverage and relax project threshold

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,9 @@
+coverage:
+  status:
+    patch:
+      default:
+        target: 100%
+    project:
+      default:
+        # project coverage is noisy, so let's allow a 5% drop
+        threshold: 5


### PR DESCRIPTION
Add configuration to codecov.yml to require 100% coverage on 
patches, ensuring new code is fully tested. Set a 5% threshold 
for overall project coverage to reduce noise from minor drops.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Configures Codecov to enforce strict coverage on new changes while softening project-wide thresholds.
> 
> - Adds `codecov.yml` with `coverage.status.patch.default.target` set to `100%` to require full coverage on modified lines/patches
> - Sets `coverage.status.project.default.threshold` to `5` to allow minor overall coverage drops
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c62534d65334379d0b3640abdb5faacd4336163e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->