### PR TITLE
Add rollover validity message to membership section and update subscription model.

### DIFF
--- a/app/components/settings/billing-page/membership-section.hbs
+++ b/app/components/settings/billing-page/membership-section.hbs
@@ -30,6 +30,12 @@
           <p>
             You have access to all CodeCrafters content, valid until
             <strong>{{date-format @user.activeSubscription.cancelAt format="PPPp"}}</strong>.
+            {{#if @user.activeSubscription.hasRolloverValidity}}
+              This includes
+              {{@user.activeSubscription.rolloverValidityInDays}}
+              {{pluralize "day" count=@user.activeSubscription.rolloverValidityInDays}}
+              rolled over from a previous membership.
+            {{/if}}
           </p>
         {{/if}}
       </div>

--- a/app/models/subscription.ts
+++ b/app/models/subscription.ts
@@ -3,13 +3,19 @@ import type UserModel from 'codecrafters-frontend/models/user';
 import type InstitutionMembershipGrantModel from './institution-membership-grant';
 
 export default class SubscriptionModel extends Model {
+  @attr('number') declare baseValidityInDays: number;
   @attr('date') declare cancelAt: Date;
   @attr('date') declare endedAt: Date | null;
+  @attr('number') declare rolloverValidityInDays: number;
   @attr('date') declare startedAt: Date;
 
   // TODO(CC-1888): Add other sources
   @belongsTo('subscription-source', { async: false, inverse: null, polymorphic: true }) declare source: InstitutionMembershipGrantModel;
   @belongsTo('user', { async: false, inverse: 'subscriptions' }) declare user: UserModel;
+
+  get hasRolloverValidity(): boolean {
+    return this.rolloverValidityInDays > 0;
+  }
 
   get isActive() {
     return !this.endedAt && !this.isNew;

--- a/mirage/factories/subscription.js
+++ b/mirage/factories/subscription.js
@@ -1,5 +1,7 @@
 import { Factory } from 'miragejs';
 
 export default Factory.extend({
+  baseValidityInDays: 30,
+  rolloverValidityInDays: 0,
   startedAt: () => new Date(),
 });

--- a/tests/acceptance/settings-page/billing-test.js
+++ b/tests/acceptance/settings-page/billing-test.js
@@ -35,6 +35,25 @@ module('Acceptance | settings-page | billing-test', function (hooks) {
     await percySnapshot('Billing Page - Active Subscription');
   });
 
+  test('membership section shows rollover days when subscription has rollover validity', async function (assert) {
+    testScenario(this.server);
+    signInAsSubscriber(this.owner, this.server);
+    const subscription = this.server.schema.subscriptions.first();
+    subscription.update('cancelAt', new Date('2035-07-31T01:00:00Z'));
+    subscription.update('rolloverValidityInDays', 15);
+
+    await billingPage.visit();
+
+    assert.ok(billingPage.membershipSection.isVisible, 'membership section is visible');
+    assert.ok(billingPage.membershipSection.text.includes('Membership active'), 'shows active plan');
+    assert.ok(
+      billingPage.membershipSection.text.includes('This includes 15 days rolled over from a previous membership'),
+      'shows rollover days message',
+    );
+
+    await percySnapshot('Billing Page - Active Subscription with Rollover Days');
+  });
+
   test('membership section shows correct plan for subscriber with institution membership', async function (assert) {
     testScenario(this.server);
     createInstitution(this.server, 'nus');


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds rollover visibility to membership UI and supporting data.
> 
> - Update `membership-section.hbs` to conditionally show `rolloverValidityInDays` when `hasRolloverValidity`
> - Extend `SubscriptionModel` with `baseValidityInDays`, `rolloverValidityInDays`, and `hasRolloverValidity` getter
> - Set Mirage factory defaults for new fields in `subscription.js`
> - Add acceptance test asserting rollover message and keep existing billing scenarios passing
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c78f96d542c557d01b6b6d1dcbd83988dca02d78. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->