### PR TITLE
feat(billing): show early renewal discount on renewal section

### DIFF
--- a/app/components/settings/billing-page/renewal-section.hbs
+++ b/app/components/settings/billing-page/renewal-section.hbs
@@ -15,4 +15,14 @@
   <PrimaryButton @size="small" {{on "click" @onExtendMembershipButtonClick}} data-test-extend-membership-button>
     Extend membership →
   </PrimaryButton>
+
+  {{#if @activeDiscountForYearlyPlan}}
+    <div class="prose prose-sm prose-compact dark:prose-invert mt-4" data-test-early-renewal-discount-text>
+      <p>
+        <b>Offer:</b>
+        Get 🎁&nbsp;<b class="text-teal-500">{{@activeDiscountForYearlyPlan.percentageOff}}% off</b>
+        the yearly plan if you renew before expiry!
+      </p>
+    </div>
+  {{/if}}
 </Settings::FormSection>

--- a/app/components/settings/billing-page/renewal-section.ts
+++ b/app/components/settings/billing-page/renewal-section.ts
@@ -1,10 +1,12 @@
 import Component from '@glimmer/component';
+import type PromotionalDiscountModel from 'codecrafters-frontend/models/promotional-discount';
 import type SubscriptionModel from 'codecrafters-frontend/models/subscription';
 
 interface Signature {
   Element: HTMLDivElement;
 
   Args: {
+    activeDiscountForYearlyPlan: PromotionalDiscountModel | null;
     onExtendMembershipButtonClick: () => void;
     subscription: SubscriptionModel;
   };

--- a/app/templates/settings/billing.hbs
+++ b/app/templates/settings/billing.hbs
@@ -14,6 +14,7 @@
     <Settings::FormDivider />
 
     <Settings::BillingPage::RenewalSection
+      @activeDiscountForYearlyPlan={{@model.user.activeDiscountFromMembershipExpiry}}
       @onExtendMembershipButtonClick={{fn (mut this.chooseMembershipPlanModalIsOpen) true}}
       @subscription={{@model.user.activeSubscription}}
     />


### PR DESCRIPTION
Add display of active promotional discount for yearly plans in the 
renewal section of the billing page. Pass the active discount model 
from the template and conditionally render the discount message 
below the extend membership button.

This informs users of potential savings when renewing before 
expiry, encouraging early membership renewal.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only change that conditionally displays a discount message and adds a typed arg; no billing logic or checkout flow changes.
> 
> **Overview**
> Shows an *early-renewal promotional offer* in the billing page renewal section when a membership-expiry discount is active.
> 
> Passes `@model.user.activeDiscountFromMembershipExpiry` into `Settings::BillingPage::RenewalSection`, adds a typed `@activeDiscountForYearlyPlan` arg, and conditionally renders the percentage-off text below the “Extend membership” button.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0f5c6647f3d2133cdb56cdb9c0053cac11957a85. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->