### PR TITLE
fix(ui): improve clarity of workflow tutorial step 1 text

### DIFF
--- a/app/components/course-page/setup-step-complete-modal/workflow-tutorial-step1-screen.hbs
+++ b/app/components/course-page/setup-step-complete-modal/workflow-tutorial-step1-screen.hbs
@@ -5,12 +5,12 @@
 
   <div class="px-3 sm:px-6 py-6 bg-gray-50 dark:bg-gray-925 rounded-sm border border-gray-200 dark:border-gray-700 mb-6">
     <div class="mb-4 font-bold text-lg text-gray-700 dark:text-gray-100 text-center text-pretty">
-      Work in your Git repo
+      Write code in your repo
     </div>
 
     <div class="prose prose-sm dark:prose-invert mb-4 text-center text-pretty">
       <p>
-        You'll work out of the Git repository that you cloned in the last step.
+        The Git repository you cloned in the last step is where you will make all your changes.
       </p>
     </div>
 
@@ -24,7 +24,7 @@
       <p>
         It contains some basic
         {{@step.repository.language.name}}
-        code.
+        code to get you started.
       </p>
     </div>
   </div>


### PR DESCRIPTION
Update text in the workflow tutorial step 1 screen to provide clearer
instructions. Change the heading to "Write code in your repo" for a more
active tone. Revise the descriptive paragraph to specify that all changes
should be made in the cloned Git repository. Slightly enhance the wording
about the example code to emphasize it is a starting point. These changes
aim to improve user understanding during the setup process.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Improves clarity of the workflow tutorial step 1 screen copy.
> 
> - Changes heading to `Write code in your repo`
> - Revises description to state all changes should be made in the cloned Git repository
> - Tweaks language example note to say the starter `{{@step.repository.language.name}}` code is "to get you started"
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fe18c10ad13f508a80d09266b92c907fa88e4e57. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->