### PR TITLE
feat(alert): add dismissable alerts with dismiss button support

### DIFF
--- a/app/components/alert-with-icon.hbs
+++ b/app/components/alert-with-icon.hbs
@@ -1,4 +1,4 @@
-<Alert @color={{this.color}} ...attributes>
+<Alert @color={{this.color}} @isDismissable={{@isDismissable}} @onDismiss={{@onDismiss}} ...attributes>
   <div class="flex">
     <div class="mr-3 mt-0.5">
       {{svg-jar this.icon class=(concat "w-6 fill-current " this.iconColorClasses)}}

--- a/app/components/alert-with-icon.ts
+++ b/app/components/alert-with-icon.ts
@@ -6,6 +6,8 @@ interface Signature {
   Args: {
     type?: 'success' | 'info' | 'error' | 'warning';
     icon?: string;
+    isDismissable?: boolean;
+    onDismiss?: () => void;
   };
 
   Blocks: {

--- a/app/components/alert.hbs
+++ b/app/components/alert.hbs
@@ -7,5 +7,20 @@
     "
   ...attributes
 >
-  {{yield}}
+  <div class="flex-1">
+    {{yield}}
+  </div>
+
+  {{#if @isDismissable}}
+    <div class="flex items-center justify-center ml-3">
+      <button
+        class="border p-1 rounded-sm {{this.dismissButtonColorClasses}}"
+        type="button"
+        {{on "click" this.handleDismissButtonClick}}
+        data-test-dismiss-button
+      >
+        {{svg-jar "x" class="w-5 h-5 fill-current"}}
+      </button>
+    </div>
+  {{/if}}
 </div>

--- a/app/components/alert.ts
+++ b/app/components/alert.ts
@@ -1,3 +1,5 @@
+import { action } from '@ember/object';
+import type Owner from '@ember/owner';
 import Component from '@glimmer/component';
 
 interface Signature {
@@ -7,6 +9,8 @@ interface Signature {
     color: 'blue' | 'green' | 'red' | 'teal' | 'yellow';
     size?: 'regular' | 'large';
     isInteractive?: boolean;
+    isDismissable?: boolean;
+    onDismiss?: () => void;
   };
 
   Blocks: {
@@ -15,6 +19,14 @@ interface Signature {
 }
 
 export default class Alert extends Component<Signature> {
+  constructor(owner: Owner, args: Signature['Args']) {
+    super(owner, args);
+
+    if (args.isDismissable && !args.onDismiss) {
+      throw new Error('Alert: @onDismiss is required when @isDismissable is true');
+    }
+  }
+
   get containerColorClasses(): string {
     return {
       green: 'bg-green-100/20 dark:bg-green-900/30 border-green-500/60 dark:border-green-500/40',
@@ -39,12 +51,27 @@ export default class Alert extends Component<Signature> {
     }[this.args.color];
   }
 
+  get dismissButtonColorClasses(): string {
+    return {
+      green: 'border-green-300 dark:border-green-700 hover:bg-green-200 dark:hover:bg-green-800/50 text-green-500',
+      blue: 'border-blue-300 dark:border-blue-700 hover:bg-blue-200 dark:hover:bg-blue-800/50 text-blue-500',
+      red: 'border-red-300 dark:border-red-700 hover:bg-red-200 dark:hover:bg-red-800/50 text-red-500',
+      teal: 'border-teal-300 dark:border-teal-700 hover:bg-teal-200 dark:hover:bg-teal-800/50 text-teal-500',
+      yellow: 'border-yellow-300 dark:border-yellow-700 hover:bg-yellow-200 dark:hover:bg-yellow-800/50 text-yellow-500',
+    }[this.args.color];
+  }
+
   get sizeIsLarge(): boolean {
     return this.args.size === 'large';
   }
 
   get sizeIsRegular(): boolean {
     return this.args.size === 'regular' || !this.args.size;
+  }
+
+  @action
+  handleDismissButtonClick() {
+    this.args.onDismiss?.();
   }
 }
 

--- a/app/components/course-page/course-stage-step/feedback-prompt.hbs
+++ b/app/components/course-page/course-stage-step/feedback-prompt.hbs
@@ -11,87 +11,89 @@
     </button>
   {{/if}}
 
-  <div class="mr-2 mt-0.5 shrink-0">
-    {{svg-jar "check-circle" class="w-6 fill-current text-teal-500"}}
-  </div>
-
-  <div class="w-full">
-    <div class="flex items-center">
-      {{#if (and this.submissionIsClosed (not this.isEditingClosedSubmission))}}
-        <div class="prose prose-green dark:prose-invert leading-7">
-          Feedback submitted!
-
-          <span
-            class="underline font-semibold"
-            role="button"
-            {{on "click" (fn (mut this.isEditingClosedSubmission) true)}}
-            data-test-edit-feedback-button
-          >
-            Edit Feedback
-          </span>
-        </div>
-      {{else}}
-        <div class="prose prose-green dark:prose-invert leading-7" data-test-question-text>
-          {{#if this.isEditingClosedSubmission}}
-            How did we do?
-          {{else}}
-            {{this.congratulatoryMessage}}
-            How did we do?
-          {{/if}}
-        </div>
-      {{/if}}
+  <div class="flex">
+    <div class="mr-2 mt-0.5 shrink-0">
+      {{svg-jar "check-circle" class="w-6 fill-current text-teal-500"}}
     </div>
 
-    {{#if (or this.isEditingClosedSubmission (not this.submissionIsClosed))}}
-      <div class="flex items-center mt-2">
-        {{#each this.answerOptionsWithColors as |answerOptionWithColor|}}
-          <CoursePage::CourseStageStep::FeedbackPromptOption
-            @emoji={{answerOptionWithColor.answer}}
-            @isSelected={{eq this.feedbackSubmission.selectedAnswer answerOptionWithColor.answer}}
-            @colorOnHoverAndSelect={{answerOptionWithColor.colorOnHoverAndSelect}}
-            {{on "click" (fn this.handleAnswerOptionSelected answerOptionWithColor.answer)}}
-            class="mr-2"
-          />
-        {{/each}}
+    <div class="w-full">
+      <div class="flex items-center">
+        {{#if (and this.submissionIsClosed (not this.isEditingClosedSubmission))}}
+          <div class="prose prose-green dark:prose-invert leading-7">
+            Feedback submitted!
+
+            <span
+              class="underline font-semibold"
+              role="button"
+              {{on "click" (fn (mut this.isEditingClosedSubmission) true)}}
+              data-test-edit-feedback-button
+            >
+              Edit Feedback
+            </span>
+          </div>
+        {{else}}
+          <div class="prose prose-green dark:prose-invert leading-7" data-test-question-text>
+            {{#if this.isEditingClosedSubmission}}
+              How did we do?
+            {{else}}
+              {{this.congratulatoryMessage}}
+              How did we do?
+            {{/if}}
+          </div>
+        {{/if}}
       </div>
 
-      {{#if this.feedbackSubmission.hasSelectedAnswer}}
-        <div class="prose prose-sm prose-green dark:prose-invert mt-4">
-          P.S.
-          <a
-            href="https://forum.codecrafters.io/u/rohitpaulk/activity"
-            target="_blank"
-            rel="noopener noreferrer"
-            class="underline font-semibold"
-          >rohitpaulk</a>
-          reads every one of these messages! We act on most feedback within a week.
+      {{#if (or this.isEditingClosedSubmission (not this.submissionIsClosed))}}
+        <div class="flex items-center mt-2">
+          {{#each this.answerOptionsWithColors as |answerOptionWithColor|}}
+            <CoursePage::CourseStageStep::FeedbackPromptOption
+              @emoji={{answerOptionWithColor.answer}}
+              @isSelected={{eq this.feedbackSubmission.selectedAnswer answerOptionWithColor.answer}}
+              @colorOnHoverAndSelect={{answerOptionWithColor.colorOnHoverAndSelect}}
+              {{on "click" (fn this.handleAnswerOptionSelected answerOptionWithColor.answer)}}
+              class="mr-2"
+            />
+          {{/each}}
         </div>
 
-        {{! template-lint-disable require-input-label }}
-        <Textarea
-          @value={{this.feedbackSubmission.explanation}}
-          class="mt-4 border border-teal-500/50 rounded-sm w-full p-4 placeholder-gray-400 dark:placeholder-gray-600 bg-white dark:bg-gray-950 text-gray-950 dark:text-gray-100"
-          rows="5"
-          placeholder={{this.explanationTextareaPlaceholder}}
-          {{on "blur" this.handleExplanationTextareaBlur}}
-          {{markdown-input}}
-          {{focus-on-insert}}
-        />
-
-        <div class="flex items-start justify-between mt-1">
-          <div class="flex items-center">
-            {{svg-jar "markdown" class="fill-current w-5 mr-1 text-teal-500"}}
-
-            <div class="text-xs text-teal-600">
-              Markdown supported.
-            </div>
+        {{#if this.feedbackSubmission.hasSelectedAnswer}}
+          <div class="prose prose-sm prose-green dark:prose-invert mt-4">
+            P.S.
+            <a
+              href="https://forum.codecrafters.io/u/rohitpaulk/activity"
+              target="_blank"
+              rel="noopener noreferrer"
+              class="underline font-semibold"
+            >rohitpaulk</a>
+            reads every one of these messages! We act on most feedback within a week.
           </div>
 
-          <PrimaryButton {{on "click" this.handleSubmitButtonClick}} data-test-submit-feedback-button>
-            Submit
-          </PrimaryButton>
-        </div>
+          {{! template-lint-disable require-input-label }}
+          <Textarea
+            @value={{this.feedbackSubmission.explanation}}
+            class="mt-4 border border-teal-500/50 rounded-sm w-full p-4 placeholder-gray-400 dark:placeholder-gray-600 bg-white dark:bg-gray-950 text-gray-950 dark:text-gray-100"
+            rows="5"
+            placeholder={{this.explanationTextareaPlaceholder}}
+            {{on "blur" this.handleExplanationTextareaBlur}}
+            {{markdown-input}}
+            {{focus-on-insert}}
+          />
+
+          <div class="flex items-start justify-between mt-1">
+            <div class="flex items-center">
+              {{svg-jar "markdown" class="fill-current w-5 mr-1 text-teal-500"}}
+
+              <div class="text-xs text-teal-600">
+                Markdown supported.
+              </div>
+            </div>
+
+            <PrimaryButton {{on "click" this.handleSubmitButtonClick}} data-test-submit-feedback-button>
+              Submit
+            </PrimaryButton>
+          </div>
+        {{/if}}
       {{/if}}
-    {{/if}}
+    </div>
   </div>
 </Alert>

--- a/app/components/private-leaderboard-feature-suggestion.hbs
+++ b/app/components/private-leaderboard-feature-suggestion.hbs
@@ -1,20 +1,12 @@
-<Alert @color="blue" class="flex p-3 pr-6 relative" data-test-private-leaderboard-feature-suggestion ...attributes>
-  <div class="mr-3 mt-0.5">
-    {{svg-jar "user-group" class="w-6 fill-current text-blue-400 dark:text-blue-600"}}
-  </div>
-
-  <div class="prose prose-blue dark:prose-invert leading-7 text-sm">
-    Private leaderboards are here.
-    <br />
-    <span role="button" class="font-semibold underline" {{on "click" this.handleCreateTeamButtonClick}}>Create one for your team.</span>
-  </div>
-
-  <button
-    class="absolute right-3 top-3 opacity-60 hover:opacity-100"
-    type="button"
-    {{on "click" this.handleDismissButtonClick}}
-    data-test-dismiss-button
-  >
-    {{svg-jar "x" class="w-3 h-3 text-blue-500"}}
-  </button>
-</Alert>
+<AlertWithIcon
+  @type="info"
+  @icon="user-group"
+  @isDismissable={{true}}
+  @onDismiss={{this.handleDismissButtonClick}}
+  data-test-private-leaderboard-feature-suggestion
+  ...attributes
+>
+  Private leaderboards are here.
+  <br />
+  <span role="button" class="font-semibold underline" {{on "click" this.handleCreateTeamButtonClick}}>Create one for your team.</span>
+</AlertWithIcon>

--- a/app/components/product-walkthrough-feature-suggestion.hbs
+++ b/app/components/product-walkthrough-feature-suggestion.hbs
@@ -1,20 +1,13 @@
-<AlertWithIcon @type="info" class="relative" ...attributes data-test-product-walkthrough-feature-suggestion>
-  <span class="leading-7 inline-block mr-10">
+<AlertWithIcon
+  @type="info"
+  @isDismissable={{this.isDismissable}}
+  @onDismiss={{this.handleDismissButtonClick}}
+  ...attributes
+  data-test-product-walkthrough-feature-suggestion
+>
+  <span class="leading-7 inline-block">
     New here?
     <b role="button" class="underline" {{on "click" this.handleViewWalkthroughButtonClick}} data-test-start-here-button>Start here</b>
     to learn how challenges work.
   </span>
-
-  {{#if this.isDismissable}}
-    <div class="absolute right-3 top-0 bottom-0 flex items-center justify-center">
-      <button
-        class="border border-blue-300 dark:border-blue-700 p-1 rounded-sm hover:bg-blue-200 dark:hover:bg-blue-800/50"
-        type="button"
-        {{on "click" this.handleDismissButtonClick}}
-        data-test-dismiss-button
-      >
-        {{svg-jar "x" class="w-5 h-5 text-blue-500"}}
-      </button>
-    </div>
-  {{/if}}
 </AlertWithIcon>


### PR DESCRIPTION
Introduce `isDismissable` and `onDismiss` args to Alert and AlertWithIcon  
components to allow alerts to be dismissable by users. Render a dismiss  
button conditionally when `isDismissable` is true, triggering the passed  
`onDismiss` callback on click. Update AlertWithIcon usage in  
product-walkthrough-feature-suggestion to enable dismissal and consolidate  
dismiss logic inside Alert, removing redundant markup. This improves alert  
flexibility and user control over notification visibility.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds user-dismissable alerts and consolidates dismiss logic in the base `Alert` component.
> 
> - Add `@isDismissable` and `@onDismiss` to `Alert`; render an X button that calls `handleDismissButtonClick` and require `@onDismiss` when dismissable
> - New `dismissButtonColorClasses` and content wrapper (`flex-1`) in `Alert` for layout and theming
> - Update `AlertWithIcon` to pass through `@isDismissable`/`@onDismiss`; extend its signature
> - Replace custom dismiss UI in `product-walkthrough-feature-suggestion` and `private-leaderboard-feature-suggestion` with dismissable `AlertWithIcon`
> - Small layout refactor in `feedback-prompt.hbs` (grouped content in a flex container)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4f17e5f0d228ed72aabbf1292d4cae60f95f5ac0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->