### PR TITLE
feat(pay-page): add customizable close modal CTA to plan modal

### DIFF
--- a/app/components/pay-page/choose-membership-plan-modal.hbs
+++ b/app/components/pay-page/choose-membership-plan-modal.hbs
@@ -19,7 +19,8 @@
     {{#animated-if (eq this.currentStep "plan-selection") use=this.transition duration=200}}
       <PayPage::ChooseMembershipPlanModal::PlanSelectionStep
         @activeDiscountForYearlyPlan={{@activeDiscountForYearlyPlan}}
-        @onBackToPricingPageLinkClick={{@onClose}}
+        @closeModalCTAText={{@closeModalCTAText}}
+        @onCloseModalCTAClick={{@onClose}}
         @onChoosePlanButtonClick={{this.handleContinueButtonClick}}
         @onPlanSelect={{this.handlePlanSelect}}
         @pricingPlans={{this.pricingPlans}}

--- a/app/components/pay-page/choose-membership-plan-modal.ts
+++ b/app/components/pay-page/choose-membership-plan-modal.ts
@@ -1,14 +1,14 @@
-import Component from '@glimmer/component';
-import { action } from '@ember/object';
-import { tracked } from '@glimmer/tracking';
-import fade from 'ember-animated/transitions/fade';
-import { service } from '@ember/service';
-import Store from '@ember-data/store';
-import window from 'ember-window-mock';
 import * as Sentry from '@sentry/ember';
-import type RegionalDiscountModel from 'codecrafters-frontend/models/regional-discount';
-import type PromotionalDiscountModel from 'codecrafters-frontend/models/promotional-discount';
+import Component from '@glimmer/component';
+import Store from '@ember-data/store';
+import fade from 'ember-animated/transitions/fade';
 import type AuthenticatorService from 'codecrafters-frontend/services/authenticator';
+import type PromotionalDiscountModel from 'codecrafters-frontend/models/promotional-discount';
+import type RegionalDiscountModel from 'codecrafters-frontend/models/regional-discount';
+import window from 'ember-window-mock';
+import { action } from '@ember/object';
+import { service } from '@ember/service';
+import { tracked } from '@glimmer/tracking';
 
 export interface PricingPlan {
   id: 'v1-3mo' | 'v1-1yr' | 'v1-lifetime';
@@ -29,6 +29,9 @@ interface Signature {
 
   Args: {
     activeDiscountForYearlyPlan: PromotionalDiscountModel | null;
+    checkoutSessionCancelPath: string;
+    checkoutSessionSuccessPath: string;
+    closeModalCTAText: string;
     onClose: () => void;
     regionalDiscount: RegionalDiscountModel | null;
   };
@@ -89,12 +92,12 @@ export default class ChooseMembershipPlanModal extends Component<Signature> {
     this.isCreatingCheckoutSession = true;
 
     const checkoutSession = this.store.createRecord('individual-checkout-session', {
-      cancelUrl: `${window.location.origin}/pay`,
+      cancelUrl: window.location.origin + this.args.checkoutSessionCancelPath,
       extraInvoiceDetailsRequested: this.extraInvoiceDetailsRequested,
       pricingPlanId: this.selectedPlanId,
       promotionalDiscount: this.selectedPlanId === 'v1-1yr' ? this.args.activeDiscountForYearlyPlan : null,
       regionalDiscount: this.args.regionalDiscount || null,
-      successUrl: `${window.location.origin}/catalog`,
+      successUrl: window.location.origin + this.args.checkoutSessionSuccessPath,
     });
 
     await checkoutSession.save();

--- a/app/components/pay-page/choose-membership-plan-modal/plan-selection-step.hbs
+++ b/app/components/pay-page/choose-membership-plan-modal/plan-selection-step.hbs
@@ -20,11 +20,11 @@
   <div class="flex justify-center mt-4">
     <div
       class="inline-block text-gray-500 dark:text-gray-400 text-sm border-b border-gray-300 dark:border-gray-700 cursor-pointer"
-      data-test-back-to-pricing-page-link
+      data-test-close-modal-cta
       role="button"
-      {{on "click" @onBackToPricingPageLinkClick}}
+      {{on "click" @onCloseModalCTAClick}}
     >
-      Back to pricing page
+      {{@closeModalCTAText}}
     </div>
   </div>
 </div>

--- a/app/components/pay-page/choose-membership-plan-modal/plan-selection-step.ts
+++ b/app/components/pay-page/choose-membership-plan-modal/plan-selection-step.ts
@@ -8,7 +8,8 @@ interface Signature {
 
   Args: {
     activeDiscountForYearlyPlan: PromotionalDiscountModel | null;
-    onBackToPricingPageLinkClick: () => void;
+    closeModalCTAText: string;
+    onCloseModalCTAClick: () => void;
     onChoosePlanButtonClick: () => void;
     onPlanSelect: (plan: PricingPlan) => void;
     pricingPlans: PricingPlan[];

--- a/app/templates/pay.hbs
+++ b/app/templates/pay.hbs
@@ -106,8 +106,11 @@
 {{#if (eq this.chooseMembershipPlanModalIsOpen "true")}}
   <ModalBackdrop>
     <PayPage::ChooseMembershipPlanModal
-      @onClose={{this.handleChooseMembershipPlanModalClose}}
       @activeDiscountForYearlyPlan={{this.activeDiscountForYearlyPlan}}
+      @checkoutSessionCancelPath="/pay"
+      @checkoutSessionSuccessPath="/settings/billing"
+      @closeModalCTAText="Back to pricing page"
+      @onClose={{this.handleChooseMembershipPlanModalClose}}
       @regionalDiscount={{this.regionalDiscount}}
     />
   </ModalBackdrop>

--- a/tests/acceptance/pay-test.js
+++ b/tests/acceptance/pay-test.js
@@ -283,7 +283,7 @@ module('Acceptance | pay-test', function (hooks) {
     assert.true(payPage.chooseMembershipPlanModal.isVisible, 'membership plan modal is visible');
     assert.strictEqual(currentURL(), '/pay?plans=true');
 
-    await payPage.chooseMembershipPlanModal.clickOnBackToPricingPageLink();
+    await payPage.chooseMembershipPlanModal.clickOnCloseModalCTA();
 
     assert.false(payPage.chooseMembershipPlanModal.isVisible, 'membership plan modal is not visible after closing');
     assert.strictEqual(currentURL(), '/pay', 'plans query param is removed from URL');

--- a/tests/pages/components/choose-membership-plan-modal.ts
+++ b/tests/pages/components/choose-membership-plan-modal.ts
@@ -1,12 +1,12 @@
 import { clickable, collection, isVisible, text } from 'ember-cli-page-object';
 
 export default {
-  scope: '[data-test-choose-membership-plan-modal]',
-  clickOnBackToPricingPageLink: clickable('[data-test-back-to-pricing-page-link]'),
   clickOnChoosePlanButton: clickable('[data-test-choose-plan-button]'),
+  clickOnCloseModalCTA: clickable('[data-test-close-modal-cta]'),
   clickOnExtraInvoiceDetailsToggle: clickable('[data-test-extra-invoice-details-toggle]'),
   clickOnProceedToCheckoutButton: clickable('[data-test-proceed-to-checkout-button]'),
   isVisible: isVisible(),
+
   planCards: collection('[data-test-plan-card]', {
     discountedPriceText: text('[data-test-discounted-price]'),
 
@@ -18,4 +18,6 @@ export default {
       scope: '[data-test-regional-discount-notice]',
     },
   }),
+
+  scope: '[data-test-choose-membership-plan-modal]',
 };


### PR DESCRIPTION
Replace back-to-pricing-page link with a configurable close modal
call-to-action button in the membership plan selection step. Update
checkout session URLs to use dynamic success and cancel paths. Improve
test coverage to reflect these UI changes.

These updates enhance flexibility for modal actions and support
dynamic navigation flows after checkout.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> - **Customizable close action in plan modal:** Replaces the "Back to pricing page" link with a configurable CTA in `PlanSelectionStep` via `closeModalCTAText` and `onCloseModalCTAClick`; updates data-test selector.
> - **Dynamic checkout URLs:** `ChooseMembershipPlanModal` now accepts `checkoutSessionCancelPath` and `checkoutSessionSuccessPath` to construct `cancelUrl`/`successUrl` for checkout sessions; wired in `pay.hbs`.
> - **Tests updated:** Acceptance tests and page object switched to the new CTA selector and continue validating URL query param removal and checkout session creation.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 056886741062dd16e13352f6c2ba3052f711d091. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->