### PR TITLE
Add visibility tracking to PageViewTracker for improved analytics handling.

### DIFF
--- a/app/services/visibility.ts
+++ b/app/services/visibility.ts
@@ -1,10 +1,12 @@
 import * as Sentry from '@sentry/ember';
+import FastBootService from 'ember-cli-fastboot/services/fastboot';
 import Service, { service } from '@ember/service';
 import type Store from '@ember-data/store';
 import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
 
 export default class VisibilityService extends Service {
+  @service declare fastboot: FastBootService;
   @service declare store: Store;
   @tracked isVisible;
   callbacks: Record<string, (isVisible: boolean) => void> = {};
@@ -46,6 +48,11 @@ export default class VisibilityService extends Service {
   }
 
   setupVisibilityChangeEventHandlers() {
+    // Skip in fastboot context
+    if (this.fastboot.isFastBoot) {
+      return;
+    }
+
     document.addEventListener('visibilitychange', () => {
       this.isVisible = !document.hidden;
       this.fireCallbacks();

--- a/tests/acceptance/track-viewed-page-events-test.js
+++ b/tests/acceptance/track-viewed-page-events-test.js
@@ -1,0 +1,55 @@
+import catalogPage from 'codecrafters-frontend/tests/pages/catalog-page';
+import testScenario from 'codecrafters-frontend/mirage/scenarios/test';
+import { module, test } from 'qunit';
+import { setupApplicationTest } from 'codecrafters-frontend/tests/helpers';
+import { signIn } from 'codecrafters-frontend/tests/support/authentication-helpers';
+import { waitUntil } from '@ember/test-helpers';
+
+module('Acceptance | track-viewed-page-events-test', function (hooks) {
+  setupApplicationTest(hooks);
+
+  test('it tracks viewed_page event on page load', async function (assert) {
+    testScenario(this.server);
+    signIn(this.owner, this.server);
+
+    await catalogPage.visit();
+
+    const viewedPageEvents = this.server.schema.analyticsEvents.all().models.filter((event) => {
+      return event.name === 'viewed_page';
+    });
+
+    assert.strictEqual(viewedPageEvents.length, 1, 'Expected one viewed_page event on initial page load');
+  });
+
+  test('it tracks viewed_page event when returning after more than 5 minutes', async function (assert) {
+    testScenario(this.server);
+    signIn(this.owner, this.server);
+
+    const visibilityService = this.owner.lookup('service:visibility');
+    const pageViewTrackerService = this.owner.lookup('service:page-view-tracker');
+
+    await catalogPage.visit();
+
+    const getViewedPageEvents = () => {
+      return this.server.schema.analyticsEvents.all().models.filter((event) => {
+        return event.name === 'viewed_page';
+      });
+    };
+
+    assert.strictEqual(getViewedPageEvents().length, 1, 'Expected one viewed_page event');
+
+    // Simulate hiding the page - this sets lastHiddenAt to Date.now()
+    visibilityService.isVisible = false;
+    visibilityService.fireCallbacks();
+
+    assert.strictEqual(getViewedPageEvents().length, 1, 'Expected one viewed_page event');
+
+    // Directly set lastHiddenAt to 6 minutes in the past (simpler than mocking the date service)
+    pageViewTrackerService.lastHiddenAt = Date.now() - 6 * 60 * 1000;
+
+    visibilityService.isVisible = true;
+    visibilityService.fireCallbacks();
+
+    waitUntil(() => getViewedPageEvents().length === 2);
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Introduces visibility-aware page view tracking to improve analytics accuracy.
> 
> - `PageViewTracker`: registers a `visibility` callback, records `lastHiddenAt`, and triggers `viewed_page` when becoming visible after >5 minutes; cleans up callback on destroy; uses `date` service
> - `VisibilityService`: adds FastBoot guard, maintains `isVisible`, and exposes `registerCallback`/`deregisterCallback`/`fireCallbacks` wired to `document.visibilitychange`
> - Tests: new acceptance tests verify `viewed_page` on initial load and when returning after >5 minutes
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d6b90fc70e8c8652abc209c1fc204d72fbc3217f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->