### PR TITLE
chore(env): add environment config for bun install and serve

### DIFF
--- a/.cursor/environment.json
+++ b/.cursor/environment.json
@@ -1,0 +1,9 @@
+{
+  "install": "bun install",
+  "terminals": [
+    {
+      "name": "make serve",
+      "command": "make serve"
+    }
+  ]
+}


### PR DESCRIPTION
Add a .cursor/environment.json file to automate project setup and  
development workflow. The config runs `bun install` for dependencies  
and defines a terminal named "make serve" to start the development  
server. This streamlines the onboarding process and standardizes  
commands across environments.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds project environment config for streamlined setup.
> 
> - New `.cursor/environment.json` defining `install: "bun install"`
> - Preconfigures a terminal entry named `make serve` that runs `make serve`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7dcc28567a8cd0f035f116717c74957b349481d8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->