### PR TITLE
feat(course-page): add dynamic CTA and loading state to leaderboard rank

### DIFF
--- a/app/components/course-page/current-step-complete-modal.hbs
+++ b/app/components/course-page/current-step-complete-modal.hbs
@@ -1,4 +1,4 @@
-<ModalBody @allowManualClose={{false}} @onClose={{@onClose}} data-test-current-step-complete-modal class="max-w-xl" ...attributes>
+<ModalBody @allowManualClose={{false}} @onClose={{@onClose}} data-test-current-step-complete-modal class="w-full max-w-xs" ...attributes>
   <div class="flex flex-col items-center w-full">
     <div class="text-[60px]">
       🎉
@@ -13,7 +13,8 @@
       {{#if this.currentStepAsCourseStageStep.repository.language}}
         <CoursePage::CurrentStepCompleteModal::LanguageLeaderboardRankSection
           @language={{this.currentStepAsCourseStageStep.repository.language}}
-          class="mt-3 mb-3"
+          @shouldShowCTA={{eq this.coursePageState.activeStep this.coursePageState.nextStep}}
+          class="mt-3 mb-3 w-full"
         />
       {{/if}}
     {{else}}

--- a/app/components/course-page/current-step-complete-modal/language-leaderboard-rank-section.hbs
+++ b/app/components/course-page/current-step-complete-modal/language-leaderboard-rank-section.hbs
@@ -4,13 +4,13 @@
   class="w-full p-5 pb-6"
   role="button"
   {{on "click" this.handleClick}}
-  ...attributes
   data-test-language-leaderboard-rank-section
+  ...attributes
 >
   <div class="flex flex-col items-center w-full">
     {{svg-jar "presentation-chart-line" class="w-8 h-8 fill-current text-teal-500/90 mb-2"}}
 
-    <span class="text-teal-700 dark:text-teal-400 text-xs mb-0.5 text-center">
+    <span class="text-teal-700 dark:text-teal-400 text-xs mb-2 text-center">
       Your
       {{@language.name}}
       leaderboard rank is
@@ -18,7 +18,7 @@
 
     <AnimatedContainer>
       <div class="flex items-center w-full justify-center" data-test-rank>
-        {{#animated-if this.refreshRankTask.isRunning use=this.transition duration=300}}
+        {{#animated-if this.isLoadingRank use=this.transition duration=300}}
           <b
             class="text-2xl text-teal-600 dark:text-teal-400 border-b border-teal-600 dark:border-teal-400 group-hover:text-teal-500 border-dashed animate-pulse"
           >
@@ -35,5 +35,17 @@
         {{/animated-if}}
       </div>
     </AnimatedContainer>
+
+    {{#if @shouldShowCTA}}
+      <AnimatedContainer class="w-full mt-4">
+        <div class="flex items-center justify-center">
+          {{#animated-value this.ctaText use=this.transition duration=500 as |ctaText|}}
+            <div class="text-xs text-teal-600 dark:text-teal-400">
+              {{ctaText}}
+            </div>
+          {{/animated-value}}
+        </div>
+      </AnimatedContainer>
+    {{/if}}
   </div>
 </Alert>


### PR DESCRIPTION
Display a loading animation while fetching leaderboard rank and show a
dynamic call-to-action (CTA) message based on the user's progress and
course stage. Update modal size for better layout consistency and adjust
styles for improved spacing and alignment.

These changes enhance user engagement by providing contextual feedback
and encouragement upon completing course steps.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Enhances the completion modal and leaderboard rank section with loading and contextual feedback.
> 
> - Adds loading state `isLoadingRank` and animated CTA text (`ctaText`) driven by `computeLeaderboardCTA`, shown when `@shouldShowCTA` is true
> - Introduces new args on `LanguageLeaderboardRankSection`: `currentCourseStage`, `repository`, and `shouldShowCTA`; rank refresh now uses `refreshRankTask` with staged timeouts and switches template to use `isLoadingRank`
> - UI tweaks: modal width reduced to `max-w-xs`, rank section made `w-full`, and spacing adjustments (e.g., `mb-2`)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit efff2431626f6cc4b37abdb626ce406dd4c872eb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->