### PR TITLE
feat(track-leaderboard): improve leaderboard CTA with course stage and repo

### DIFF
--- a/app/components/course-page/right-sidebar.hbs
+++ b/app/components/course-page/right-sidebar.hbs
@@ -14,9 +14,10 @@
 
     {{#if this.featureFlags.canViewTrackLeaderboardOnCoursePage}}
       <TrackLeaderboard
+        @currentCourseStage={{this.currentCourseStageForTrackLeaderboard}}
         @isCollapsed={{not @isExpanded}}
         @language={{this.languageForTrackLeaderboard}}
-        @nextStagesInContext={{this.nextStagesInContextForTrackLeaderboard}}
+        @repository={{@activeRepository}}
       />
     {{else}}
       <CourseLeaderboard

--- a/app/components/course-page/right-sidebar.ts
+++ b/app/components/course-page/right-sidebar.ts
@@ -10,7 +10,6 @@ import type FeatureSuggestionModel from 'codecrafters-frontend/models/feature-su
 import type LanguageModel from 'codecrafters-frontend/models/language';
 import type Store from '@ember-data/store';
 import { service } from '@ember/service';
-import type CourseStageStep from 'codecrafters-frontend/utils/course-page-step-list/course-stage-step';
 
 interface Signature {
   Element: HTMLDivElement;
@@ -32,6 +31,22 @@ export default class CoursePageRightSidebar extends Component<Signature> {
   @service declare preferredLanguageLeaderboard: PreferredLanguageLeaderboardService;
   @service declare store: Store;
   @service declare featureFlags: FeatureFlagsService;
+
+  get currentCourseStageForTrackLeaderboard(): CourseStageModel | undefined {
+    if (!this.coursePageState.stepList) {
+      return undefined;
+    }
+
+    if (this.coursePageState.currentStep.type !== 'CourseStageStep') {
+      return undefined;
+    }
+
+    if (this.coursePageState.currentStep !== this.coursePageState.activeStep) {
+      return undefined;
+    }
+
+    return this.coursePageState.currentStepAsCourseStageStep.courseStage;
+  }
 
   get currentUser() {
     return this.authenticator.currentUser;
@@ -59,28 +74,6 @@ export default class CoursePageRightSidebar extends Component<Signature> {
     }
 
     return this.args.course.betaOrLiveLanguages[0]!;
-  }
-
-  get nextStagesInContextForTrackLeaderboard(): CourseStageModel[] {
-    if (!this.coursePageState.stepList) {
-      return [];
-    }
-
-    if (this.coursePageState.currentStep.type !== 'CourseStageStep') {
-      return [];
-    }
-
-    if (this.coursePageState.currentStep !== this.coursePageState.activeStep) {
-      return [];
-    }
-
-    return [
-      this.coursePageState.currentStepAsCourseStageStep.courseStage,
-      ...this.coursePageState.stepList
-        .visibleStepsAfter(this.coursePageState.currentStep)
-        .filter((step) => step.type === 'CourseStageStep')
-        .map((step) => (step as CourseStageStep).courseStage),
-    ];
   }
 
   get visiblePrivateLeaderboardFeatureSuggestion(): FeatureSuggestionModel | null {

--- a/app/components/track-leaderboard.ts
+++ b/app/components/track-leaderboard.ts
@@ -8,6 +8,7 @@ import type LanguageModel from 'codecrafters-frontend/models/language';
 import type LeaderboardEntriesCache from 'codecrafters-frontend/utils/leaderboard-entries-cache';
 import type LeaderboardEntriesCacheRegistryService from 'codecrafters-frontend/services/leaderboard-entries-cache-registry';
 import type LeaderboardModel from 'codecrafters-frontend/models/leaderboard';
+import type RepositoryModel from 'codecrafters-frontend/models/repository';
 import type { LeaderboardEntryWithRank } from 'codecrafters-frontend/utils/leaderboard-entries-cache';
 import { action } from '@ember/object';
 import { fadeIn, fadeOut } from 'ember-animated/motions/opacity';
@@ -17,9 +18,10 @@ interface Signature {
   Element: HTMLDivElement;
 
   Args: {
+    currentCourseStage?: CourseStageModel;
     isCollapsed: boolean;
     language: LanguageModel;
-    nextStagesInContext?: CourseStageModel[];
+    repository?: RepositoryModel;
   };
 }
 
@@ -36,7 +38,8 @@ export default class TrackLeaderboard extends Component<Signature> {
     return computeLeaderboardCTA(
       this.leaderboardEntriesCache.userEntry,
       this.leaderboardEntriesCache.userRankCalculation,
-      this.args.nextStagesInContext || [],
+      this.args.repository,
+      this.args.currentCourseStage,
     );
   }
 

--- a/tests/unit/utils/compute-leaderboard-cta-test.ts
+++ b/tests/unit/utils/compute-leaderboard-cta-test.ts
@@ -2,6 +2,9 @@ import computeLeaderboardCTA from 'codecrafters-frontend/utils/compute-leaderboa
 import CourseStageModel from 'codecrafters-frontend/models/course-stage';
 import LeaderboardEntryModel from 'codecrafters-frontend/models/leaderboard-entry';
 import LeaderboardRankCalculationModel from 'codecrafters-frontend/models/leaderboard-rank-calculation';
+import RepositoryModel from 'codecrafters-frontend/models/repository';
+import RepositoryStageListModel from 'codecrafters-frontend/models/repository-stage-list';
+import RepositoryStageListItemModel from 'codecrafters-frontend/models/repository-stage-list-item';
 import { module, test } from 'qunit';
 
 module('Unit | Utility | compute-leaderboard-cta', function () {
@@ -17,11 +20,28 @@ module('Unit | Utility | compute-leaderboard-cta', function () {
     return { difficulty } as CourseStageModel;
   }
 
+  function createStageListItem(stage: CourseStageModel, position: number, isCompleted: boolean = false): RepositoryStageListItemModel {
+    return {
+      stage,
+      position,
+      isCompleted,
+      completedAt: isCompleted ? new Date() : null,
+    } as RepositoryStageListItemModel;
+  }
+
+  function createRepository(stageListItems: RepositoryStageListItemModel[]): RepositoryModel {
+    const stageList = {
+      items: stageListItems,
+    } as RepositoryStageListModel;
+
+    return { stageList } as RepositoryModel;
+  }
+
   test('returns null when rank is 1', function (assert) {
     const leaderboardEntry = createLeaderboardEntry(100);
     const rankCalculation = createRankCalculation(1, []);
 
-    const result = computeLeaderboardCTA(leaderboardEntry, rankCalculation, []);
+    const result = computeLeaderboardCTA(leaderboardEntry, rankCalculation);
 
     assert.strictEqual(result, null);
   });
@@ -31,28 +51,49 @@ module('Unit | Utility | compute-leaderboard-cta', function () {
     const leaderboardEntry = createLeaderboardEntry(100);
     const rankCalculation = createRankCalculation(50, [{ rank: 10, score: 1000 }]);
 
-    const result = computeLeaderboardCTA(leaderboardEntry, rankCalculation, []);
+    const result = computeLeaderboardCTA(leaderboardEntry, rankCalculation);
 
     assert.strictEqual(result, null);
   });
 
-  test('returns CTA for completing one stage when single stage in context is enough', function (assert) {
+  test('returns CTA for completing this stage when current stage is incomplete', function (assert) {
     const leaderboardEntry = createLeaderboardEntry(100);
     const rankCalculation = createRankCalculation(50, [{ rank: 45, score: 110 }]);
-    const nextStages = [createCourseStage('easy')]; // easy = 15 points
+    const currentStage = createCourseStage('easy'); // easy = 15 points
+    const stageListItems = [createStageListItem(currentStage, 1)];
+    const repository = createRepository(stageListItems);
 
-    const result = computeLeaderboardCTA(leaderboardEntry, rankCalculation, nextStages);
+    const result = computeLeaderboardCTA(leaderboardEntry, rankCalculation, repository, currentStage);
 
     assert.strictEqual(result, 'Complete this stage to hit #45');
+  });
+
+  test('returns CTA for completing next stage when current stage is complete', function (assert) {
+    const leaderboardEntry = createLeaderboardEntry(100);
+    const rankCalculation = createRankCalculation(50, [{ rank: 45, score: 110 }]);
+    const currentStage = createCourseStage('easy');
+    const nextStage = createCourseStage('easy'); // easy = 15 points
+    const stageListItems = [
+      createStageListItem(currentStage, 1, true), // current stage is completed
+      createStageListItem(nextStage, 2), // next stage is incomplete
+    ];
+    const repository = createRepository(stageListItems);
+
+    const result = computeLeaderboardCTA(leaderboardEntry, rankCalculation, repository, currentStage);
+
+    assert.strictEqual(result, 'Complete next stage to hit #45');
   });
 
   test('returns CTA for completing multiple stages when more than one stage needed', function (assert) {
     const leaderboardEntry = createLeaderboardEntry(100);
     const rankCalculation = createRankCalculation(50, [{ rank: 45, score: 140 }]); // Need 40 points
     // easy (15) + medium (30) = 45 points, which is enough
-    const nextStages = [createCourseStage('easy'), createCourseStage('medium')];
+    const currentStage = createCourseStage('easy');
+    const nextStage = createCourseStage('medium');
+    const stageListItems = [createStageListItem(currentStage, 1), createStageListItem(nextStage, 2)];
+    const repository = createRepository(stageListItems);
 
-    const result = computeLeaderboardCTA(leaderboardEntry, rankCalculation, nextStages);
+    const result = computeLeaderboardCTA(leaderboardEntry, rankCalculation, repository, currentStage);
 
     assert.strictEqual(result, 'Complete 2 stages to hit #45');
   });
@@ -61,16 +102,18 @@ module('Unit | Utility | compute-leaderboard-cta', function () {
     const leaderboardEntry = createLeaderboardEntry(100);
     const rankCalculation = createRankCalculation(50, [{ rank: 45, score: 200 }]); // Need 100 points
     // 6 easy stages provided, but only first 5 are considered (5 * 15 = 75 points, not enough)
-    const nextStages = [
-      createCourseStage('easy'),
-      createCourseStage('easy'),
-      createCourseStage('easy'),
-      createCourseStage('easy'),
-      createCourseStage('easy'),
-      createCourseStage('easy'),
+    const currentStage = createCourseStage('easy');
+    const stageListItems = [
+      createStageListItem(currentStage, 1),
+      createStageListItem(createCourseStage('easy'), 2),
+      createStageListItem(createCourseStage('easy'), 3),
+      createStageListItem(createCourseStage('easy'), 4),
+      createStageListItem(createCourseStage('easy'), 5),
+      createStageListItem(createCourseStage('easy'), 6),
     ];
+    const repository = createRepository(stageListItems);
 
-    const result = computeLeaderboardCTA(leaderboardEntry, rankCalculation, nextStages);
+    const result = computeLeaderboardCTA(leaderboardEntry, rankCalculation, repository, currentStage);
 
     // Falls back to difficulty-based: 5 easy = 75 (not enough), 4 medium = 120 (enough)
     assert.strictEqual(result, 'Complete 4 medium stages to hit #45');
@@ -80,7 +123,7 @@ module('Unit | Utility | compute-leaderboard-cta', function () {
     const leaderboardEntry = createLeaderboardEntry(100);
     const rankCalculation = createRankCalculation(50, [{ rank: 45, score: 145 }]); // Need 45 points
 
-    const result = computeLeaderboardCTA(leaderboardEntry, rankCalculation, []);
+    const result = computeLeaderboardCTA(leaderboardEntry, rankCalculation);
 
     // 3 easy stages = 45 points
     assert.strictEqual(result, 'Complete 3 easy stages to hit #45');
@@ -90,7 +133,7 @@ module('Unit | Utility | compute-leaderboard-cta', function () {
     const leaderboardEntry = createLeaderboardEntry(100);
     const rankCalculation = createRankCalculation(50, [{ rank: 45, score: 180 }]); // Need 80 points
 
-    const result = computeLeaderboardCTA(leaderboardEntry, rankCalculation, []);
+    const result = computeLeaderboardCTA(leaderboardEntry, rankCalculation);
 
     // 5 easy stages = 75 points (not enough), 3 medium stages = 90 points (enough)
     assert.strictEqual(result, 'Complete 3 medium stages to hit #45');
@@ -100,7 +143,7 @@ module('Unit | Utility | compute-leaderboard-cta', function () {
     const leaderboardEntry = createLeaderboardEntry(100);
     const rankCalculation = createRankCalculation(50, [{ rank: 45, score: 250 }]); // Need 150 points
 
-    const result = computeLeaderboardCTA(leaderboardEntry, rankCalculation, []);
+    const result = computeLeaderboardCTA(leaderboardEntry, rankCalculation);
 
     // 5 easy stages = 75 points (not enough)
     // 5 medium stages = 150 points (exactly enough)
@@ -111,7 +154,7 @@ module('Unit | Utility | compute-leaderboard-cta', function () {
     const leaderboardEntry = createLeaderboardEntry(100);
     const rankCalculation = createRankCalculation(50, [{ rank: 45, score: 260 }]); // Need 160 points
 
-    const result = computeLeaderboardCTA(leaderboardEntry, rankCalculation, []);
+    const result = computeLeaderboardCTA(leaderboardEntry, rankCalculation);
 
     // 5 easy stages = 75 points (not enough)
     // 5 medium stages = 150 points (not enough)
@@ -125,9 +168,11 @@ module('Unit | Utility | compute-leaderboard-cta', function () {
       { rank: 49, score: 90 }, // Below current score, should be skipped
       { rank: 45, score: 110 },
     ]);
-    const nextStages = [createCourseStage('easy')];
+    const currentStage = createCourseStage('easy');
+    const stageListItems = [createStageListItem(currentStage, 1)];
+    const repository = createRepository(stageListItems);
 
-    const result = computeLeaderboardCTA(leaderboardEntry, rankCalculation, nextStages);
+    const result = computeLeaderboardCTA(leaderboardEntry, rankCalculation, repository, currentStage);
 
     assert.strictEqual(result, 'Complete this stage to hit #45');
   });
@@ -140,9 +185,11 @@ module('Unit | Utility | compute-leaderboard-cta', function () {
       { rank: 45, score: 110 },
       { rank: 42, score: 115 },
     ]);
-    const nextStages = [createCourseStage('easy')]; // 15 points -> 115 total
+    const currentStage = createCourseStage('easy'); // 15 points -> 115 total
+    const stageListItems = [createStageListItem(currentStage, 1)];
+    const repository = createRepository(stageListItems);
 
-    const result = computeLeaderboardCTA(leaderboardEntry, rankCalculation, nextStages);
+    const result = computeLeaderboardCTA(leaderboardEntry, rankCalculation, repository, currentStage);
 
     // Should show the highest rank (#42) since we can achieve all three
     assert.strictEqual(result, 'Complete this stage to hit #42');
@@ -157,7 +204,7 @@ module('Unit | Utility | compute-leaderboard-cta', function () {
       { rank: 42, score: 115 },
     ]);
 
-    const result = computeLeaderboardCTA(leaderboardEntry, rankCalculation, []);
+    const result = computeLeaderboardCTA(leaderboardEntry, rankCalculation);
 
     // Should show the highest rank (#42) since 1 easy stage achieves all three
     assert.strictEqual(result, 'Complete 1 easy stage to hit #42');
@@ -170,9 +217,11 @@ module('Unit | Utility | compute-leaderboard-cta', function () {
       { rank: 55, score: 105 }, // Invalid: rank 55 is worse than current rank 50
       { rank: 45, score: 110 },
     ]);
-    const nextStages = [createCourseStage('easy')];
+    const currentStage = createCourseStage('easy');
+    const stageListItems = [createStageListItem(currentStage, 1)];
+    const repository = createRepository(stageListItems);
 
-    const result = computeLeaderboardCTA(leaderboardEntry, rankCalculation, nextStages);
+    const result = computeLeaderboardCTA(leaderboardEntry, rankCalculation, repository, currentStage);
 
     // Should ignore rank 55 and use rank 45
     assert.strictEqual(result, 'Complete this stage to hit #45');
@@ -185,9 +234,11 @@ module('Unit | Utility | compute-leaderboard-cta', function () {
       { rank: 50, score: 105 }, // Invalid: rank 50 is same as current rank
       { rank: 45, score: 110 },
     ]);
-    const nextStages = [createCourseStage('easy')];
+    const currentStage = createCourseStage('easy');
+    const stageListItems = [createStageListItem(currentStage, 1)];
+    const repository = createRepository(stageListItems);
 
-    const result = computeLeaderboardCTA(leaderboardEntry, rankCalculation, nextStages);
+    const result = computeLeaderboardCTA(leaderboardEntry, rankCalculation, repository, currentStage);
 
     // Should ignore rank 50 and use rank 45
     assert.strictEqual(result, 'Complete this stage to hit #45');
@@ -199,10 +250,65 @@ module('Unit | Utility | compute-leaderboard-cta', function () {
       { rank: 55, score: 105 }, // Invalid
       { rank: 60, score: 110 }, // Invalid
     ]);
-    const nextStages = [createCourseStage('easy')];
+    const currentStage = createCourseStage('easy');
+    const stageListItems = [createStageListItem(currentStage, 1)];
+    const repository = createRepository(stageListItems);
 
-    const result = computeLeaderboardCTA(leaderboardEntry, rankCalculation, nextStages);
+    const result = computeLeaderboardCTA(leaderboardEntry, rankCalculation, repository, currentStage);
 
     assert.strictEqual(result, null);
+  });
+
+  test('skips completed stages when computing next stages in context', function (assert) {
+    const leaderboardEntry = createLeaderboardEntry(100);
+    const rankCalculation = createRankCalculation(50, [{ rank: 45, score: 140 }]); // Need 40 points
+    // Current stage (easy 15) + next stage is completed (skipped) + third stage (medium 30) = 45 points
+    const currentStage = createCourseStage('easy');
+    const completedStage = createCourseStage('easy');
+    const nextStage = createCourseStage('medium');
+    const stageListItems = [
+      createStageListItem(currentStage, 1),
+      createStageListItem(completedStage, 2, true), // This stage is completed
+      createStageListItem(nextStage, 3),
+    ];
+    const repository = createRepository(stageListItems);
+
+    const result = computeLeaderboardCTA(leaderboardEntry, rankCalculation, repository, currentStage);
+
+    // Should skip the completed stage and use current (15) + next uncompleted (30) = 45 points
+    assert.strictEqual(result, 'Complete 2 stages to hit #45');
+  });
+
+  test('returns fallback CTA when context is undefined', function (assert) {
+    const leaderboardEntry = createLeaderboardEntry(100);
+    const rankCalculation = createRankCalculation(50, [{ rank: 45, score: 110 }]);
+
+    const result = computeLeaderboardCTA(leaderboardEntry, rankCalculation);
+
+    // Falls back to difficulty-based: 1 easy = 15 points (enough)
+    assert.strictEqual(result, 'Complete 1 easy stage to hit #45');
+  });
+
+  test('returns fallback CTA when only currentCourseStage is provided', function (assert) {
+    const leaderboardEntry = createLeaderboardEntry(100);
+    const rankCalculation = createRankCalculation(50, [{ rank: 45, score: 110 }]);
+    const currentStage = createCourseStage('easy');
+
+    const result = computeLeaderboardCTA(leaderboardEntry, rankCalculation, undefined, currentStage);
+
+    // Falls back to difficulty-based: 1 easy = 15 points (enough)
+    assert.strictEqual(result, 'Complete 1 easy stage to hit #45');
+  });
+
+  test('returns fallback CTA when only repository is provided', function (assert) {
+    const leaderboardEntry = createLeaderboardEntry(100);
+    const rankCalculation = createRankCalculation(50, [{ rank: 45, score: 110 }]);
+    const stageListItems = [createStageListItem(createCourseStage('easy'), 1)];
+    const repository = createRepository(stageListItems);
+
+    const result = computeLeaderboardCTA(leaderboardEntry, rankCalculation, repository);
+
+    // Falls back to difficulty-based: 1 easy = 15 points (enough)
+    assert.strictEqual(result, 'Complete 1 easy stage to hit #45');
   });
 });


### PR DESCRIPTION
Update TrackLeaderboard and related components to pass current course  
stage and repository context to computeLeaderboardCTA. This replaces the  
previous approach of passing nextStagesInContext, simplifying context  
management and improving accuracy of the leaderboard call-to-action  
logic. Remove unused nextStagesInContext computation and ensure the CTA  
reflects the current step and repository state on course pages.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Modernizes CTA computation and wiring for the track leaderboard.
> 
> - TrackLeaderboard: add `@repository` and `@currentCourseStage` args; remove `nextStagesInContext`; `ctaText` now calls `computeLeaderboardCTA(entry, calc, repository, currentCourseStage)`
> - CoursePage RightSidebar: add `currentCourseStageForTrackLeaderboard` getter and pass `@activeRepository`; remove unused `nextStagesInContextForTrackLeaderboard`
> - compute-leaderboard-cta: replace "next stages" input with repository-based stage scanning (uses `stageList`, skips completed, caps at 5), with specific copy for "this stage" vs "next stage"; keeps difficulty-based fallbacks and rank validation
> - Tests: updated and expanded to cover repository/context flows, completed-stage skipping, and fallback behavior
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2ca3f554baed4c4ad3bb83258602075a2e92f48b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->