### PR TITLE
feat(course-admin): add dark mode support to code example insights

### DIFF
--- a/app/components/course-admin/code-example-insights/metadata-container.hbs
+++ b/app/components/course-admin/code-example-insights/metadata-container.hbs
@@ -1,3 +1,3 @@
-<div class="prose prose-sm">
+<div class="prose prose-sm dark:prose-invert">
   {{markdown-to-html this.markdownContent}}
 </div>

--- a/app/routes/course-admin/code-example-insights.ts
+++ b/app/routes/course-admin/code-example-insights.ts
@@ -2,6 +2,7 @@ import BaseRoute from 'codecrafters-frontend/utils/base-route';
 import CommunityCourseStageSolutionModel from 'codecrafters-frontend/models/community-course-stage-solution';
 import Store from '@ember-data/store';
 import fieldComparator from 'codecrafters-frontend/utils/field-comparator';
+import RouteInfoMetadata, { RouteColorScheme } from 'codecrafters-frontend/utils/route-info-metadata';
 import type CourseModel from 'codecrafters-frontend/models/course';
 import type CourseStageModel from 'codecrafters-frontend/models/course-stage';
 import type LanguageModel from 'codecrafters-frontend/models/language';
@@ -15,6 +16,10 @@ export type CodeExampleInsightsRouteModel = {
 
 export default class CodeExampleInsightsRoute extends BaseRoute {
   @service declare store: Store;
+
+  buildRouteInfoMetadata() {
+    return new RouteInfoMetadata({ colorScheme: RouteColorScheme.Both });
+  }
 
   queryParams = {
     language_slug: {

--- a/app/templates/course-admin/code-example-insights.hbs
+++ b/app/templates/course-admin/code-example-insights.hbs
@@ -1,16 +1,16 @@
-<div class="bg-white min-h-screen">
+<div class="bg-white dark:bg-gray-950 min-h-screen">
   <div class="container mx-auto pt-4 pb-10 px-6">
-    <div class="pt-3 pb-6 border-b border-gray-200 flex items-start justify-between mb-8">
+    <div class="pt-3 pb-6 border-b border-gray-200 dark:border-white/5 flex items-start justify-between mb-8">
       <div>
         <TertiaryLinkButton @route="course-admin.code-example-insights-index" @size="small" class="pl-1.5 mb-3">
           <div class="flex items-center">
-            {{svg-jar "arrow-circle-left" class="w-4 h-4 mr-1.5 text-gray-500"}}
+            {{svg-jar "arrow-circle-left" class="w-4 h-4 mr-1.5 text-gray-500 dark:text-gray-400"}}
             <span>
               Back
             </span>
           </div>
         </TertiaryLinkButton>
-        <h3 class="text-xl font-bold text-gray-900">
+        <h3 class="text-xl font-bold text-gray-900 dark:text-gray-100">
           Code Examples in
           {{@model.language.name}}
           for
@@ -35,7 +35,7 @@
       </div>
     </div>
 
-    <div class="prose mb-8">
+    <div class="prose dark:prose-invert mb-8">
       Displaying code examples sorted by
       <div class="inline-block">
         <BasicDropdown as |dd|>
@@ -81,7 +81,7 @@
         </div>
         <CourseAdmin::CodeExampleInsights::MetadataContainer @solution={{solution}} />
         {{#if (not-eq solutionIndex (sub this.sortedSolutions.length 1))}}
-          <div class="col-span-2 bg-gray-200 h-px">
+          <div class="col-span-2 bg-gray-200 dark:bg-white/5 h-px">
           </div>
         {{/if}}
       {{/each}}


### PR DESCRIPTION
Update code example insights UI to support dark mode by adding 
dark variant classes and colors for backgrounds, borders, and text. 
Enhance metadata container with dark mode prose styling. 

Add route metadata specifying a color scheme to enable consistent 
theming across this route. This improves usability in low-light 
environments and aligns with the app-wide dark mode support.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Primarily adds Tailwind dark-mode styling classes and route theming metadata; low risk since it doesn’t alter data fetching or business logic.
> 
> **Overview**
> Enables dark mode for the Course Admin *Code Example Insights* UI by adding `dark:*` Tailwind classes for page background, borders, text, dividers, and prose rendering (including the metadata markdown container).
> 
> The route now implements `buildRouteInfoMetadata()` to return `RouteInfoMetadata({ colorScheme: RouteColorScheme.Both })`, allowing the page to participate in app-wide theming.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 59e84f53519d3f66153fb8cf89b23431afb86cca. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->