### PR TITLE
fix(course-page): remove redundant step validation in sidebar

### DIFF
--- a/app/components/course-page/right-sidebar.ts
+++ b/app/components/course-page/right-sidebar.ts
@@ -41,10 +41,6 @@ export default class CoursePageRightSidebar extends Component<Signature> {
       return undefined;
     }
 
-    if (this.coursePageState.currentStep !== this.coursePageState.activeStep) {
-      return undefined;
-    }
-
     return this.coursePageState.currentStepAsCourseStageStep.courseStage;
   }
 


### PR DESCRIPTION
Remove the check that compares currentStep and activeStep in the
right-sidebar component. This validation is unnecessary as it causes
the function to return undefined incorrectly, blocking the course
stage retrieval. The change simplifies the logic and ensures the
correct course stage is returned consistently.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Simplifies course stage resolution in `CoursePageRightSidebar`.
> 
> - In `app/components/course-page/right-sidebar.ts`, removes the `currentStep !== activeStep` guard from `currentCourseStageForTrackLeaderboard`, preventing erroneous `undefined` and ensuring `courseStage` is returned when the current step is a `CourseStageStep`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 47c7f42c94a7e46e453ba045e8cb0968a0e6b968. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->