### PR TITLE
fix(styles): add dark mode hover color to track card title

### DIFF
--- a/app/components/track-page/card.hbs
+++ b/app/components/track-page/card.hbs
@@ -8,7 +8,7 @@
       <div class="flex items-center flex-wrap gap-3">
         <div
           class="text-xl font-semibold text-gray-900 dark:text-gray-200 flex items-center
-            {{if @isNavigatingToOtherPage 'group-hover:text-teal-500 transition-colors'}}"
+            {{if @isNavigatingToOtherPage 'group-hover:text-teal-500 dark:group-hover:text-teal-500 transition-colors'}}"
           data-test-track-page-card-title
         >
           {{this.titleForDisplay}}


### PR DESCRIPTION
Ensure the track card title changes color on hover in dark mode
when navigating to another page by adding 'dark:group-hover:text-teal-500'.
This improves visual feedback consistency across light and dark themes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Improves dark theme hover feedback for the track card title.
> 
> - In `track-page/card.hbs`, extends the conditional title classes to include `dark:group-hover:text-teal-500` when `@isNavigatingToOtherPage` is true
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1e4a1ab5104888a4e0d1f6dad3aeff09e479e67b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->