### PR TITLE
refactor: rename startDate to startedAt across models and factories

### DIFF
--- a/app/models/subscription.ts
+++ b/app/models/subscription.ts
@@ -5,7 +5,7 @@ import type InstitutionMembershipGrantModel from './institution-membership-grant
 export default class SubscriptionModel extends Model {
   @attr('date') declare cancelAt: Date;
   @attr('date') declare endedAt: Date | null;
-  @attr('date') declare startDate: Date;
+  @attr('date') declare startedAt: Date;
 
   // TODO(CC-1888): Add other sources
   @belongsTo('subscription-source', { async: false, inverse: null, polymorphic: true }) declare source: InstitutionMembershipGrantModel;

--- a/app/models/team-subscription.ts
+++ b/app/models/team-subscription.ts
@@ -4,7 +4,7 @@ import type TeamModel from './team';
 export default class TeamSubscriptionModel extends Model {
   @belongsTo('team', { async: false, inverse: 'subscriptions' }) declare team: TeamModel;
   @attr('date') declare endedAt: Date | null;
-  @attr('date') declare startDate: Date;
+  @attr('date') declare startedAt: Date;
 
   get isActive() {
     return !this.endedAt && !this.isNew;

--- a/app/models/team.ts
+++ b/app/models/team.ts
@@ -34,7 +34,7 @@ export default class TeamModel extends Model {
 
   get activeSubscription() {
     return this.subscriptions
-      .toSorted(fieldComparator('startDate'))
+      .toSorted(fieldComparator('startedAt'))
       .reverse()
       .find((item) => item.isActive);
   }

--- a/app/models/user.ts
+++ b/app/models/user.ts
@@ -104,7 +104,7 @@ export default class UserModel extends Model {
 
   get activeSubscription() {
     return this.subscriptions
-      .toSorted(fieldComparator('startDate'))
+      .toSorted(fieldComparator('startedAt'))
       .reverse()
       .find((item) => item.isActive);
   }
@@ -141,7 +141,7 @@ export default class UserModel extends Model {
       return null;
     } else {
       return this.subscriptions
-        .toSorted(fieldComparator('startDate'))
+        .toSorted(fieldComparator('startedAt'))
         .reverse()
         .find((item) => item.isInactive);
     }

--- a/mirage/factories/subscription.js
+++ b/mirage/factories/subscription.js
@@ -1,5 +1,5 @@
 import { Factory } from 'miragejs';
 
 export default Factory.extend({
-  startDate: () => new Date(),
+  startedAt: () => new Date(),
 });

--- a/mirage/handlers/membership-gifts.js
+++ b/mirage/handlers/membership-gifts.js
@@ -44,7 +44,7 @@ export default function (server) {
     schema.subscriptions.create({
       user: schema.users.find(CurrentMirageUser.currentUserId),
       source: membershipGift,
-      startDate: membershipGift.redeemedAt.toISOString(),
+      startedAt: membershipGift.redeemedAt.toISOString(),
       cancelAt: new Date(membershipGift.redeemedAt.getTime() + membershipGift.validityInDays * 24 * 60 * 60 * 1000).toISOString(),
     });
 


### PR DESCRIPTION
Update the subscription-related attributes and sorting keys from
startDate to startedAt in Team, User, Subscription, and TeamSubscription
models, as well as in Mirage factory and handlers. This change improves
consistency and clarity in date naming conventions and aligns with the
source data naming.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Standardizes start-date naming for subscriptions.
> 
> - Rename `startDate` to `startedAt` in `Subscription`, `TeamSubscription` models and Mirage `subscription` factory/`membership-gifts` handler
> - Update sorting keys in `Team` and `User` to use `startedAt` for determining active/expired subscriptions
> - No behavioral changes beyond field rename and corresponding references
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bceb662fe0cc445ba8d8c4d97fb4ea3f791ebac2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->