### PR TITLE
Refactor: Replace 'flex-shrink-0' with 'shrink-0' in multiple components.

### DIFF
--- a/app/components/course-overview-page/notices/free-course-notice.hbs
+++ b/app/components/course-overview-page/notices/free-course-notice.hbs
@@ -1,6 +1,6 @@
 <Alert @color="teal" @size="large" data-test-free-course-notice ...attributes>
   <div class="flex items-start gap-2">
-    <div class="mt-1 flex-shrink-0 hidden sm:block">
+    <div class="mt-1 shrink-0 hidden sm:block">
       {{svg-jar "sparkles" class="w-6 h-6 fill-current text-teal-500"}}
     </div>
     <div class="flex-1">

--- a/app/components/course-overview-page/notices/paid-course-notice.hbs
+++ b/app/components/course-overview-page/notices/paid-course-notice.hbs
@@ -1,6 +1,6 @@
 <Alert @color="yellow" @size="large" data-test-paid-course-notice ...attributes>
   <div class="flex items-start gap-2">
-    <div class="mt-1 flex-shrink-0 hidden sm:block">
+    <div class="mt-1 shrink-0 hidden sm:block">
       {{svg-jar "lock-closed" class="w-6 h-6 fill-current text-gray-900 dark:text-yellow-50"}}
     </div>
     <div class="flex-1">

--- a/app/components/course-page/header/main-section.hbs
+++ b/app/components/course-page/header/main-section.hbs
@@ -34,6 +34,6 @@
     @nextStep={{@nextStep}}
     @stepList={{@stepList}}
     @track={{@track}}
-    class="flex-shrink-0"
+    class="shrink-0"
   />
 </div>

--- a/app/components/gift-payment-page/choose-plan-step-container.hbs
+++ b/app/components/gift-payment-page/choose-plan-step-container.hbs
@@ -20,7 +20,7 @@
       >
         <div class="flex items-start gap-3">
           <div
-            class="flex-shrink-0 flex items-center justify-center w-4 h-4 border rounded-full mt-0.5
+            class="shrink-0 flex items-center justify-center w-4 h-4 border rounded-full mt-0.5
               {{if (eq @giftPaymentFlow.pricingPlanId plan.id) 'border-teal-500 dark:border-teal-400' 'border-gray-400 dark:border-gray-600'}}"
           >
             {{#if (eq @giftPaymentFlow.pricingPlanId plan.id)}}
@@ -54,7 +54,7 @@
           </div>
         </div>
 
-        <div class="flex flex-col items-end pl-4 flex-shrink-0">
+        <div class="flex flex-col items-end pl-4 shrink-0">
           <div class="text-gray-600 dark:text-gray-300 font-bold">
             ${{plan.priceInDollars}}
           </div>

--- a/app/components/latest-releases-card.hbs
+++ b/app/components/latest-releases-card.hbs
@@ -4,7 +4,7 @@
   </h4>
   {{#each this.releases as |release releaseIndex|}}
     <div class="flex items-start gap-2 relative {{if (not-eq releaseIndex (sub this.releases.length 1)) 'pb-4'}}" data-test-latest-release-item>
-      <div class="w-2 h-2 bg-gray-200 dark:bg-gray-600 rounded-full mt-1 flex-shrink-0"></div>
+      <div class="w-2 h-2 bg-gray-200 dark:bg-gray-600 rounded-full mt-1 shrink-0"></div>
       <div class="w-full">
         <div class="text-xs text-gray-400 dark:text-gray-500 mb-1" data-test-latest-release-timestamp>
           {{date-format release.releasedAt format="MMM yyyy"}}

--- a/app/components/leaderboard-page/entries-table/row.hbs
+++ b/app/components/leaderboard-page/entries-table/row.hbs
@@ -16,7 +16,7 @@
   <LeaderboardPage::EntriesTable::RowCell>
     <div class="flex items-center justify-between gap-x-6">
       <div class="flex items-center gap-1.5">
-        <div class="flex-shrink-0 h-6 w-6">
+        <div class="shrink-0 h-6 w-6">
           <AvatarImage @user={{@entry.user}} class="h-6 w-6 rounded-full border border-gray-300 dark:border-gray-600" />
         </div>
         <div
@@ -48,7 +48,7 @@
           </a>
         {{/if}}
       </div>
-      <div class="hidden md:flex items-center gap-1.5 flex-shrink-0 {{unless this.isCurrentUser 'opacity-25 group-hover/table-row:opacity-100'}}">
+      <div class="hidden md:flex items-center gap-1.5 shrink-0 {{unless this.isCurrentUser 'opacity-25 group-hover/table-row:opacity-100'}}">
         {{#if (gt this.hiddenCourses.length 0)}}
           <div class="text-gray-500 dark:text-gray-400">
             ...

--- a/app/components/leaderboard-page/entries-table/skeleton-row.hbs
+++ b/app/components/leaderboard-page/entries-table/skeleton-row.hbs
@@ -8,12 +8,12 @@
   <LeaderboardPage::EntriesTable::RowCell>
     <div class="flex items-center justify-between gap-x-6">
       <div class="flex items-center gap-1.5">
-        <LoadingSkeleton @isCircle={{true}} class="size-6 flex-shrink-0" />
+        <LoadingSkeleton @isCircle={{true}} class="size-6 shrink-0" />
         <LoadingSkeleton class="w-[12ch] sm:w-[16ch] text-xs" />
       </div>
-      <div class="hidden md:flex items-center gap-1.5 flex-shrink-0 opacity-25 group-hover/table-row:opacity-100">
+      <div class="hidden md:flex items-center gap-1.5 shrink-0 opacity-25 group-hover/table-row:opacity-100">
         {{#each (repeat 6)}}
-          <LoadingSkeleton class="w-4 flex-shrink-0" />
+          <LoadingSkeleton class="w-4 shrink-0" />
         {{/each}}
       </div>
     </div>

--- a/app/components/leaderboard-page/header.hbs
+++ b/app/components/leaderboard-page/header.hbs
@@ -1,5 +1,5 @@
 <div class="flex items-center justify-between gap-x-6 gap-y-4 flex-wrap" ...attributes>
-  <div class="flex-shrink-0">
+  <div class="shrink-0">
     <div class="flex items-center gap-x-2">
       <h3 class="text-2xl font-bold text-gray-900 dark:text-gray-200" data-test-leaderboard-title>
         {{@selectedLanguage.name}}

--- a/app/components/pay-page/choose-membership-plan-modal/plan-card.hbs
+++ b/app/components/pay-page/choose-membership-plan-modal/plan-card.hbs
@@ -10,7 +10,7 @@
 >
   <div class="flex items-start gap-2">
     <div
-      class="flex-shrink-0 flex items-center justify-center w-4 h-4 border rounded-full mt-0.5
+      class="shrink-0 flex items-center justify-center w-4 h-4 border rounded-full mt-0.5
         {{if @isSelected 'border-teal-500 dark:border-teal-700' 'border-gray-400 dark:border-gray-600'}}"
     >
       {{#if @isSelected}}
@@ -74,7 +74,7 @@
     </div>
   </div>
 
-  <div class="flex flex-col items-end pl-4 flex-shrink-0">
+  <div class="flex flex-col items-end pl-4 shrink-0">
     {{#if this.discountedPriceInDollars}}
       <div class="flex items-center gap-x-1">
         <span class="text-gray-400 dark:text-gray-500 font-bold line-through text-lg">${{@plan.priceInDollars}}</span>
@@ -88,7 +88,7 @@
       </div>
     {{/if}}
 
-    <div class="text-gray-500 dark:text-gray-400 text-xxs flex-shrink-0 text-right mt-0.5">
+    <div class="text-gray-500 dark:text-gray-400 text-xxs shrink-0 text-right mt-0.5">
       {{#if this.amortizedMonthlyPriceInDollars}}
         Effectively ${{this.amortizedMonthlyPriceInDollars}}/mo
       {{else}}

--- a/app/components/step-list/item.hbs
+++ b/app/components/step-list/item.hbs
@@ -2,13 +2,13 @@
   <div class="flex flex-col items-center gap-2">
     {{#if @step.isComplete}}
       {{! Checkmark }}
-      <div class="flex w-7 h-7 items-center justify-center flex-shrink-0" data-test-step-complete-icon>
+      <div class="flex w-7 h-7 items-center justify-center shrink-0" data-test-step-complete-icon>
         {{svg-jar "check-circle" class="w-full text-teal-500"}}
       </div>
     {{else}}
       {{! Step number }}
       <div
-        class="h-7 w-7 flex-shrink-0 rounded-full bg-gray-100 dark:bg-gray-900 text-xs text-gray-900 dark:text-gray-200 font-semibold flex items-center justify-center"
+        class="h-7 w-7 shrink-0 rounded-full bg-gray-100 dark:bg-gray-900 text-xs text-gray-900 dark:text-gray-200 font-semibold flex items-center justify-center"
       >
         {{add @stepIndex 1}}
       </div>

--- a/app/components/track-leaderboard/skeleton-row.hbs
+++ b/app/components/track-leaderboard/skeleton-row.hbs
@@ -1,6 +1,6 @@
 <div class="flex items-center justify-between py-1.5 px-2 -mx-2" ...attributes>
   <div class="flex items-center gap-2">
-    <LoadingSkeleton class="size-8 flex-shrink-0" />
+    <LoadingSkeleton class="size-8 shrink-0" />
 
     {{#unless @isCollapsed}}
       <LoadingSkeleton class="w-[16ch] text-xs" />

--- a/app/templates/roadmap/course-extension-ideas.hbs
+++ b/app/templates/roadmap/course-extension-ideas.hbs
@@ -1,5 +1,5 @@
 <div class="flex flex-col md:flex-row-reverse gap-3">
-  <div class="w-full md:w-60 flex-shrink-0">
+  <div class="w-full md:w-60 shrink-0">
     <div class="md:sticky md:top-4 flex flex-col gap-3">
       <LatestReleasesCard @courseExtensionIdeas={{@model.courseExtensionIdeas}} @courseIdeas={{@model.courseIdeas}} />
     </div>

--- a/app/templates/roadmap/course-ideas.hbs
+++ b/app/templates/roadmap/course-ideas.hbs
@@ -1,5 +1,5 @@
 <div class="flex flex-col md:flex-row-reverse gap-3">
-  <div class="w-full md:w-60 flex-shrink-0">
+  <div class="w-full md:w-60 shrink-0">
     <div class="md:sticky md:top-4 flex flex-col gap-3">
 
       <LatestReleasesCard @courseExtensionIdeas={{@model.courseExtensionIdeas}} @courseIdeas={{@model.courseIdeas}} />


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Updates Tailwind shrink utility usage for consistency and modern syntax.
> 
> - Replaces `flex-shrink-0` with `shrink-0` across UI templates: course notices, course header, gift/pay plan cards, latest releases card, leaderboard rows/header/skeletons, step list item, and roadmap pages
> - Class-only changes; layout preserved, no logic or behavior changes
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6d1a471c910618a278fc497af47838620de62623. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->