### PR TITLE
update(COPYRIGHT): extend copyright year to 2026 in LICENSE and footer

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -6,7 +6,7 @@ FSL-1.1-MIT
 
 ## Notice
 
-Copyright 2021-2025 CodeCrafters, Inc.
+Copyright 2021-2026 CodeCrafters, Inc.
 
 ## Terms and Conditions
 

--- a/app/components/footer.hbs
+++ b/app/components/footer.hbs
@@ -57,7 +57,7 @@
       </div>
       <div class="mt-12 border-t border-white/5 pt-8">
         <p class="text-base text-gray-600 xl:text-center">
-          &copy; 2025 CodeCrafters, Inc. All rights reserved.
+          &copy; 2026 CodeCrafters, Inc. All rights reserved.
         </p>
       </div>
     </div>


### PR DESCRIPTION
**Checklist**:

- [x] I've thoroughly self-reviewed my changes
- [ ] I've added tests for my changes, unless they affect admin-only areas (or are otherwise not worth testing)
- [ ] I've verified any visual changes using Percy (add a commit with `[percy]` in the message to trigger)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates legal notices to reflect the current year.
> 
> - Bumps copyright range in `LICENSE.md` to `2021–2026`
> - Updates footer text in `app/components/footer.hbs` to `© 2026 CodeCrafters, Inc.`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 42e5e487acb349059b067223332580edf29e2342. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->