### PR TITLE
chore: add Docker and development environment config

### DIFF
--- a/.cursor/Dockerfile
+++ b/.cursor/Dockerfile
@@ -1,0 +1,10 @@
+FROM oven/bun:1.3.5
+
+# Create a non-root user
+RUN useradd -m -s /bin/bash developer
+
+# Switch to the non-root user
+USER developer
+
+# Set working directory to the user's home
+WORKDIR /home/developer

--- a/.cursor/environment.json
+++ b/.cursor/environment.json
@@ -1,0 +1,13 @@
+{
+  "build": {
+    "context": ".",
+    "dockerfile": "Dockerfile"
+  },
+  "install": "bun install",
+  "terminals": [
+    {
+      "name": "make serve",
+      "command": "make serve"
+    }
+  ]
+}


### PR DESCRIPTION
Add a Dockerfile based on oven/bun to run as a non-root user for
security. Add .cursor/environment.json to define build context,
installation command, and a terminal shortcut for easier local
development setup and serving.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Sets up a lightweight local dev container and Cursor environment configuration.
> 
> - Adds `.cursor/Dockerfile` based on `oven/bun:1.3.5`, creates non-root `developer` user, and sets `WORKDIR` to `/home/developer`
> - Adds `.cursor/environment.json` to define Docker build context (`.`) and `dockerfile` (`Dockerfile`), sets install command to `bun install`, and provides a terminal shortcut for `make serve`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8ad6730e5954bff8a09bad562cae6e45c9987d16. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->