### PR TITLE
Remove unused properties and methods from create-repository-card component.

### DIFF
--- a/tests/pages/components/course-page/create-repository-card.js
+++ b/tests/pages/components/course-page/create-repository-card.js
@@ -8,11 +8,9 @@ export default {
   clickOnOptionButton: clickOnText('button'),
   clickOnRequestLanguageButton: clickable('.ember-basic-dropdown-trigger'),
   continueButton: { scope: '[data-test-continue-button]' },
-  copyableCloneRepositoryInstructions: text('[data-test-copyable-repository-clone-instructions] .font-mono'),
-  description: text('[data-test-course-description]'),
   expandedSectionTitle: text('[data-test-expanded-section-title]'),
-  footerText: text('[data-test-footer]'),
   hasRequestedLanguagesPrompt: isVisible('[data-test-requested-languages-prompt]'),
+
   languageButtons: collection('[data-test-language-button]', {
     text: text('[data-test-language-button-text]'),
   }),
@@ -25,14 +23,4 @@ export default {
   requestLanguageDropdown: requestLanguageDropdown,
   scope: '[data-test-create-repository-card]',
   showOtherLanguagesButton: { scope: '[data-test-show-other-languages-button]' },
-
-  get statusIsInProgress() {
-    return this.statusText === 'In-progress';
-  },
-
-  get statusIsComplete() {
-    return this.statusText === 'Completed';
-  },
-
-  statusText: text('[data-test-status-text]'),
 };


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Cleans up the `tests/pages/components/course-page/create-repository-card.js` page object by removing unused properties without altering existing interactions.
> 
> - Deleted `copyableCloneRepositoryInstructions`, `description`, `footerText`, `statusText`, and computed status helpers (`statusIsInProgress`, `statusIsComplete`)
> - Retains existing click actions, visibility checks, language button collection, and dropdown helpers
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 012d14789ca7d247fbe1594bc8d1f888c450eec2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->