### PR TITLE
Refactor leaderboard component to use LinkTo for navigation and styling updates.

### DIFF
--- a/app/components/track-leaderboard.hbs
+++ b/app/components/track-leaderboard.hbs
@@ -1,8 +1,17 @@
 <div data-test-track-leaderboard {{did-insert this.handleDidInsert}} ...attributes>
   <div class="items-center justify-between mb-2 ease-out transition-all duration-300 {{if @isCollapsed 'hidden' 'flex'}} ">
-    <div class="flex items-center">
-      <span class="uppercase text-teal-500 dark:text-teal-600 text-xs font-bold" data-test-leaderboard-title>{{@language.name}} LEADERBOARD</span>
-    </div>
+    <LinkTo
+      @route="leaderboard"
+      @model={{@language.slug}}
+      class="group flex items-center gap-1 text-teal-500 dark:text-teal-600 hover:text-teal-600 dark:hover:text-teal-500 transition-colors"
+    >
+      <span class="uppercase text-xs font-bold" data-test-leaderboard-title>
+        {{@language.name}}
+        LEADERBOARD
+      </span>
+
+      {{svg-jar "arrow-right" class="-rotate-45 size-3 group-hover:rotate-0 transition-transform ease-out duration-100"}}
+    </LinkTo>
     <div>
       {{! Add team dropdown if needed }}
     </div>


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Makes the leaderboard header clickable and updates its styling.
> 
> - Wraps the leaderboard title in `LinkTo @route="leaderboard" @model={{@language.slug}}` to navigate to the language-specific leaderboard
> - Adds `arrow-right` icon with hover rotation and color transition classes; removes previous non-link container
> - No changes to entries rendering, loading state, or CTA logic
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b6c2e65b0421b6c33f136b1cbfb8779876a6a2a8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->