### PR TITLE
style(components): scope leaderboard link hover styles

### DIFF
--- a/app/components/track-leaderboard.hbs
+++ b/app/components/track-leaderboard.hbs
@@ -3,14 +3,14 @@
     <LinkTo
       @route="leaderboard"
       @model={{@language.slug}}
-      class="group flex items-center gap-1 text-teal-500 dark:text-teal-600 hover:text-teal-600 dark:hover:text-teal-500 transition-colors"
+      class="group/leaderboard-title flex items-center gap-1 text-teal-500 dark:text-teal-600 hover:text-teal-600 dark:hover:text-teal-500 transition-colors"
     >
       <span class="uppercase text-xs font-bold" data-test-leaderboard-title>
         {{@language.name}}
         LEADERBOARD
       </span>
 
-      {{svg-jar "arrow-right" class="-rotate-45 size-3 group-hover:rotate-0 transition-transform ease-out duration-100"}}
+      {{svg-jar "arrow-right" class="-rotate-45 size-3 group-hover/leaderboard-title:rotate-0 transition-transform ease-out duration-100"}}
     </LinkTo>
     <div>
       {{! Add team dropdown if needed }}


### PR DESCRIPTION
Update the leaderboard link in track-leaderboard component to use
a more specific CSS group class for the hover state. Replace the
generic "group" class with "group/leaderboard-title" to prevent
style conflicts and ensure hover effects only apply within the
leaderboard title context. Adjust the related SVG rotation classes
to use the new scoped group selector for consistent transitions.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Scopes hover interactions for the leaderboard title link to prevent bleed into other elements.
> 
> - Replace `group` with `group/leaderboard-title` on the `LinkTo` in `track-leaderboard.hbs`
> - Update SVG rotation class to `group-hover/leaderboard-title:rotate-0` for consistent scoped transitions
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 157b7a16855f879a4a91ff93ff0a9532e42d6d95. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->