### PR TITLE
test: fix missing await in track-viewed-page-events test

### DIFF
--- a/tests/acceptance/track-viewed-page-events-test.js
+++ b/tests/acceptance/track-viewed-page-events-test.js
@@ -50,6 +50,6 @@ module('Acceptance | track-viewed-page-events-test', function (hooks) {
     visibilityService.isVisible = true;
     visibilityService.fireCallbacks();
 
-    waitUntil(() => getViewedPageEvents().length === 2);
+    await waitUntil(() => getViewedPageEvents().length === 2);
   });
 });


### PR DESCRIPTION
Add await before waitUntil to ensure asynchronous operation
completes correctly in track-viewed-page-events-test.js. This
change prevents potential test flakiness by properly waiting for
the expected number of viewed page events.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Fix test flakiness by properly awaiting async condition**
> 
> - Add `await` before `waitUntil` in `tests/acceptance/track-viewed-page-events-test.js` so the test waits for the second `viewed_page` event after simulating a 6-minute return.
> - Scope: test-only change; no production code modified.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e5d4a6567b9adb0be5ed6bfc618c8b08ec6df8c7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->