### PR TITLE
Refactor step status check to simplify rendering of completed steps in HBS.

### DIFF
--- a/app/components/course-page/step-list-item.hbs
+++ b/app/components/course-page/step-list-item.hbs
@@ -8,7 +8,14 @@
   {{! @glint-expect-error modifier helper types aren't right? }}
   {{(if @isCurrent (modifier "scroll-into-view" block="start"))}}
 >
-  {{#if (eq @step.status "complete")}}
+  {{#if
+    (or
+      (eq @step.status "complete")
+      (eq @step.type "BaseStagesCompletedStep")
+      (eq @step.type "ExtensionCompletedStep")
+      (eq @step.type "CourseCompletedStep")
+    )
+  }}
     <div class="rounded-full w-6 h-6 border flex items-center justify-center shrink-0 bg-teal-500 border-teal-500 dark:bg-teal-500/40">
       {{svg-jar "check" class="w-4 h-4 fill-current text-white dark:text-teal-400"}}
     </div>
@@ -27,18 +34,6 @@
   {{else if (eq @step.type "SetupStep")}}
     <div class="rounded-full w-6 h-6 border flex items-center justify-center shrink-0 bg-white dark:bg-gray-925 border-teal-500 shadow-xs">
       {{svg-jar "dots-horizontal" class="w-4 h-4 fill-current text-teal-500"}}
-    </div>
-  {{else if (eq @step.type "CourseCompletedStep")}}
-    <div class="rounded-full w-6 h-6 border flex items-center justify-center shrink-0 bg-teal-500 border-teal-500">
-      {{svg-jar "check" class="w-4 h-4 fill-current text-white"}}
-    </div>
-  {{else if (eq @step.type "BaseStagesCompletedStep")}}
-    <div class="rounded-full w-6 h-6 border flex items-center justify-center shrink-0 bg-teal-500 border-teal-500">
-      {{svg-jar "check" class="w-4 h-4 fill-current text-white"}}
-    </div>
-  {{else if (eq @step.type "ExtensionCompletedStep")}}
-    <div class="rounded-full w-6 h-6 border flex items-center justify-center shrink-0 bg-teal-500 border-teal-500">
-      {{svg-jar "check" class="w-4 h-4 fill-current text-white"}}
     </div>
   {{/if}}
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Simplifies how completed steps render and tidies styles.
> 
> - Consolidates multiple `else if` branches into a single `{{#if (or ...)}}` to show the check icon for `status === "complete"` and `BaseStagesCompletedStep`/`ExtensionCompletedStep`/`CourseCompletedStep`
> - Removes redundant type-specific completed branches
> - Tweaks dark mode styles for the completed icon (`dark:bg-teal-500/40`, `dark:text-teal-400`)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit df1e43ac9985c4c1cba0263f4707feda148807d2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->