### PR TITLE
docs(cursor): add boolean variable naming conventions

### DIFF
--- a/.cursor/rules/naming-conventions.mdc
+++ b/.cursor/rules/naming-conventions.mdc
@@ -1,0 +1,19 @@
+---
+alwaysApply: true
+---
+# Naming Conventions
+
+## Boolean Variables
+
+Boolean variables and properties should use descriptive prefixes that indicate their boolean nature:
+
+- `is` - current state (e.g., `isLoading`, `isVisible`, `isAuthenticated`)
+- `was` - past state (e.g., `wasClicked`, `wasSubmitted`)
+- `should` - conditional/intended behavior (e.g., `shouldShowNotice`, `shouldRefresh`)
+- `has` - possession/existence (e.g., `hasErrors`, `hasSubscription`)
+- `can` - capability/permission (e.g., `canEdit`, `canAccessPaidContent`)
+
+Bad examples:
+- `loading` (use `isLoading`)
+- `showNotice` (use `shouldShowNotice`)
+- `visible` (use `isVisible`)


### PR DESCRIPTION
Introduce a new naming conventions document specifying prefixes for boolean
variables to improve code readability and maintainability. The guidelines
cover prefixes like is, was, should, has, and can, with examples and bad
cases, ensuring consistent and descriptive boolean variable names across
the codebase.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a new `.cursor/rules/naming-conventions.mdc` document defining boolean variable naming conventions.
> 
> - Introduces prefixes `is`, `was`, `should`, `has`, `can` with examples for clarity and consistency
> - Includes “bad examples” to discourage ambiguous names (e.g., `loading`, `visible`)
> - Rule marked `alwaysApply: true` to enforce across the codebase
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9f8d76dc893f2deee17b1753f4716abe2fb05743. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->