### PR TITLE
feat: add isLive status and display live/draft pills

### DIFF
--- a/app/models/community-solution-evaluator.ts
+++ b/app/models/community-solution-evaluator.ts
@@ -21,4 +21,8 @@ export default class CommunitySolutionEvaluatorModel extends Model {
   get isDraft() {
     return this.status === 'draft';
   }
+
+  get isLive() {
+    return this.status === 'live';
+  }
 }

--- a/app/templates/course-admin/code-example-evaluators.hbs
+++ b/app/templates/course-admin/code-example-evaluators.hbs
@@ -25,6 +25,12 @@
               <div class="min-w-0">
                 <div class="flex items-center gap-x-2">
                   <span class="font-semibold leading-6 text-gray-950 dark:text-gray-100" data-test-evaluator-slug>{{evaluator.slug}}</span>
+
+                  {{#if evaluator.isDraft}}
+                    <Pill @color="gray">Draft</Pill>
+                  {{else if evaluator.isLive}}
+                    <Pill @color="green">Live</Pill>
+                  {{/if}}
                 </div>
               </div>
               <div class="flex flex-none items-center gap-x-4">


### PR DESCRIPTION
Add a new isLive getter to CommunitySolutionEvaluator to identify live
evaluators. Update code-example-evaluators template to show a colored
Pill component indicating whether an evaluator is Draft (gray) or Live
(green). This improves UI clarity by visually distinguishing evaluator
statuses.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI/model change: adds a derived `isLive` getter and surfaces status in the admin list without altering persistence or business logic.
> 
> **Overview**
> Adds an `isLive` getter to `CommunitySolutionEvaluatorModel` alongside `isDraft`.
> 
> Updates `course-admin/code-example-evaluators` to render a status `Pill` next to each evaluator slug, showing **Draft** (gray) or **Live** (green) based on the evaluator status.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f34d2083278b2cee3e5246d49aba7528b8aed8ca. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->