### PR TITLE
fix(billing-page): remove dark mode color for gray status pill

### DIFF
--- a/app/components/settings/billing-page/status-pill.hbs
+++ b/app/components/settings/billing-page/status-pill.hbs
@@ -12,7 +12,7 @@
       {{if (eq @color 'green') 'text-teal-500 dark:text-teal-400'}}
       {{if (eq @color 'red') 'text-red-500 dark:text-red-400'}}
       {{if (eq @color 'yellow') 'text-yellow-500 dark:text-yellow-400'}}
-      {{if (eq @color 'gray') 'text-gray-400 dark:text-gray-500'}}"
+      {{if (eq @color 'gray') 'text-gray-400'}}"
   >
     {{yield}}
   </div>


### PR DESCRIPTION
Remove the dark mode text color for the gray status pill in the billing
page to improve visual consistency. The gray color is now consistent
across light and dark themes, preventing poor contrast issues in dark
mode.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Aligns the gray status pill text color across themes.
> 
> - In `status-pill.hbs`, removes `dark:text-gray-500` from the gray variant, leaving `text-gray-400` for both light and dark modes
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 91d84d5fdb965edc8ffe3544c8a8c3d20b552578. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->