### PR TITLE
fix(layout): reduce right margin of icons in tab header

### DIFF
--- a/app/components/tab-header.hbs
+++ b/app/components/tab-header.hbs
@@ -11,13 +11,13 @@
   ...attributes
 >
   {{#if @iconUrl}}
-    <img src={{@iconUrl}} alt="icon" class="{{if (eq @size 'small') 'h-4' 'h-5'}} mr-2" />
+    <img src={{@iconUrl}} alt="icon" class="{{if (eq @size 'small') 'h-4' 'h-5'}} mr-1.5" />
   {{else if @icon}}
     {{svg-jar
       @icon
       class=(concat
         (if (eq @size "small") "w-4 " "w-5 ")
-        "mr-2 fill-current "
+        "mr-1.5 fill-current "
         (if
           @isActive
           "text-gray-700 dark:text-gray-400 "


### PR DESCRIPTION
Adjust the right margin of icon images and SVGs in the tab header
component from 0.5rem (mr-2) to 0.375rem (mr-1.5) for better alignment 
and visual balance with surrounding elements. This improves the 
overall aesthetics and consistency of the tab header layout.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only styling tweak that adjusts spacing; no logic, data, or behavioral changes.
> 
> **Overview**
> Tightens spacing in `app/components/tab-header.hbs` by reducing the right margin on both image-based and SVG icons from `mr-2` to `mr-1.5`, improving visual alignment of tab headers.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d0c12b041132e9414b383c72fcd28406f996309a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->