### PR TITLE
style: add dark mode support to code example insights page

### DIFF
--- a/app/components/course-admin/code-example-insights-index-page/stage-list-item/index.hbs
+++ b/app/components/course-admin/code-example-insights-index-page/stage-list-item/index.hbs
@@ -1,5 +1,5 @@
 <LinkTo
-  class="flex items-center justify-between flex-wrap gap-x-6 gap-y-2 py-3 group/stage-list-item hover:bg-gray-50 px-1"
+  class="flex items-center justify-between flex-wrap gap-x-6 gap-y-2 py-3 group/stage-list-item hover:bg-gray-50 dark:hover:bg-gray-900 px-1"
   data-test-code-example-insights-index-list-item
   role="button"
   @route="course-admin.code-example-insights"
@@ -9,8 +9,8 @@
 >
   <div class="min-w-0">
     <div class="flex items-center flex-wrap gap-2">
-      <div class="font-semibold text-sm text-gray-700">{{@stage.name}}</div>
-      <svg viewBox="0 0 2 2" class="h-0.5 w-0.5 fill-current text-gray-300">
+      <div class="font-semibold text-sm text-gray-700 dark:text-gray-200">{{@stage.name}}</div>
+      <svg viewBox="0 0 2 2" class="h-0.5 w-0.5 fill-current text-gray-300 dark:text-gray-700">
         <circle cx="1" cy="1" r="1" />
       </svg>
       <CourseAdmin::CodeExampleInsightsIndexPage::StageListItem::Statistic
@@ -24,14 +24,14 @@
       @statistic={{this.analysis.medianChangedLinesStatistic}}
       @fallbackLabel="lines"
     />
-    <svg viewBox="0 0 2 2" class="h-0.5 w-0.5 fill-current text-gray-300">
+    <svg viewBox="0 0 2 2" class="h-0.5 w-0.5 fill-current text-gray-300 dark:text-gray-700">
       <circle cx="1" cy="1" r="1" />
     </svg>
     <CourseAdmin::CodeExampleInsightsIndexPage::StageListItem::Statistic
       @statistic={{this.analysis.upvotesCountStatistic}}
       @fallbackLabel="upvotes"
     />
-    <svg viewBox="0 0 2 2" class="h-0.5 w-0.5 fill-current text-gray-300">
+    <svg viewBox="0 0 2 2" class="h-0.5 w-0.5 fill-current text-gray-300 dark:text-gray-700">
       <circle cx="1" cy="1" r="1" />
     </svg>
     <CourseAdmin::CodeExampleInsightsIndexPage::StageListItem::Statistic

--- a/app/components/course-admin/code-example-insights-index-page/stage-list-item/statistic.hbs
+++ b/app/components/course-admin/code-example-insights-index-page/stage-list-item/statistic.hbs
@@ -8,7 +8,7 @@
       -
     {{/if}}
   </div>
-  <div class="text-gray-400">
+  <div class="text-gray-400 dark:text-gray-500">
     {{#if @statistic}}
       {{@statistic.label}}
     {{else if @fallbackLabel}}

--- a/app/components/course-admin/code-example-insights-index-page/stage-list-item/statistic.ts
+++ b/app/components/course-admin/code-example-insights-index-page/stage-list-item/statistic.ts
@@ -13,14 +13,14 @@ interface Signature {
 export default class Statistic extends Component<Signature> {
   get valueColorClasses(): string {
     if (!this.args.statistic) {
-      return 'text-gray-500';
+      return 'text-gray-500 dark:text-gray-400';
     }
 
     return {
-      green: 'text-teal-500',
-      yellow: 'text-yellow-500',
-      red: 'text-red-500',
-      gray: 'text-gray-500',
+      green: 'text-teal-500 dark:text-teal-400',
+      yellow: 'text-yellow-500 dark:text-yellow-400',
+      red: 'text-red-500 dark:text-red-400',
+      gray: 'text-gray-500 dark:text-gray-400',
     }[this.args.statistic.color];
   }
 }

--- a/app/templates/course-admin/code-example-insights-index.hbs
+++ b/app/templates/course-admin/code-example-insights-index.hbs
@@ -1,11 +1,11 @@
-<div class="bg-white min-h-screen" data-test-code-example-insights-index-page>
+<div class="bg-white dark:bg-gray-950 min-h-screen" data-test-code-example-insights-index-page>
   <div class="container mx-auto pt-4 pb-10 px-6">
-    <div class="pt-3 pb-6 border-b border-gray-200 flex items-start justify-between">
+    <div class="pt-3 pb-6 border-b border-gray-200 dark:border-white/10 flex items-start justify-between">
       <div>
-        <h3 class="text-lg font-bold text-gray-900 mb-1">
+        <h3 class="text-lg font-bold text-gray-900 dark:text-gray-100 mb-1">
           Code Examples 🚧 (Work in progress!)
         </h3>
-        <div class="text-xs text-gray-400">
+        <div class="text-xs text-gray-400 dark:text-gray-500">
           Summaries of code examples submitted by users.
         </div>
       </div>
@@ -22,31 +22,31 @@
 
     {{#if @model.selectedLanguage}}
       {{#if (gt @model.course.stages.length 0)}}
-        <ul role="list" class="divide-y divide-gray-100">
+        <ul role="list" class="divide-y divide-gray-100 dark:divide-white/5">
           {{#each @model.course.sortedBaseStages as |stage|}}
             <CourseAdmin::CodeExampleInsightsIndexPage::StageListItem @stage={{stage}} @language={{@model.selectedLanguage}} />
           {{/each}}
         </ul>
 
         {{#each @model.course.sortedExtensions as |extension|}}
-          <h3 class="font-semibold text-gray-400 text-center relative mt-8 mb-3">
-            <span class="block h-px w-full bg-gray-200 absolute top-50-percent -mt-px"></span>
-            <span class="relative px-6 bg-white">{{extension.name}}</span>
+          <h3 class="font-semibold text-gray-400 dark:text-gray-500 text-center relative mt-8 mb-3">
+            <span class="block h-px w-full bg-gray-200 dark:bg-white/10 absolute top-50-percent -mt-px"></span>
+            <span class="relative px-6 bg-white dark:bg-gray-950">{{extension.name}}</span>
           </h3>
 
-          <ul role="list" class="divide-y divide-gray-100">
+          <ul role="list" class="divide-y divide-gray-100 dark:divide-white/5">
             {{#each extension.sortedStages as |stage|}}
               <CourseAdmin::CodeExampleInsightsIndexPage::StageListItem @stage={{stage}} @language={{@model.selectedLanguage}} />
             {{/each}}
           </ul>
         {{/each}}
       {{else}}
-        <div class="text-gray-400 py-32 flex items-center justify-center">
+        <div class="text-gray-400 dark:text-gray-500 py-32 flex items-center justify-center">
           No stages found.
         </div>
       {{/if}}
     {{else}}
-      <div class="text-gray-400 py-32 flex items-center justify-center">
+      <div class="text-gray-400 dark:text-gray-500 py-32 flex items-center justify-center">
         No language selected.
       </div>
     {{/if}}


### PR DESCRIPTION
Update styles throughout the code example insights index page and its
components to support dark mode. Adjust text colors, background colors,
borders, and svg fills to ensure readability and appropriate contrast
when dark mode is enabled. This improves the user experience for users
who prefer or use dark themes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this PR only adjusts Tailwind classes for dark-mode colors (backgrounds, borders, text, and separators) without changing data flow or behavior.
> 
> **Overview**
> Adds dark mode styling to the Course Admin Code Example Insights index page and stage list items.
> 
> Updates templates/components to apply `dark:` Tailwind classes for page background, borders/dividers, hover states, text/labels, and SVG separator colors, and extends `StageListItem::Statistic.valueColorClasses` to provide dark-mode variants for each statistic color.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 74cba9680d1dc54db596927e6105e300287d2f5d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->