### PR TITLE
Add support for extension completed steps in course page state service.

### DIFF
--- a/app/services/course-page-state.ts
+++ b/app/services/course-page-state.ts
@@ -3,6 +3,7 @@ import RouterService from '@ember/routing/router-service';
 import { StepDefinition, StepListDefinition } from 'codecrafters-frontend/utils/course-page-step-list';
 import { tracked } from '@glimmer/tracking';
 import CourseStageStep from 'codecrafters-frontend/utils/course-page-step-list/course-stage-step';
+import ExtensionCompletedStep from 'codecrafters-frontend/utils/course-page-step-list/extension-completed-step';
 
 export default class CoursePageStateService extends Service {
   @service declare router: RouterService;
@@ -46,15 +47,17 @@ export default class CoursePageStateService extends Service {
     } else if (this.router.currentRouteName === 'course.base-stages-completed') {
       return this.stepList!.visibleStepByType('BaseStagesCompletedStep') || null;
     } else if (this.router.currentRouteName && this.router.currentRouteName.startsWith('course.stage')) {
-      const courseStageRoute = this.router.currentRoute.find((route: { name: string }) => route.name === 'course.stage');
+      const route = this.router.currentRoute.find((route: { name: string }) => route.name === 'course.stage')!;
+      const routeParams = route.params as { stage_slug: string };
+      const courseStageSteps = this.stepList!.visibleStepsByType('CourseStageStep') as CourseStageStep[];
 
-      const routeParams = courseStageRoute!.params as { stage_slug: string };
+      return courseStageSteps.find((step) => step.courseStage.slug === routeParams.stage_slug) || null;
+    } else if (this.router.currentRouteName === 'course.extension-completed') {
+      const route = this.router.currentRoute.find((route: { name: string }) => route.name === 'course.extension-completed')!;
+      const routeParams = route.params as { extension_slug: string };
+      const extensionCompletedSteps = this.stepList!.visibleStepsByType('ExtensionCompletedStep') as ExtensionCompletedStep[];
 
-      return (
-        this.stepList!.steps.find(
-          (step) => step.type === 'CourseStageStep' && (step as CourseStageStep).courseStage.slug === routeParams.stage_slug,
-        ) || null
-      );
+      return extensionCompletedSteps.find((step) => step.extension.slug === routeParams.extension_slug) || null;
     } else {
       return null;
     }

--- a/app/utils/course-page-step-list.ts
+++ b/app/utils/course-page-step-list.ts
@@ -164,4 +164,8 @@ export class StepListDefinition {
 
     return this.visibleSteps.slice(stepIndex + 1);
   }
+
+  visibleStepsByType(type: StepDefinition['type']): StepDefinition[] {
+    return this.visibleSteps.filter((step) => step.type === type);
+  }
 }

--- a/tests/acceptance/course-page/extensions/enable-extensions-after-completion-test.js
+++ b/tests/acceptance/course-page/extensions/enable-extensions-after-completion-test.js
@@ -2,7 +2,7 @@ import { setupAnimationTest } from 'ember-animated/test-support';
 import { module, test } from 'qunit';
 import { setupApplicationTest } from 'codecrafters-frontend/tests/helpers';
 import { signInAsSubscriber } from 'codecrafters-frontend/tests/support/authentication-helpers';
-import { currentURL } from '@ember/test-helpers';
+import { currentURL, visit } from '@ember/test-helpers';
 import baseStagesCompletePage from 'codecrafters-frontend/tests/pages/course/base-stages-complete-page';
 import coursePage from 'codecrafters-frontend/tests/pages/course-page';
 import catalogPage from 'codecrafters-frontend/tests/pages/catalog-page';
@@ -143,11 +143,44 @@ module('Acceptance | course-page | extensions | enable-extensions-after-completi
     await courseOverviewPage.clickOnStartCourse();
 
     assert.strictEqual(currentURL(), '/courses/dummy/extension-completed/ext1', 'current URL is extension completed page');
+    assert.strictEqual(coursePage.sidebar.stepListItems.length, 8, 'step list has 8 items when extension 1 is completed');
 
     await coursePage.sidebar.configureExtensionsToggles[0].click();
     await coursePage.configureExtensionsModal.toggleExtension('Extension 2');
     await coursePage.configureExtensionsModal.clickOnCloseButton();
 
-    assert.strictEqual(currentURL(), '/courses/dummy/stages/ae0', 'current URL is next extension stage');
+    assert.strictEqual(currentURL(), '/courses/dummy/extension-completed/ext1', 'current URL is still extension completed page');
+    assert.strictEqual(coursePage.sidebar.stepListItems.length, 10, 'step list has 10 items when extension 2 is enabled');
+  });
+
+  test('can directly navigate to extension-completed URL', async function (assert) {
+    testScenario(this.server);
+    signInAsSubscriber(this.owner, this.server);
+
+    let currentUser = this.server.schema.users.first();
+    let python = this.server.schema.languages.findBy({ name: 'Python' });
+    let course = this.server.schema.courses.findBy({ slug: 'dummy' });
+    course.update('releaseStatus', 'live');
+
+    const repository = this.server.create('repository', 'withBaseStagesCompleted', {
+      course: course,
+      language: python,
+      user: currentUser,
+    });
+
+    // Complete all stages for extension 1
+    course.stages.models.forEach((stage) => {
+      if (stage.primaryExtensionSlug === 'ext1') {
+        this.server.create('submission', 'withStageCompletion', {
+          repository,
+          courseStage: stage,
+        });
+      }
+    });
+
+    // Directly visit the extension-completed URL
+    await visit('/courses/dummy/extension-completed/ext1');
+
+    assert.strictEqual(currentURL(), '/courses/dummy/extension-completed/ext1', 'stays on extension-completed page');
   });
 });


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Medium risk because it changes route-to-step resolution logic used for navigation/next-step behavior; errors here could send users to the wrong step or break direct navigation to `extension-completed` URLs.
> 
> **Overview**
> Updates `CoursePageStateService.currentStepSansFallback` to correctly resolve `ExtensionCompletedStep` when on the `course.extension-completed` route, and refactors stage-step lookup to use visible steps of a given type.
> 
> Adds `StepListDefinition.visibleStepsByType()` and extends acceptance coverage to assert step list updates while staying on the extension-completed page when enabling additional extensions, plus a new test for direct visits to an `extension-completed` URL.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ca4582ceb53e911c287578ddac424be4ed627e58. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->