### PR TITLE
fix(support-section): correct button position in support text

### DIFF
--- a/app/components/settings/billing-page/support-section.hbs
+++ b/app/components/settings/billing-page/support-section.hbs
@@ -1,7 +1,7 @@
 <Settings::FormSection @title="Support" @description="How to get help with billing" data-test-support-section>
   <div class="prose prose-sm prose-compact dark:prose-invert">
     <p>
-      Questions? Click the button above or write to us at
+      Questions? Click the button below or write to us at
       <a href="mailto:hello@codecrafters.io?subject=Billing help (account: {{@user.username}})">hello@codecrafters.io</a>
       and we'll help sort things out.
     </p>


### PR DESCRIPTION
Update the support section text to refer to the button below
instead of above, improving accuracy and clarity for users seeking
billing help.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adjusts support copy to reflect correct button placement.
> 
> - In `app/components/settings/billing-page/support-section.hbs`, changes phrasing from "button above" to "button below" to match the UI
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6ecc516f9fd55465bcd1dac9b603697fe5ed8a8b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->