### PR TITLE
fix(alert): adjust dismiss button styles for better consistency

### DIFF
--- a/app/components/alert.hbs
+++ b/app/components/alert.hbs
@@ -14,12 +14,12 @@
   {{#if @isDismissable}}
     <div class="flex items-center justify-center ml-3">
       <button
-        class="border p-1 rounded-sm {{this.dismissButtonColorClasses}}"
+        class="border p-0.5 rounded-sm {{this.dismissButtonColorClasses}}"
         type="button"
         {{on "click" this.handleDismissButtonClick}}
         data-test-dismiss-button
       >
-        {{svg-jar "x" class="w-5 h-5 fill-current"}}
+        {{svg-jar "x" class="w-4 h-4 fill-current"}}
       </button>
     </div>
   {{/if}}

--- a/app/components/alert.ts
+++ b/app/components/alert.ts
@@ -53,11 +53,11 @@ export default class Alert extends Component<Signature> {
 
   get dismissButtonColorClasses(): string {
     return {
-      green: 'border-green-300 dark:border-green-700 hover:bg-green-200 dark:hover:bg-green-800/50 text-green-500',
-      blue: 'border-blue-300 dark:border-blue-700 hover:bg-blue-200 dark:hover:bg-blue-800/50 text-blue-500',
-      red: 'border-red-300 dark:border-red-700 hover:bg-red-200 dark:hover:bg-red-800/50 text-red-500',
-      teal: 'border-teal-300 dark:border-teal-700 hover:bg-teal-200 dark:hover:bg-teal-800/50 text-teal-500',
-      yellow: 'border-yellow-300 dark:border-yellow-700 hover:bg-yellow-200 dark:hover:bg-yellow-800/50 text-yellow-500',
+      green: 'border-green-300 dark:border-green-700/50 hover:bg-green-200 dark:hover:bg-green-800/50 text-green-500',
+      blue: 'border-blue-300 dark:border-blue-700/50 hover:bg-blue-200 dark:hover:bg-blue-800/50 text-blue-500',
+      red: 'border-red-300 dark:border-red-700/50 hover:bg-red-200 dark:hover:bg-red-800/50 text-red-500',
+      teal: 'border-teal-300 dark:border-teal-700/50 hover:bg-teal-200 dark:hover:bg-teal-800/50 text-teal-500',
+      yellow: 'border-yellow-300 dark:border-yellow-700/50 hover:bg-yellow-200 dark:hover:bg-yellow-800/50 text-yellow-500',
     }[this.args.color];
   }
 


### PR DESCRIPTION
Reduce dismiss button padding and icon size for improved visual balance.
Modify dark mode border opacity to 50% for all colors to enhance
contrast and consistency across themes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Refines `Alert` dismiss button sizing and dark-mode styling for consistent visuals.
> 
> - In `alert.hbs`, decreases button padding to `p-0.5` and icon to `w-4 h-4`
> - In `alert.ts`, updates `dismissButtonColorClasses` to use `dark:border-*-700/50` for all colors
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0eaa5101639dc610b2121c2f72f91f4ba4b1817c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->