### PR TITLE
Refactor course card to conditionally display progress bar and content layout.

### DIFF
--- a/app/components/track-page/course-card.hbs
+++ b/app/components/track-page/course-card.hbs
@@ -47,23 +47,29 @@
     </:afterTitle>
 
     <:default>
-      <div class="h-80 overflow-hidden">
-        {{#if @activeRepository}}
-          <div class="mb-4">
-            <TrackPage::CourseCard::ProgressBar @course={{@course}} @lastPushedRepository={{@activeRepository}} />
+      {{#if @activeRepository.allStagesAreComplete}}
+        <TrackPage::CourseCard::ProgressBar @course={{@course}} @lastPushedRepository={{@activeRepository}} />
+      {{else}}
+        <div class="h-80 overflow-hidden">
+          {{#if @activeRepository}}
+            <div class="mb-4">
+              <TrackPage::CourseCard::ProgressBar @course={{@course}} @lastPushedRepository={{@activeRepository}} />
+            </div>
+          {{/if}}
+
+          <div class="leading-6 prose dark:prose-invert mb-4 pr-8">
+            {{markdown-to-html this.introductionMarkdown}}
           </div>
-        {{/if}}
 
-        <div class="leading-6 prose dark:prose-invert mb-4 pr-8">
-          {{markdown-to-html this.introductionMarkdown}}
+          <TrackPage::CourseCard::StageList @completedStages={{this.completedStages}} @course={{@course}} />
+
+          <div
+            class="absolute top-20 bottom-0 left-0 right-0 vertical-mask dark:vertical-mask-gray-925 rounded-b-md p-4 flex items-end justify-center"
+          >
+            <TrackPage::CourseCard::VisitCourseOverviewButton @course={{@course}} @language={{@language}} />
+          </div>
         </div>
-
-        <TrackPage::CourseCard::StageList @completedStages={{this.completedStages}} @course={{@course}} />
-
-        <div class="absolute top-20 bottom-0 left-0 right-0 vertical-mask dark:vertical-mask-gray-925 rounded-b-md p-4 flex items-end justify-center">
-          <TrackPage::CourseCard::VisitCourseOverviewButton @course={{@course}} @language={{@language}} />
-        </div>
-      </div>
+      {{/if}}
     </:default>
   </TrackPage::Card>
 {{/if}}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adjusts `course-card` rendering to show only a progress bar when `@activeRepository.allStagesAreComplete` is true, and otherwise keep the previous masked layout with optional progress, intro markdown, stage list, and CTA.
> 
> - New conditional: complete courses render a standalone `ProgressBar` (no masked content)
> - Non-complete courses retain existing layout with progress (if present), introduction, `StageList`, and `VisitCourseOverviewButton`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f549bed0698fbf4023b279c5612f9a09bb7ecfe2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->