### PR TITLE
fix(repository-setup-card): update CLI install command for reliability

### DIFF
--- a/app/components/course-page/setup-step/repository-setup-card/test-cli-connection-step.ts
+++ b/app/components/course-page/setup-step/repository-setup-card/test-cli-connection-step.ts
@@ -19,7 +19,7 @@ export default class TestCliConnectionStep extends Component<Signature> {
   get commandVariants(): CopyableTerminalCommandVariant[] {
     const linuxMacOSVariant = {
       label: 'Linux / macOS',
-      commands: ['curl https://codecrafters.io/install.sh | sh', 'codecrafters ping'],
+      commands: ['curl -fsSL https://codecrafters.io/install.sh | bash', 'codecrafters ping'],
     };
 
     const powershellVariant = {


### PR DESCRIPTION
Change the Linux/macOS install command to use curl with -fsSL flags and
pipe it to bash instead of sh. This improves the command's reliability
and security by ensuring the download fails silently on errors and uses
bash-specific features.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates the Linux/macOS CLI install command for reliability.
> 
> - In `TestCliConnectionStep`, replace `curl https://codecrafters.io/install.sh | sh` with `curl -fsSL https://codecrafters.io/install.sh | bash` in the Linux/macOS command variant
> - PowerShell command variant remains unchanged; platform ordering logic is unchanged
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 39c022183b8f8d3c8e2f82097f5320d80221c7c5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->