### PR TITLE
fix(tailwind): add bottom margin to prose unordered lists

### DIFF
--- a/app/tailwind.config.js
+++ b/app/tailwind.config.js
@@ -345,6 +345,7 @@ module.exports = {
             },
             '.prose :where(ul):not(:where([class~="not-prose"],[class~="not-prose"] *))': {
               marginTop: '0.6em',
+              marginBottom: '0.6em',
             },
             '.prose :where(li):not(:where([class~="not-prose"],[class~="not-prose"] *))': {
               marginTop: '0.3em',


### PR DESCRIPTION
Add margin-bottom of 0.6em to unordered lists within prose content
to improve vertical spacing. This change ensures consistent spacing
above and below lists for better readability.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Improves list spacing in prose content.
> 
> - In `app/tailwind.config.js`, the `typography.compact` variant now sets `margin-bottom: 0.6em` on `'.prose :where(ul)'` to match top spacing
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7bd2dab449b17f3454891b64bfdceb97bb9d92e7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->