### PR TITLE
Bun setup migration

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -22,15 +22,11 @@ jobs:
           # Ensure we are on an actual branch (not a detached HEAD)
           ref: ${{ github.head_ref || github.ref }}
 
-      - uses: actions/setup-node@v4
-        with:
-          node-version: '22'
-
       - uses: oven-sh/setup-bun@v2
         with:
           bun-version: '1.3.5'
 
-      # Caching node_modules is faster than using setup-node's cache
+      # Caching node_modules directory for faster installs
       - id: cache
         name: Cache dependencies
         uses: actions/cache@v5

--- a/.github/workflows/publish_bundle.yml
+++ b/.github/workflows/publish_bundle.yml
@@ -15,9 +15,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@v6
-      - uses: actions/setup-node@v4
-        with:
-          node-version: '22'
       - uses: oven-sh/setup-bun@v2
         with:
           bun-version: '1.3.5'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,15 +23,11 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - uses: actions/setup-node@v4
-        with:
-          node-version: '22'
-
       - uses: oven-sh/setup-bun@v2
         with:
           bun-version: '1.3.5'
 
-      # Caching node_modules is faster than using setup-node's cache
+      # Caching node_modules directory for faster installs
       - id: cache
         name: Cache dependencies
         uses: actions/cache@v5


### PR DESCRIPTION
This pull request contains changes generated by a Cursor Cloud Agent

<a href="https://cursor.com/background-agent?bcId=bc-ef2bb481-a5a5-4497-8f10-8017ca8d7e37"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-ef2bb481-a5a5-4497-8f10-8017ca8d7e37"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Consolidates CI on Bun and streamlines dependency installs.
> 
> - Remove `actions/setup-node` from `lint.yml`, `test.yml`, and `publish_bundle.yml`; use `oven-sh/setup-bun@v2` (`bun 1.3.5`) exclusively
> - Add `actions/cache` for `node_modules` in `lint.yml` and `test.yml` and gate `bun install --frozen-lockfile --ignore-scripts` behind cache hit checks
> - Keep build/test commands using Bun (`bun run build`, `bunx ember`, `bunx percy`) with existing env vars
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3d75aa03484fe0f16841e60928301476d602e8de. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->