### PR TITLE
fix(package.json): add reminder comment on node-fetch upgrade

### DIFF
--- a/vercel-functions/prerender/_prerender-ember-route.func/package.json
+++ b/vercel-functions/prerender/_prerender-ember-route.func/package.json
@@ -3,7 +3,7 @@
   "dependencies": {
     "abortcontroller-polyfill": "^1.7.8",
     "fastboot": "^4.1.5",
-    "node-fetch": "^2.6.12"
+    "node-fetch": "^2.6.12" // When upgrading, make sure /concepts/xyz works on Vercel preview.
   },
   "type": "module"
 }


### PR DESCRIPTION
Include a comment in package.json to remind developers that when
upgrading node-fetch, the /concepts/xyz route must be verified on
Vercel preview. This helps ensure that critical routes function
correctly after dependency updates.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Non-functional change to aid future dependency upgrades.
> 
> - Adds a reminder comment next to `node-fetch` in `vercel-functions/prerender/_prerender-ember-route.func/package.json` to verify `/concepts/xyz` on Vercel preview when upgrading
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a0a35e7f5b2978f903e466dcee4e0d6b29f73784. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->