### PR TITLE
refactor(tests): remove redundant isVisible checks in page objects

### DIFF
--- a/tests/pages/components/choose-membership-plan-modal.ts
+++ b/tests/pages/components/choose-membership-plan-modal.ts
@@ -1,11 +1,10 @@
-import { clickable, collection, isVisible, text } from 'ember-cli-page-object';
+import { clickable, collection, text } from 'ember-cli-page-object';
 
 export default {
   clickOnChoosePlanButton: clickable('[data-test-choose-plan-button]'),
   clickOnCloseModalCTA: clickable('[data-test-close-modal-cta]'),
   clickOnExtraInvoiceDetailsToggle: clickable('[data-test-extra-invoice-details-toggle]'),
   clickOnProceedToCheckoutButton: clickable('[data-test-proceed-to-checkout-button]'),
-  isVisible: isVisible(),
 
   planCards: collection('[data-test-plan-card]', {
     discountedPriceText: text('[data-test-discounted-price]'),

--- a/tests/pages/components/course-page/setup-step-complete-modal.ts
+++ b/tests/pages/components/course-page/setup-step-complete-modal.ts
@@ -1,7 +1,6 @@
-import { clickable, isVisible } from 'ember-cli-page-object';
+import { clickable } from 'ember-cli-page-object';
 
 export default {
   clickOnNextButton: clickable('[data-test-next-button]'),
-  isVisible: isVisible(),
   scope: '[data-test-setup-step-complete-modal]',
 };

--- a/tests/pages/concept-page.js
+++ b/tests/pages/concept-page.js
@@ -20,7 +20,6 @@ export default createPage({
 
   conceptCompletedModal: {
     clickOnSignInButton: clickable('[data-test-concept-completed-modal-sign-in-button]'),
-    isVisible: isPresent(),
     scope: '[data-test-concept-completed-modal]',
     text: text(),
   },


### PR DESCRIPTION
Remove unnecessary isVisible and isPresent properties from several
page object definitions in the tests. These properties were not used 
and removing them simplifies the test code, making it cleaner and 
easier to maintain without affecting test functionality.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Cleans up test page objects by removing unused visibility checks to simplify and declutter tests.
> 
> - Removed `isVisible`/`isPresent` properties from `choose-membership-plan-modal`, `setup-step-complete-modal`, and `concept-page` (e.g., `conceptCompletedModal`)
> - Dropped corresponding `isVisible` imports where unused; no behavioral/test flow changes
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0aa7f61ad041f97552600dcc31c7404335374e53. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->