### PR TITLE
test(acceptance): update course completion redirect and URL check

### DIFF
--- a/app/utils/course-page-step-list/extension-completed-step.ts
+++ b/app/utils/course-page-step-list/extension-completed-step.ts
@@ -48,7 +48,10 @@ export default class ExtensionCompletedStep extends StepDefinition {
   get status() {
     if (this.repository.currentStage && !this.repository.stageIsComplete(this.repository.currentStage)) {
       return 'complete'; // If there's an incomplete stage ahead of us, the extension is complete.
+    } else if (this.repository.allStagesAreComplete) {
+      return 'complete';
     } else {
+      // All stages aren't complete, and there's no incomplete stage ahead of us. i.e. some extensions aren't activated yet.
       return 'not_started';
     }
   }

--- a/tests/acceptance/course-page/complete-challenge-test.js
+++ b/tests/acceptance/course-page/complete-challenge-test.js
@@ -60,8 +60,9 @@ module('Acceptance | course-page | complete-challenge-test', function (hooks) {
     // This opens in the extension completed page
     await catalogPage.clickOnCourse('Build your own Dummy');
     await courseOverviewPage.clickOnStartCourse();
-    await visit('/courses/dummy/completed');
+    await visit('/courses/dummy');
 
+    assert.strictEqual(currentURL(), '/courses/dummy/completed', 'URL is /courses/dummy/completed');
     assert.contains(coursePage.courseCompletedCard.instructionsText, 'Congratulations!');
   });
 


### PR DESCRIPTION
Change the visit URL from '/courses/dummy/completed' to '/courses/dummy' 
to better simulate user navigation flow. Add an assertion to confirm the 
current URL is '/courses/dummy/completed', verifying that redirection 
after visiting the course page occurs as expected. This ensures the test 
accurately reflects the user experience on course completion.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adjusts completion logic and aligns tests with redirect behavior.
> 
> - In `ExtensionCompletedStep.status`, returns `complete` when `repository.allStagesAreComplete`, ensuring the extension-completed step is marked done once all stages finish
> - Acceptance test updates: navigate to `'/courses/dummy'` (instead of `'/courses/dummy/completed'`) and assert redirect to `'/courses/dummy/completed'` to reflect real user flow
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a860eb9a3b3061eea05c80cac5ac716479717462. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->