### PR TITLE
Refactor border classes in course extension and idea card components.

### DIFF
--- a/app/components/roadmap-page/course-extension-idea-card.hbs
+++ b/app/components/roadmap-page/course-extension-idea-card.hbs
@@ -1,6 +1,5 @@
 <div
-  class="relative group bg-white dark:bg-gray-925 p-5 rounded-md shadow-xs border
-    {{if this.userHasVoted 'border-gray-300 dark:border-gray-700' 'border-gray-200 dark:border-white/5'}}
+  class="relative group bg-white dark:bg-gray-925 p-5 rounded-md shadow-xs border border-gray-200 dark:border-white/5
     {{if @courseExtensionIdea.developmentStatusIsReleased 'opacity-50'}}"
   data-test-course-extension-idea-card
 >

--- a/app/components/roadmap-page/course-idea-card.gts
+++ b/app/components/roadmap-page/course-idea-card.gts
@@ -77,9 +77,7 @@ export default class CourseIdeaCard extends Component<Signature> {
 
   <template>
     <div
-      class="group bg-white dark:bg-gray-925 p-5 rounded-md shadow-xs border
-        {{if this.userHasVoted 'border-gray-300 dark:border-gray-700' 'border-gray-200 dark:border-white/5'}}
-        relative
+      class="group bg-white dark:bg-gray-925 p-5 rounded-md shadow-xs border border-gray-200 dark:border-white/5 relative
         {{if @courseIdea.developmentStatusIsReleased 'opacity-50'}}"
       data-test-course-idea-card
     >


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Standardizes card borders on roadmap idea components.
> 
> - Replaces conditional `border-*` classes tied to `userHasVoted` with a consistent `border border-gray-200 dark:border-white/5` in `course-extension-idea-card.hbs` and `course-idea-card.gts`
> - Keeps existing opacity behavior for released items; no logic or behavior changes otherwise
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 110b3163f2d66d329c00a4dc850a1537a96a2718. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/codecrafters-io/frontend/pull/3632">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
