### PR TITLE
docs(cursor): update formatting test guidelines for page objects

### DIFF
--- a/.cursor/rules/formatting-test-files.mdc
+++ b/.cursor/rules/formatting-test-files.mdc
@@ -79,7 +79,8 @@ test('can create concept', async function (assert) {
 - Use `createPage` function to wrap the page object definition
 - Use `visitable` for URL patterns
 - Use `collection` for repeated elements
-- Use `clickable`, `text`, `isPresent`, etc. for element interactions
+- Use `clickable`, `text`, etc. for element interactions
+- `isVisible` is available by default on all page objects with a `scope`, so don't add `isVisible: isPresent()` explicitly
 
 Example:
 


### PR DESCRIPTION
Clarify element interactions by removing `isPresent` from the list
and note that `isVisible` is available by default on all page objects
with a `scope`. This improves accuracy and prevents redundant code in
test file documentation.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates test docs for page objects in `formatting-test-files.mdc`.
> 
> - Removes `isPresent` from the recommended element interactions list
> - Adds note that `isVisible` is available by default on scoped page objects, so avoid `isVisible: isPresent()`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 857bd8c158c6dd8d9b6f7e7aee10ca4e4904bdb7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->