### PR TITLE
feat(editable-text-field): add inline editing component with validation

### DIFF
--- a/app/components/concept-admin/form-section.hbs
+++ b/app/components/concept-admin/form-section.hbs
@@ -1,7 +1,7 @@
 <div class="grid grid-cols-1 sm:grid-cols-3 py-8 gap-6" ...attributes>
   <div class="col-span-1">
-    <div class="text-gray-900 font-semibold mb-1 text-lg">{{@title}}</div>
-    <div class="text-gray-400 text-xs">
+    <div class="text-gray-900 dark:text-gray-100 font-semibold mb-1 text-lg">{{@title}}</div>
+    <div class="text-gray-400 dark:text-gray-600 text-xs">
       {{@description}}
       {{yield to="description"}}
     </div>

--- a/app/components/course-admin/code-example-evaluator-page/accuracy-section.hbs
+++ b/app/components/course-admin/code-example-evaluator-page/accuracy-section.hbs
@@ -1,16 +1,4 @@
 <div data-test-evaluations-section ...attributes>
-  <div class="mb-4">
-    <div class="flex items-center mb-1 gap-2">
-      <span class="text-gray-900 font-semibold text-lg">
-        Accuracy
-      </span>
-    </div>
-
-    <div class="text-gray-400 text-xs">
-      Measure accuracy by comparing LLM evaluations against human evaluations
-    </div>
-  </div>
-
   {{! TODO: Use a "generic" statistic component? }}
   <div class="mt-6 grid grid-cols-1 gap-5 sm:grid-cols-2 mb-6">
     <CourseAdmin::StageInsightsPage::StatisticCard @statistic={{this.falsePositiveRateStatistic}} />

--- a/app/components/course-admin/code-example-evaluator-page/evaluations-section.hbs
+++ b/app/components/course-admin/code-example-evaluator-page/evaluations-section.hbs
@@ -1,12 +1,12 @@
 <div data-test-evaluations-section ...attributes>
   <div class="mb-4">
     <div class="flex items-center mb-1 gap-2">
-      <span class="text-gray-900 font-semibold text-lg">
+      <span class="text-gray-900 dark:text-gray-100 font-semibold text-lg">
         Recent Evaluations
       </span>
     </div>
 
-    <div class="text-gray-400 text-xs">
+    <div class="text-gray-400 dark:text-gray-600 text-xs">
       View recent evaluations by result
     </div>
   </div>

--- a/app/components/course-admin/code-example-evaluator-page/prompt-template-section.hbs
+++ b/app/components/course-admin/code-example-evaluator-page/prompt-template-section.hbs
@@ -1,25 +1,38 @@
-<div>
-  <div class="mb-6">
-    <div class="text-gray-900 font-semibold mb-1 text-lg">Prompt Template</div>
-    <div class="text-gray-400 text-xs">
-      Must start with a "&lt;criteria&gt; ... &lt;/criteria&gt;" section. Can be followed by additional instructions as a markdown list.
-    </div>
-  </div>
+<ConceptAdmin::FormSection
+  @title="Prompt Template"
+  @description='Must start with a "&lt;criteria&gt; ... &lt;/criteria&gt;" section. Can be followed by additional instructions as a markdown list.'
+  data-test-prompt-template-section
+>
+  <:content>
+    <Textarea
+      @value={{@evaluator.promptTemplate}}
+      class="font-mono text-sm rounded-sm px-3 py-2 placeholder-gray-300 dark:placeholder-gray-600 focus:outline-hidden focus:ring-2 focus:ring-teal-500 border border-gray-300 dark:border-gray-700 bg-white dark:bg-gray-950 text-gray-900 dark:text-gray-100 shadow-xs w-full"
+      placeholder="Learn about various network protocols and the TCP/IP model."
+      rows="3"
+      id="prompt_template"
+      required
+      disabled={{not @evaluator.isDraft}}
+      {{autoresize @evaluator.promptTemplate}}
+      {{markdown-input}}
+      {{on "input" this.handlePromptTemplateInput}}
+    />
 
-  <Textarea
-    @value={{@evaluator.promptTemplate}}
-    class="font-mono text-sm rounded-sm px-3 py-2 placeholder-gray-300 focus:outline-hidden focus:ring-2 focus:ring-teal-500 border border-gray-300 shadow-xs w-full"
-    placeholder="Learn about various network protocols and the TCP/IP model."
-    rows="3"
-    id="prompt_template"
-    required
-    {{autoresize @evaluator.promptTemplate}}
-    {{markdown-input}}
-  />
+    {{#if @evaluator.isDraft}}
+      <PrimaryButtonWithSpinner
+        data-test-update-prompt-template-button
+        @isDisabled={{or (not this.hasUnsavedChanges) this.updatePromptTemplateTask.isRunning}}
+        @shouldShowSpinner={{this.updatePromptTemplateTask.isRunning}}
+        {{on "click" (perform this.updatePromptTemplateTask)}}
+        class="mt-4"
+      >
+        Update
+      </PrimaryButtonWithSpinner>
+    {{else}}
+      <PrimaryButton data-test-update-prompt-template-button @isDisabled={{true}} class="flex! mt-4">
+        Update
 
-  <PrimaryButton @isDisabled={{true}} class="flex! mt-4">
-    Update Prompt Template
-
-    <EmberTooltip @text="Not supported yet" />
-  </PrimaryButton>
-</div>
+        <EmberTooltip @text="Only available for draft evaluators" />
+      </PrimaryButton>
+    {{/if}}
+  </:content>
+</ConceptAdmin::FormSection>

--- a/app/components/course-admin/code-example-evaluator-page/prompt-template-section.ts
+++ b/app/components/course-admin/code-example-evaluator-page/prompt-template-section.ts
@@ -1,5 +1,7 @@
 import Component from '@glimmer/component';
+import { action } from '@ember/object';
 import type CommunitySolutionEvaluatorModel from 'codecrafters-frontend/models/community-solution-evaluator';
+import { task } from 'ember-concurrency';
 
 export interface Signature {
   Element: HTMLDivElement;
@@ -9,7 +11,24 @@ export interface Signature {
   };
 }
 
-export default class PromptTemplateSection extends Component<Signature> {}
+export default class PromptTemplateSection extends Component<Signature> {
+  get hasUnsavedChanges() {
+    return (this.args.evaluator.hasDirtyAttributes as unknown as boolean) && 'promptTemplate' in this.args.evaluator.changedAttributes();
+  }
+
+  @action
+  handlePromptTemplateInput(event: Event) {
+    this.args.evaluator.promptTemplate = (event.target as HTMLTextAreaElement).value;
+  }
+
+  updatePromptTemplateTask = task({ drop: true }, async (): Promise<void> => {
+    if (!this.hasUnsavedChanges) {
+      return;
+    }
+
+    await this.args.evaluator.save();
+  });
+}
 
 declare module '@glint/environment-ember-loose/registry' {
   export default interface Registry {

--- a/app/components/course-admin/stage-insights-page/statistic-card.hbs
+++ b/app/components/course-admin/stage-insights-page/statistic-card.hbs
@@ -1,9 +1,12 @@
-<div class="rounded-lg bg-white px-4 py-5 border border-gray-200 sm:p-6">
+<div class="rounded-lg bg-white dark:bg-gray-925 px-4 py-5 border border-gray-200 dark:border-white/5 sm:p-6">
   <div class="inline-flex items-center gap-1 group/statistic-card-title">
-    <span class="truncate font-medium text-gray-600">
+    <span class="truncate font-medium text-gray-600 dark:text-gray-300">
       {{@statistic.title}}
     </span>
-    {{svg-jar "question-mark-circle" class="w-4 h-4 text-gray-300 group-hover/statistic-card-title:text-gray-400"}}
+    {{svg-jar
+      "question-mark-circle"
+      class="w-4 h-4 text-gray-300 dark:text-gray-700 group-hover/statistic-card-title:text-gray-400 dark:group-hover/statistic-card-title:text-gray-600"
+    }}
     <EmberTooltip>
       <div class="prose prose-sm prose-invert text-white">
         {{markdown-to-html @statistic.explanationMarkdown}}

--- a/app/components/course-admin/stage-insights-page/statistic-card.ts
+++ b/app/components/course-admin/stage-insights-page/statistic-card.ts
@@ -12,10 +12,10 @@ interface Signature {
 export default class StatisticCard extends Component<Signature> {
   get valueColorClasses(): string {
     return {
-      green: 'text-teal-500',
-      yellow: 'text-yellow-500',
-      red: 'text-red-500',
-      gray: 'text-gray-500',
+      green: 'text-teal-500 dark:text-teal-400',
+      yellow: 'text-yellow-500 dark:text-yellow-400',
+      red: 'text-red-500 dark:text-red-400',
+      gray: 'text-gray-500 dark:text-gray-400',
     }[this.args.statistic.color];
   }
 }

--- a/app/components/course-stage-dropdown.hbs
+++ b/app/components/course-stage-dropdown.hbs
@@ -3,9 +3,9 @@
     <dd.Trigger>
       <button
         type="button"
-        class="inline-flex justify-center w-full rounded-md border border-gray-300
-          {{if dd.isOpen 'bg-gray-50' 'bg-white'}}
-          shadow-xs px-4 py-2 text-sm font-medium text-gray-600 hover:bg-gray-50 focus:outline-hidden"
+        class="inline-flex justify-center w-full rounded-md border border-gray-300 dark:border-white/10
+          {{if dd.isOpen 'bg-gray-50 dark:bg-gray-900' 'bg-white dark:bg-gray-950'}}
+          shadow-xs px-4 py-2 text-sm font-medium text-gray-600 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-900 focus:outline-hidden"
         data-test-course-stage-dropdown-trigger
       >
         <span class="mr-1" data-test-current-course-stage-name>
@@ -16,42 +16,42 @@
           {{/if}}
         </span>
 
-        {{svg-jar "chevron-down" class=(concat "fill-current w-5 transform transition-all " (if dd.isOpen "text-teal-500" ""))}}
+        {{svg-jar "chevron-down" class=(concat "fill-current w-5 transform transition-all " (if dd.isOpen "text-teal-500 dark:text-teal-400" ""))}}
       </button>
     </dd.Trigger>
     <dd.Content>
       <div
-        class="bg-white rounded-lg shadow-lg max-h-96 overflow-y-auto border border-gray-200 py-2 mt-1 mb-1 w-56"
+        class="bg-white dark:bg-gray-925 rounded-lg shadow-lg max-h-96 overflow-y-auto border border-gray-200 dark:border-white/5 py-2 mt-1 mb-1 w-56"
         data-test-course-stage-dropdown-content
       >
         {{#unless this.shouldHideAllCourseStagesOption}}
           <div
-            class="flex justify-between items-center py-2 px-4 group hover:bg-gray-50 cursor-pointer"
+            class="flex justify-between items-center py-2 px-4 group hover:bg-gray-50 dark:hover:bg-gray-900 cursor-pointer"
             role="button"
             data-test-course-stage-link
             {{on "click" (fn this.handleAllCourseStagesDropdownLinkClick dd.actions.close)}}
           >
-            <span class="text-gray-600 text-sm">
+            <span class="text-gray-600 dark:text-gray-300 text-sm">
               All Stages
             </span>
           </div>
         {{/unless}}
 
         <div class="w-full flex items-center px-4 py-2 gap-2">
-          <span class="border-b border-gray-200 h-px w-full"></span>
-          <span class="text-gray-400 text-xs text-nowrap">
+          <span class="border-b border-gray-200 dark:border-white/5 h-px w-full"></span>
+          <span class="text-gray-400 dark:text-gray-600 text-xs text-nowrap">
             Base Stages
           </span>
         </div>
 
         {{#each @course.sortedBaseStages as |stage|}}
           <div
-            class="flex justify-between items-center py-2 px-4 group hover:bg-gray-50 cursor-pointer"
+            class="flex justify-between items-center py-2 px-4 group hover:bg-gray-50 dark:hover:bg-gray-900 cursor-pointer"
             role="button"
             data-test-course-stage-link
             {{on "click" (fn this.handleStageDropdownLinkClick stage dd.actions.close)}}
           >
-            <span class="text-gray-600 text-sm">
+            <span class="text-gray-600 dark:text-gray-300 text-sm">
               {{stage.name}}
             </span>
           </div>
@@ -59,20 +59,20 @@
 
         {{#each @course.sortedExtensions as |extension|}}
           <div class="w-full flex items-center px-4 py-2 gap-2">
-            <span class="border-b border-gray-200 h-px w-full"></span>
-            <span class="text-gray-400 text-xs text-nowrap">
+            <span class="border-b border-gray-200 dark:border-white/5 h-px w-full"></span>
+            <span class="text-gray-400 dark:text-gray-600 text-xs text-nowrap">
               {{extension.name}}
             </span>
           </div>
 
           {{#each extension.sortedStages as |stage|}}
             <div
-              class="flex items-center py-2 px-4 hover:bg-gray-50 cursor-pointer"
+              class="flex items-center py-2 px-4 hover:bg-gray-50 dark:hover:bg-gray-900 cursor-pointer"
               role="button"
               data-test-course-stage-link
               {{on "click" (fn this.handleStageDropdownLinkClick stage dd.actions.close)}}
             >
-              <span class="text-gray-600 text-sm">
+              <span class="text-gray-600 dark:text-gray-300 text-sm">
                 {{stage.name}}
               </span>
             </div>

--- a/app/components/editable-text-field.hbs
+++ b/app/components/editable-text-field.hbs
@@ -1,0 +1,42 @@
+{{#if this.shouldShowEditMode}}
+  <div ...attributes>
+    <div class="flex items-center gap-2">
+      <label for="editable-text-field-input" class="sr-only">Edit value</label>
+
+      <input
+        id="editable-text-field-input"
+        data-test-editable-text-field-input
+        type="text"
+        value={{this.editingValue}}
+        {{on "input" this.handleInput}}
+        class="text-xl font-bold rounded px-2 py-1 border border-gray-300 dark:border-gray-700 bg-white dark:bg-gray-950 text-gray-900 dark:text-gray-100 focus:outline-none focus:ring-2 focus:ring-teal-500"
+      />
+
+      <div class="flex items-center gap-1">
+        <button
+          type="button"
+          data-test-editable-text-field-confirm-button
+          {{on "click" this.handleUpdate}}
+          class="text-teal-500 hover:text-teal-600 dark:text-teal-400 dark:hover:text-teal-300 text-lg"
+        >
+          {{svg-jar "check" class="w-4 h-4"}}
+        </button>
+        <button
+          type="button"
+          data-test-editable-text-field-cancel-button
+          {{on "click" this.handleCancel}}
+          class="text-red-500 hover:text-red-600 dark:text-red-400 dark:hover:text-red-300 text-lg"
+        >
+          {{svg-jar "x" class="w-4 h-4"}}
+        </button>
+      </div>
+    </div>
+    {{#if @errorMessage}}
+      <div class="text-red-500 text-sm mt-1" data-test-editable-text-field-error>{{@errorMessage}}</div>
+    {{/if}}
+  </div>
+{{else}}
+  <div role="button" data-test-editable-text-field-display {{on "click" this.handleDisplayClick}} class="cursor-pointer" ...attributes>
+    {{yield}}
+  </div>
+{{/if}}

--- a/app/components/editable-text-field.ts
+++ b/app/components/editable-text-field.ts
@@ -1,0 +1,55 @@
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+import { action } from '@ember/object';
+
+interface Signature {
+  Element: HTMLDivElement;
+
+  Args: {
+    value: string;
+    onUpdate: (newValue: string) => void | Promise<void>;
+    errorMessage?: string;
+  };
+
+  Blocks: {
+    default: [];
+  };
+}
+
+export default class EditableTextField extends Component<Signature> {
+  @tracked isEditing = false;
+  @tracked editingValue = '';
+
+  get shouldShowEditMode() {
+    return this.isEditing || !!this.args.errorMessage;
+  }
+
+  @action
+  handleCancel() {
+    this.editingValue = this.args.value;
+    this.isEditing = false;
+  }
+
+  @action
+  handleDisplayClick() {
+    this.editingValue = this.args.value;
+    this.isEditing = true;
+  }
+
+  @action
+  handleInput(event: Event) {
+    this.editingValue = (event.target as HTMLInputElement).value;
+  }
+
+  @action
+  async handleUpdate() {
+    await this.args.onUpdate(this.editingValue);
+    this.isEditing = false;
+  }
+}
+
+declare module '@glint/environment-ember-loose/registry' {
+  export default interface Registry {
+    EditableTextField: typeof EditableTextField;
+  }
+}

--- a/app/controllers/course-admin/code-example-evaluator.ts
+++ b/app/controllers/course-admin/code-example-evaluator.ts
@@ -6,6 +6,7 @@ import type CourseStageModel from 'codecrafters-frontend/models/course-stage';
 import type LanguageModel from 'codecrafters-frontend/models/language';
 import type { CodeExampleEvaluatorRouteModel } from 'codecrafters-frontend/routes/course-admin/code-example-evaluator';
 import fieldComparator from 'codecrafters-frontend/utils/field-comparator';
+import { task } from 'ember-concurrency';
 
 export default class CodeExampleEvaluatorController extends Controller {
   declare model: CodeExampleEvaluatorRouteModel;
@@ -56,4 +57,10 @@ export default class CodeExampleEvaluatorController extends Controller {
   handleRequestedLanguageChange(language: LanguageModel) {
     this.router.transitionTo({ queryParams: { languages: language.slug } });
   }
+
+  updateSlugTask = task({ drop: true }, async (newSlug: string): Promise<void> => {
+    this.model.evaluator.slug = newSlug;
+    await this.model.evaluator.save();
+    await this.router.replaceWith('course-admin.code-example-evaluator', this.model.course.slug, this.model.evaluator.slug).followRedirects();
+  });
 }

--- a/app/mirage/handlers/community-solution-evaluators.js
+++ b/app/mirage/handlers/community-solution-evaluators.js
@@ -8,4 +8,11 @@ export default function (server) {
 
     return schema.communitySolutionEvaluators.create(attrs);
   });
+
+  server.patch('/community-solution-evaluators/:id', function (schema, request) {
+    const evaluator = schema.communitySolutionEvaluators.find(request.params.id);
+    const attrs = this.normalizedRequestAttrs();
+
+    return evaluator.update(attrs);
+  });
 }

--- a/app/models/community-solution-evaluator.ts
+++ b/app/models/community-solution-evaluator.ts
@@ -16,4 +16,9 @@ export default class CommunitySolutionEvaluatorModel extends Model {
 
   @attr('string') declare slug: string;
   @attr('string') declare promptTemplate: string;
+  @attr('string') declare status: 'draft' | 'live';
+
+  get isDraft() {
+    return this.status === 'draft';
+  }
 }

--- a/app/templates/course-admin/code-example-evaluator.hbs
+++ b/app/templates/course-admin/code-example-evaluator.hbs
@@ -1,9 +1,9 @@
-<div class="bg-white min-h-screen">
+<div class="bg-white dark:bg-gray-950 min-h-screen">
   <div class="container mx-auto pt-4 pb-32 px-6">
-    <div class="py-3 border-b border-gray-200 mb-6">
+    <div class="py-3 border-b border-gray-200 dark:border-white/5 mb-6">
       <TertiaryLinkButton @route="course-admin.code-example-evaluators" @models={{array @model.course.slug}} @size="small" class="pl-1.5 mb-3">
         <div class="flex items-center">
-          {{svg-jar "arrow-circle-left" class="w-4 h-4 mr-1.5 text-gray-500"}}
+          {{svg-jar "arrow-circle-left" class="w-4 h-4 mr-1.5 text-gray-500 dark:text-gray-400"}}
 
           <span>
             Back
@@ -12,18 +12,26 @@
       </TertiaryLinkButton>
 
       <div class="flex items-center justify-between">
-        <div>
-          <h3 class="text-xl font-bold text-gray-900">
+        <EditableTextField @value={{@model.evaluator.slug}} @onUpdate={{perform this.updateSlugTask}}>
+          <h3 class="text-xl font-bold text-gray-900 dark:text-gray-100 {{if this.updateSlugTask.isRunning 'animate-pulse'}}">
             {{@model.evaluator.slug}}
           </h3>
-        </div>
-        <div class="flex items-center">
+        </EditableTextField>
+      </div>
+    </div>
+
+    <div>
+      <CourseAdmin::CodeExampleEvaluatorPage::PromptTemplateSection @evaluator={{@model.evaluator}} />
+
+      <div class="py-3 border-b border-gray-200 dark:border-white/5 mb-6 mt-8 flex items-center justify-between">
+        <div class="text-gray-900 dark:text-gray-100 font-semibold mb-1 text-2xl">Results</div>
+
+        <div class="flex items-center gap-3">
           <CourseStageDropdown
             @course={{@model.course}}
             @selectedCourseStage={{this.currentCourseStage}}
             @onAllCourseStagesDropdownLinkClick={{this.handleAllCourseStagesDropdownLinkClick}}
             @onSelectedCourseStageChange={{this.handleCourseStageChange}}
-            class="py-3 mr-4"
           />
 
           <LanguageDropdown
@@ -34,13 +42,9 @@
             @onAllLanguagesDropdownLinkClick={{this.handleAllLanguagesDropdownLinkClick}}
             @onRequestedLanguageChange={{this.handleRequestedLanguageChange}}
             @onDidInsertDropdown={{(noop)}}
-            class="py-3"
           />
         </div>
       </div>
-    </div>
-    <div>
-      <CourseAdmin::CodeExampleEvaluatorPage::PromptTemplateSection @evaluator={{@model.evaluator}} />
 
       <CourseAdmin::CodeExampleEvaluatorPage::AccuracySection @evaluator={{@model.evaluator}} class="mt-8" />
 

--- a/tests/acceptance/course-admin/evaluators/update-prompt-template-test.js
+++ b/tests/acceptance/course-admin/evaluators/update-prompt-template-test.js
@@ -1,0 +1,54 @@
+import codeExampleEvaluatorPage from 'codecrafters-frontend/tests/pages/course-admin/code-example-evaluator-page';
+import testScenario from 'codecrafters-frontend/mirage/scenarios/test';
+import { module, test } from 'qunit';
+import { setupApplicationTest } from 'codecrafters-frontend/tests/helpers';
+import { signInAsStaff } from 'codecrafters-frontend/tests/support/authentication-helpers';
+
+module('Acceptance | course-admin | evaluators | update-prompt-template-test', function (hooks) {
+  setupApplicationTest(hooks);
+
+  hooks.beforeEach(function () {
+    testScenario(this.server);
+    signInAsStaff(this.owner, this.server);
+
+    this.course = this.server.schema.courses.findBy({ slug: 'redis' });
+  });
+
+  test('can update prompt template when evaluator is in draft status', async function (assert) {
+    this.evaluator = this.server.create('community-solution-evaluator', {
+      slug: 'relevance',
+      promptTemplate: 'Is the code example relevant to the prompt?',
+      status: 'draft',
+    });
+
+    await codeExampleEvaluatorPage.visit({ course_slug: this.course.slug, evaluator_slug: this.evaluator.slug });
+
+    assert.strictEqual(
+      codeExampleEvaluatorPage.promptTemplateSection.textareaValue,
+      'Is the code example relevant to the prompt?',
+      'Initial prompt template is shown',
+    );
+    assert.true(codeExampleEvaluatorPage.promptTemplateSection.isUpdateButtonDisabled, 'Update button is disabled when no changes');
+
+    await codeExampleEvaluatorPage.promptTemplateSection.fillTextarea('New prompt template content');
+
+    assert.false(codeExampleEvaluatorPage.promptTemplateSection.isUpdateButtonDisabled, 'Update button is enabled after making changes');
+
+    await codeExampleEvaluatorPage.promptTemplateSection.clickOnUpdateButton();
+
+    assert.strictEqual(this.evaluator.reload().promptTemplate, 'New prompt template content', 'Prompt template is updated in the database');
+    assert.true(codeExampleEvaluatorPage.promptTemplateSection.isUpdateButtonDisabled, 'Update button is disabled after saving');
+  });
+
+  test('cannot update prompt template when evaluator is live', async function (assert) {
+    this.evaluator = this.server.create('community-solution-evaluator', {
+      slug: 'relevance',
+      promptTemplate: 'Is the code example relevant to the prompt?',
+      status: 'live',
+    });
+
+    await codeExampleEvaluatorPage.visit({ course_slug: this.course.slug, evaluator_slug: this.evaluator.slug });
+
+    assert.true(codeExampleEvaluatorPage.promptTemplateSection.isUpdateButtonDisabled, 'Update button is disabled for live evaluators');
+  });
+});

--- a/tests/acceptance/course-admin/evaluators/update-slug-test.js
+++ b/tests/acceptance/course-admin/evaluators/update-slug-test.js
@@ -1,0 +1,36 @@
+import codeExampleEvaluatorPage from 'codecrafters-frontend/tests/pages/course-admin/code-example-evaluator-page';
+import testScenario from 'codecrafters-frontend/mirage/scenarios/test';
+import { currentURL } from '@ember/test-helpers';
+import { module, test } from 'qunit';
+import { setupApplicationTest } from 'codecrafters-frontend/tests/helpers';
+import { signInAsStaff } from 'codecrafters-frontend/tests/support/authentication-helpers';
+
+module('Acceptance | course-admin | evaluators | update-slug-test', function (hooks) {
+  setupApplicationTest(hooks);
+
+  hooks.beforeEach(function () {
+    testScenario(this.server);
+    signInAsStaff(this.owner, this.server);
+
+    this.course = this.server.schema.courses.findBy({ slug: 'redis' });
+
+    this.evaluator = this.server.create('community-solution-evaluator', {
+      slug: 'relevance',
+      promptTemplate: 'Is the code example relevant to the prompt?',
+      status: 'draft',
+    });
+  });
+
+  test('can update evaluator slug', async function (assert) {
+    await codeExampleEvaluatorPage.visit({ course_slug: this.course.slug, evaluator_slug: this.evaluator.slug });
+
+    assert.strictEqual(currentURL(), '/courses/redis/admin/code-example-evaluators/relevance', 'URL is correct initially');
+
+    await codeExampleEvaluatorPage.slugField.clickOnDisplay();
+    await codeExampleEvaluatorPage.slugField.fillInput('new-slug');
+    await codeExampleEvaluatorPage.slugField.clickOnConfirmButton();
+
+    assert.strictEqual(currentURL(), '/courses/redis/admin/code-example-evaluators/new-slug', 'URL is updated after slug change');
+    assert.strictEqual(this.evaluator.reload().slug, 'new-slug', 'Evaluator slug is updated in the database');
+  });
+});

--- a/tests/acceptance/course-admin/evaluators/view-test.js
+++ b/tests/acceptance/course-admin/evaluators/view-test.js
@@ -18,6 +18,7 @@ module('Acceptance | course-admin | evaluators | view-test', function (hooks) {
     this.server.create('community-solution-evaluator', {
       slug: 'relevance',
       promptTemplate: 'Is the code example relevant to the prompt?',
+      status: 'draft',
     });
   });
 

--- a/tests/acceptance/course-admin/view-code-example-evaluator-test.js
+++ b/tests/acceptance/course-admin/view-code-example-evaluator-test.js
@@ -21,6 +21,7 @@ module('Acceptance | course-admin | view-code-example-evaluator', function (hook
     this.evaluator = this.server.create('community-solution-evaluator', {
       slug: 'relevance',
       promptTemplate: 'Is the code example relevant to the prompt?',
+      status: 'draft',
     });
 
     this.solution1 = createCommunityCourseStageSolution(this.server, this.course, 2, this.language);

--- a/tests/pages/course-admin/code-example-evaluator-page.ts
+++ b/tests/pages/course-admin/code-example-evaluator-page.ts
@@ -1,5 +1,6 @@
+import { fillIn } from '@ember/test-helpers';
 import EvaluationCard from 'codecrafters-frontend/tests/pages/components/course-admin/code-examples-page/evaluation-card';
-import { collection, create, visitable } from 'ember-cli-page-object';
+import { clickable, collection, create, fillable, hasClass, text, value, visitable } from 'ember-cli-page-object';
 
 export default create({
   evaluationsSection: {
@@ -11,5 +12,24 @@ export default create({
     },
   },
 
-  visit: visitable('/courses/:course_slug/admin/code-example-evaluators'),
+  promptTemplateSection: {
+    scope: '[data-test-prompt-template-section]',
+    textareaValue: value('#prompt_template'),
+    clickOnUpdateButton: clickable('[data-test-update-prompt-template-button]'),
+    isUpdateButtonDisabled: hasClass('opacity-40', '[data-test-update-prompt-template-button]'),
+
+    async fillTextarea(newText: string) {
+      await fillIn('#prompt_template', newText);
+    },
+  },
+
+  slugField: {
+    clickOnDisplay: clickable('[data-test-editable-text-field-display]'),
+    clickOnConfirmButton: clickable('[data-test-editable-text-field-confirm-button]'),
+    clickOnCancelButton: clickable('[data-test-editable-text-field-cancel-button]'),
+    fillInput: fillable('[data-test-editable-text-field-input]'),
+    inputValue: text('[data-test-editable-text-field-input]'),
+  },
+
+  visit: visitable('/courses/:course_slug/admin/code-example-evaluators/:evaluator_slug'),
 });


### PR DESCRIPTION
Introduce EditableTextField component to support inline text editing with
cancel and confirm actions. Display an input field with action buttons when
editing or when error messages are present. This improves UX by enabling
quick, contextual edits without navigating away.

style(theme): apply dark mode styles across components

Update color classes and text colors in multiple components to support dark
mode. Ensure consistent theming, including text, borders, icons, and backgrounds,
to improve accessibility and visual coherence in dark mode.

refactor(course-admin/code-example-evaluator): enable slug editing inline

Replace static evaluator slug heading with EditableTextField to allow direct
editing of the slug. Connect editing interactions with updateTask to handle
changes asynchronously, streamlining content management workflows.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new inline-editing and save flows for evaluator slug and prompt template, including model persistence and route replacement; mistakes could cause broken admin URLs or unintended saves. Dark-mode class changes are low risk but touch multiple UI components.
> 
> **Overview**
> **Course admin evaluator editing**: The evaluator detail page now supports inline editing of the evaluator `slug` via a new reusable `EditableTextField`, persisting changes and updating the URL after save.
> 
> **Prompt template updates**: The prompt template section is refactored into `ConceptAdmin::FormSection` and now allows saving `promptTemplate` changes *only when the evaluator is `draft`* (disabled otherwise), with an ember-concurrency save task and acceptance coverage.
> 
> **Theming**: Adds dark-mode styles across multiple components (`FormSection`, evaluator page headers, dropdowns, and `StatisticCard`), and updates Mirage to support `PATCH /community-solution-evaluators/:id` plus an evaluator `status` field.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e4509e32fae445bd51b09a90308f64b678f35c75. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->