### PR TITLE
refactor: import StepListDefinition only as a type

### DIFF
--- a/app/components/course-page/header/main-section.ts
+++ b/app/components/course-page/header/main-section.ts
@@ -2,7 +2,7 @@ import Component from '@glimmer/component';
 import CourseModel from 'codecrafters-frontend/models/course';
 import RepositoryModel from 'codecrafters-frontend/models/repository';
 import StepDefinition from 'codecrafters-frontend/utils/course-page-step-list/step';
-import { StepListDefinition } from 'codecrafters-frontend/utils/course-page-step-list';
+import type { StepListDefinition } from 'codecrafters-frontend/utils/course-page-step-list';
 import type CourseStageStep from 'codecrafters-frontend/utils/course-page-step-list/course-stage-step';
 
 interface Signature {

--- a/app/components/course-page/header/sticky-section.ts
+++ b/app/components/course-page/header/sticky-section.ts
@@ -1,10 +1,10 @@
 import Component from '@glimmer/component';
 import CourseModel from 'codecrafters-frontend/models/course';
-import StepDefinition from 'codecrafters-frontend/utils/course-page-step-list/step';
-import { action } from '@ember/object';
-import { StepListDefinition } from 'codecrafters-frontend/utils/course-page-step-list';
-import { tracked } from '@glimmer/tracking';
 import CourseStageStep from 'codecrafters-frontend/utils/course-page-step-list/course-stage-step';
+import StepDefinition from 'codecrafters-frontend/utils/course-page-step-list/step';
+import type { StepListDefinition } from 'codecrafters-frontend/utils/course-page-step-list';
+import { action } from '@ember/object';
+import { tracked } from '@glimmer/tracking';
 
 interface Signature {
   Element: HTMLDivElement;

--- a/app/components/course-page/header/tab-list.ts
+++ b/app/components/course-page/header/tab-list.ts
@@ -2,7 +2,7 @@ import Component from '@glimmer/component';
 import CourseModel from 'codecrafters-frontend/models/course';
 import RouterService from '@ember/routing/router-service';
 import StepDefinition from 'codecrafters-frontend/utils/course-page-step-list/step';
-import { StepListDefinition } from 'codecrafters-frontend/utils/course-page-step-list';
+import type { StepListDefinition } from 'codecrafters-frontend/utils/course-page-step-list';
 import { service } from '@ember/service';
 
 interface Signature {

--- a/app/components/course-page/header/top-right-section.ts
+++ b/app/components/course-page/header/top-right-section.ts
@@ -3,7 +3,7 @@ import CourseModel from 'codecrafters-frontend/models/course';
 import RepositoryModel from 'codecrafters-frontend/models/repository';
 import RouterService from '@ember/routing/router-service';
 import StepDefinition from 'codecrafters-frontend/utils/course-page-step-list/step';
-import { StepListDefinition } from 'codecrafters-frontend/utils/course-page-step-list';
+import type { StepListDefinition } from 'codecrafters-frontend/utils/course-page-step-list';
 import { service } from '@ember/service';
 import { action } from '@ember/object';
 import CourseStageStep from 'codecrafters-frontend/utils/course-page-step-list/course-stage-step';

--- a/app/components/course-page/sidebar/index.ts
+++ b/app/components/course-page/sidebar/index.ts
@@ -3,7 +3,7 @@ import CourseModel from 'codecrafters-frontend/models/course';
 import CoursePageStateService from 'codecrafters-frontend/services/course-page-state';
 import MonthlyChallengeBannerService from 'codecrafters-frontend/services/monthly-challenge-banner';
 import RepositoryModel from 'codecrafters-frontend/models/repository';
-import { StepListDefinition } from 'codecrafters-frontend/utils/course-page-step-list';
+import type { StepListDefinition } from 'codecrafters-frontend/utils/course-page-step-list';
 import { action } from '@ember/object';
 import { service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';

--- a/app/components/course-page/step-list.ts
+++ b/app/components/course-page/step-list.ts
@@ -2,7 +2,7 @@ import Component from '@glimmer/component';
 import CourseModel from 'codecrafters-frontend/models/course';
 import CoursePageStateService from 'codecrafters-frontend/services/course-page-state';
 import RepositoryModel from 'codecrafters-frontend/models/repository';
-import { StepListDefinition } from 'codecrafters-frontend/utils/course-page-step-list';
+import type { StepListDefinition } from 'codecrafters-frontend/utils/course-page-step-list';
 import { service } from '@ember/service';
 
 interface Signature {


### PR DESCRIPTION
Convert all imports of StepListDefinition to type-only imports across
multiple course-page components. This improves type clarity and 
potentially reduces runtime import overhead by indicating these are 
used solely for TypeScript type checking.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Switches `StepListDefinition` to type-only imports in course-page components to clarify types and avoid runtime imports.
> 
> - Update `header/main-section.ts`, `header/sticky-section.ts`, `header/tab-list.ts`, `header/top-right-section.ts`, `sidebar/index.ts`, and `step-list.ts` to `import type { StepListDefinition } ...`
> - Minor import ordering cleanups; no logic or UI changes
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 017332f6eb23779563a6d83e1436f3b602c7b7b3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->