### PR TITLE
fix(settings): update dark mode divider color for better contrast

### DIFF
--- a/app/components/settings/form-divider.hbs
+++ b/app/components/settings/form-divider.hbs
@@ -1,1 +1,1 @@
-<div class="h-px bg-gray-100 mt-6 mb-6 dark:bg-gray-900"></div>
+<div class="h-px bg-gray-100 mt-6 mb-6 dark:bg-white/5"></div>


### PR DESCRIPTION
Change the divider color in dark mode from a solid gray to a 
semi-transparent white. This improves visibility and maintains 
consistency with the updated dark theme styling.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adjusts the dark theme styling for the settings form divider.
> 
> - In `app/components/settings/form-divider.hbs`, replace `dark:bg-gray-900` with `dark:bg-white/5` to improve visibility and align with updated dark theme
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6bd8637df784a0332fe023a1f160685503c11a92. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->