### PR TITLE
Evaluator duplicate prevention

### DIFF
--- a/app/controllers/course-admin/code-example-evaluators.ts
+++ b/app/controllers/course-admin/code-example-evaluators.ts
@@ -13,7 +13,7 @@ export default class CodeExampleEvaluatorsController extends Controller {
   @service declare router: RouterService;
   @service declare store: Store;
 
-  createEvaluatorTask = task({ keepLatest: true }, async (): Promise<void> => {
+  createEvaluatorTask = task({ drop: true }, async (): Promise<void> => {
     const evaluator = this.store.createRecord('community-solution-evaluator', {});
 
     await evaluator.save();

--- a/app/templates/course-admin/code-example-evaluators.hbs
+++ b/app/templates/course-admin/code-example-evaluators.hbs
@@ -48,6 +48,7 @@
         </div>
 
         <PrimaryButtonWithSpinner
+          @isDisabled={{this.createEvaluatorTask.isRunning}}
           @shouldShowSpinner={{this.createEvaluatorTask.isRunning}}
           data-test-create-evaluator-button
           {{on "click" this.handleCreateEvaluatorButtonClick}}


### PR DESCRIPTION
**Checklist**:

- [ ] I've thoroughly self-reviewed my changes
- [ ] I've added tests for my changes, unless they affect admin-only areas (or are otherwise not worth testing)
- [ ] I've verified any visual changes using Percy (add a commit with `[percy]` in the message to trigger)

This PR fixes a bug where rapid clicks on the "Create Evaluator" button could lead to duplicate evaluator creation.

The `createEvaluatorTask` now uses the `drop: true` modifier to prevent new task instances from running while one is already in progress. Additionally, the "Create Evaluator" button is now disabled while the task is running by binding `@isDisabled={{this.createEvaluatorTask.isRunning}}`, providing a visual and functional safeguard against rapid clicks.

---

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk UI/concurrency tweak limited to the admin evaluator creation flow; main risk is accidentally blocking intended repeated creates if the task never resolves due to an error.
> 
> **Overview**
> Prevents duplicate “Create evaluator” actions in `course-admin/code-example-evaluators` by switching `createEvaluatorTask` to `drop: true` so additional clicks are ignored while a create is in flight.
> 
> Disables the “Create evaluator” button (and shows its spinner) while `createEvaluatorTask.isRunning` to provide a clear visual/functional guard against rapid repeated clicks.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9767945f2f17567077c05fa953f8e62a919d0a09. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->