### PR TITLE
fix(ui): correct gray color classes in status-pill component

### DIFF
--- a/app/components/settings/billing-page/status-pill.hbs
+++ b/app/components/settings/billing-page/status-pill.hbs
@@ -12,7 +12,7 @@
       {{if (eq @color 'green') 'text-teal-500 dark:text-teal-400'}}
       {{if (eq @color 'red') 'text-red-500 dark:text-red-400'}}
       {{if (eq @color 'yellow') 'text-yellow-500 dark:text-yellow-400'}}
-      {{if (eq @color 'gray') 'text-gray-400 dark:text-gray-500'}}"
+      {{if (eq @color 'gray') 'text-gray-500 dark:text-gray-400'}}"
   >
     {{yield}}
   </div>


### PR DESCRIPTION
Swap the text-gray color classes for the default and dark modes in the
StatusPill component to ensure proper styling. This fixes the issue where
gray color appeared incorrectly inverted between light and dark themes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adjusts gray text styling for the billing StatusPill to render correctly across themes.
> 
> - In `status-pill.hbs`, switches `text-gray-400 dark:text-gray-500` to `text-gray-500 dark:text-gray-400` for the gray variant
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b8f54a02af8d0472d4a01ff299d34ed5c1932213. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->