### PR TITLE
feat(accuracy-section): add pass and fail rate statistics

### DIFF
--- a/app/components/course-admin/code-example-evaluator-page/accuracy-section.hbs
+++ b/app/components/course-admin/code-example-evaluator-page/accuracy-section.hbs
@@ -1,7 +1,9 @@
 <div data-test-evaluations-section ...attributes>
   {{! TODO: Use a "generic" statistic component? }}
-  <div class="mt-6 grid grid-cols-1 gap-5 sm:grid-cols-2 mb-6">
+  <div class="mt-6 grid grid-cols-1 gap-5 sm:grid-cols-2 lg:grid-cols-4 mb-6">
+    <CourseAdmin::StageInsightsPage::StatisticCard @statistic={{this.passRateStatistic}} />
     <CourseAdmin::StageInsightsPage::StatisticCard @statistic={{this.falsePositiveRateStatistic}} />
+    <CourseAdmin::StageInsightsPage::StatisticCard @statistic={{this.failRateStatistic}} />
     <CourseAdmin::StageInsightsPage::StatisticCard @statistic={{this.falseNegativeRateStatistic}} />
   </div>
 

--- a/app/components/course-admin/code-example-evaluator-page/accuracy-section.ts
+++ b/app/components/course-admin/code-example-evaluator-page/accuracy-section.ts
@@ -27,6 +27,26 @@ export default class AccuracySection extends Component<Signature> {
     });
   }
 
+  get failRatePercentage() {
+    if (this.allEvaluations.length === 0) {
+      return null;
+    }
+
+    const failCount = this.allEvaluations.filter((e) => e.result === 'fail').length;
+
+    return parseFloat(((100 * failCount) / this.allEvaluations.length).toFixed(2));
+  }
+
+  get failRateStatistic(): CourseStageParticipationAnalysisStatistic {
+    return {
+      title: 'Fail Rate',
+      label: 'fails',
+      value: this.failRatePercentage !== null ? `${this.failRatePercentage}%` : 'No evaluations',
+      color: 'gray',
+      explanationMarkdown: 'The percentage of evaluations that resulted in "fail".',
+    };
+  }
+
   get falseNegativeEvaluations() {
     return this.allEvaluations.filter((evaluation) => {
       return evaluation.result === 'fail' && evaluation.trustedEvaluation?.result === 'pass';
@@ -99,6 +119,26 @@ export default class AccuracySection extends Component<Signature> {
     return this.allEvaluations.filter((evaluation) => {
       return evaluation.result === 'fail' && evaluation.trustedEvaluation;
     });
+  }
+
+  get passRatePercentage() {
+    if (this.allEvaluations.length === 0) {
+      return null;
+    }
+
+    const passCount = this.allEvaluations.filter((e) => e.result === 'pass').length;
+
+    return parseFloat(((100 * passCount) / this.allEvaluations.length).toFixed(2));
+  }
+
+  get passRateStatistic(): CourseStageParticipationAnalysisStatistic {
+    return {
+      title: 'Pass Rate',
+      label: 'passes',
+      value: this.passRatePercentage !== null ? `${this.passRatePercentage}%` : 'No evaluations',
+      color: 'gray',
+      explanationMarkdown: 'The percentage of evaluations that resulted in "pass".',
+    };
   }
 
   get positiveEvaluationsWithTrustedEvaluation() {


### PR DESCRIPTION
Add computed properties to calculate pass and fail rates as percentages
of all evaluations. Introduce corresponding statistic objects to display
these metrics with titles, labels, colors, and explanations. Update the
template to include new statistic cards for pass and fail rates in the
dashboard. This improves insight into evaluation outcomes and helps
monitor accuracy trends more effectively.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only change that adds new computed metrics and cards without altering evaluation data or persistence. Main risk is minor: percentage calculations/empty-state display or layout changes affecting the dashboard.
> 
> **Overview**
> Adds **Pass Rate** and **Fail Rate** metrics to the code example evaluator accuracy dashboard.
> 
> `AccuracySection` now computes overall pass/fail percentages (with a `No evaluations` empty state) and exposes new statistic objects, and the template expands the stats grid to show four cards (pass rate, false positive rate, fail rate, false negative rate).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d0132b4421edc9c14a762d60a96fd8ab4627c637. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->