### PR TITLE
chore(cursor): simplify Dockerfile to use base image only

### DIFF
--- a/.cursor/Dockerfile
+++ b/.cursor/Dockerfile
@@ -1,10 +1,1 @@
 FROM oven/bun:1.3.5
-
-WORKDIR /app
-
-# Install dependencies
-COPY package.json bun.lock ./
-RUN bun install
-
-# Add the rest of the application
-COPY . .


### PR DESCRIPTION
Remove all setup steps including working directory, dependency
installation, and file copying. Rely solely on the oven/bun:1.3.5
base image for the environment, reducing build complexity and time.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Simplifies the `.cursor/Dockerfile` to rely solely on the base image.
> 
> - Replace contents with only `FROM oven/bun:1.3.5`
> - Remove setup steps: `WORKDIR /app`, copying `package.json`/`bun.lock`, running `bun install`, and `COPY . .`
> - Relies on the base image for environment, reducing build complexity and time
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d3cbf86413c713cc3c3a9029df5e825cca53380b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->