### PR TITLE
Editable field and evaluations

### DIFF
--- a/app/components/editable-text-field.ts
+++ b/app/components/editable-text-field.ts
@@ -42,8 +42,8 @@ export default class EditableTextField extends Component<Signature> {
   }
 
   @action
-  handleUpdate() {
-    this.args.onUpdate(this.editingValue);
+  async handleUpdate() {
+    await this.args.onUpdate(this.editingValue);
     this.isEditing = false;
   }
 }

--- a/app/routes/course-admin/code-example-evaluator.ts
+++ b/app/routes/course-admin/code-example-evaluator.ts
@@ -134,7 +134,7 @@ export default class CodeExampleEvaluatorRoute extends BaseRoute {
       passEvaluations: await this.loadEvaluations(evaluator, course, languageSlugs, courseStageSlugs, 'pass'),
       failEvaluations: await this.loadEvaluations(evaluator, course, languageSlugs, courseStageSlugs, 'fail'),
       unsureEvaluations: await this.loadEvaluations(evaluator, course, languageSlugs, courseStageSlugs, 'unsure'),
-      trustedEvaluations: [], // await this.loadTrustedEvaluations(evaluator, course, languageSlugs, courseStageSlugs),
+      trustedEvaluations: await this.loadTrustedEvaluations(evaluator, course, languageSlugs, courseStageSlugs),
       filteredLanguageSlugs: params.languages.split(','),
       filteredCourseStageSlugs: params.course_stage_slugs.split(','),
     };


### PR DESCRIPTION
**Checklist**:

- [x] I've thoroughly self-reviewed my changes
- [ ] I've added tests for my changes, unless they affect admin-only areas (or are otherwise not worth testing)
- [ ] I've verified any visual changes using Percy (add a commit with `[percy]` in the message to trigger)

This PR fixes two bugs:

1.  **Async onUpdate callback not awaited**: The `handleUpdate` method in `editable-text-field.ts` now awaits the `onUpdate` callback before exiting edit mode. This ensures that asynchronous save operations complete, preventing data loss or incorrect UI state if the save fails.
2.  **Trusted evaluations loading disabled**: Re-enabled the loading of `trustedEvaluations` in `code-example-evaluator.ts` by uncommenting the `await this.loadTrustedEvaluations(...)` call. This restores the intended functionality, as the previous state was debug code that had been accidentally committed.

---

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes async UI flow and re-enables an additional data query on an admin route; low complexity but may affect perceived save behavior and route load performance/error handling.
> 
> **Overview**
> Fixes `EditableTextField` so `handleUpdate` *awaits* the async `onUpdate` callback before exiting edit mode, preventing UI from switching back to display state before a save finishes.
> 
> Re-enables loading `trustedEvaluations` in `course-admin/code-example-evaluator` by restoring the `loadTrustedEvaluations(...)` call in the route model, so the admin evaluator page again fetches trusted evaluation records.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 12b98ed8854d6d01b289c3f561ef006f89488a33. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->