### PR TITLE
fix(avatar-image): improve fallback logic for avatar image URL

### DIFF
--- a/app/components/avatar-image.ts
+++ b/app/components/avatar-image.ts
@@ -15,11 +15,11 @@ export default class AvatarImage extends Component<Signature> {
   @tracked avatarImageFailedToLoad = false;
 
   get imageUrl() {
-    if (this.avatarImageFailedToLoad) {
+    if (this.avatarImageFailedToLoad || !this.args.user) {
       return 'https://codecrafters.io/images/sample-avatar-3.png';
-    } else {
-      return this.args.user.avatarUrl;
     }
+
+    return this.args.user.avatarUrl;
   }
 
   @action


### PR DESCRIPTION
**Issue**:

https://backend.codecrafters.io/admin/users/3f577353-1eeb-4a99-b130-db19450bd0cf

<img width="2646" height="1306" alt="image" src="https://github.com/user-attachments/assets/7ea00c40-07e6-4277-b0c3-d353dceafffc" />

---

**Checklist**:

- [x] I've thoroughly self-reviewed my changes
- [ ] I've added tests for my changes, unless they affect admin-only areas (or are otherwise not worth testing)
- [ ] I've verified any visual changes using Percy (add a commit with `[percy]` in the message to trigger)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Improves avatar URL fallback behavior to cover cases where `user` is missing, preventing broken images.
> 
> - Updates `AvatarImage.imageUrl` to return the placeholder when `avatarImageFailedToLoad` is true or when `args.user` is absent
> - Minor refactor removing unnecessary `else` branch; no behavioral changes elsewhere
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b982be748345d4a0ad457d90b9998d7aad4046ea. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->