### PR TITLE
feat(payments): add membership expiry discount support

### DIFF
--- a/app/components/pay-page/choose-membership-plan-modal/plan-card.hbs
+++ b/app/components/pay-page/choose-membership-plan-modal/plan-card.hbs
@@ -64,7 +64,7 @@
                   >{{@promotionalDiscount.affiliateReferral.affiliateLink.affiliateName}}'s</span>
                   referral offer{{else if @promotionalDiscount.isFromStage2Completion}}Stage 2 completion discount{{else if
                   @promotionalDiscount.isFromSignup
-                }}Signup discount{{/if}}, expires in
+                }}Signup discount{{else if @promotionalDiscount.isFromMembershipExpiry}}Early renewal discount{{/if}}, expires in
                 <span class="font-mono">{{this.promotionalDiscountCountdownTimerText}}</span>
               </li>
             {{/if}}

--- a/app/models/promotional-discount.ts
+++ b/app/models/promotional-discount.ts
@@ -10,7 +10,7 @@ export default class PromotionalDiscountModel extends Model {
 
   @attr('date') createdAt!: Date;
   @attr('date') expiresAt!: Date;
-  @attr('string') type!: 'signup' | 'affiliate_referral' | 'stage_2_completion';
+  @attr('string') type!: 'signup' | 'affiliate_referral' | 'stage_2_completion' | 'membership_expiry';
   @attr('number') percentageOff!: number;
 
   @service declare time: TimeService;
@@ -26,6 +26,10 @@ export default class PromotionalDiscountModel extends Model {
 
   get isFromAffiliateReferral() {
     return this.type === 'affiliate_referral';
+  }
+
+  get isFromMembershipExpiry() {
+    return this.type === 'membership_expiry';
   }
 
   get isFromSignup() {

--- a/app/models/user.ts
+++ b/app/models/user.ts
@@ -94,6 +94,10 @@ export default class UserModel extends Model {
     return this.activePromotionalDiscountForType('affiliate_referral');
   }
 
+  get activeDiscountFromMembershipExpiry() {
+    return this.activePromotionalDiscountForType('membership_expiry');
+  }
+
   get activeDiscountFromSignup() {
     return this.activePromotionalDiscountForType('signup');
   }

--- a/app/templates/settings/billing.hbs
+++ b/app/templates/settings/billing.hbs
@@ -31,8 +31,7 @@
     <PayPage::ChooseMembershipPlanModal
       {{! @glint-expect-error mut types are broken  }}
       @onClose={{fn (mut this.chooseMembershipPlanModalIsOpen) false}}
-      {{! we don't support discounts on extensions yet !}}
-      @activeDiscountForYearlyPlan={{null}}
+      @activeDiscountForYearlyPlan={{@model.user.activeDiscountFromMembershipExpiry}}
       @checkoutSessionCancelPath="/settings/billing"
       @checkoutSessionSuccessPath="/settings/billing?action=membership_extended"
       @closeModalCTAText="Back to billing page"


### PR DESCRIPTION
Introduce a new promotional discount type "membership_expiry" to support
early renewal offers. Update model, templates, and components to handle
this new discount type, enabling display and application of expiry-related
discounts in billing and membership plan selection.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a new `membership_expiry` promotional discount type and wires it into billing/renewal flows.
> 
> - Extends `PromotionalDiscountModel.type` and adds `isFromMembershipExpiry`
> - Adds `User.activeDiscountFromMembershipExpiry()` and uses it in `settings/billing.hbs` to pass `@activeDiscountForYearlyPlan` to the extend-membership modal
> - Updates `plan-card.hbs` to render “Early renewal discount” when `@promotionalDiscount.isFromMembershipExpiry`
> - Adds acceptance test ensuring the discount appears in the extend membership modal and price is correctly discounted
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 49749f818a1efac26d550b818772cc3b09a582e0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->