### PR TITLE
feat(course-admin): add more dropdown to evaluate more solutions

### DIFF
--- a/app/components/course-admin/code-example-evaluator-page/more-dropdown.hbs
+++ b/app/components/course-admin/code-example-evaluator-page/more-dropdown.hbs
@@ -1,0 +1,17 @@
+<div class="flex items-center justify-center">
+  <BasicDropdown @horizontalPosition="right" as |dd|>
+    <dd.Trigger>
+      {{svg-jar "dots-horizontal" class=(concat "w-4 transform transition-all " (if dd.isOpen "text-teal-500" "text-gray-500"))}}
+    </dd.Trigger>
+    <dd.Content>
+      <div class="py-2 border border-gray-200 dark:border-white/10 rounded-sm shadow-sm bg-white dark:bg-gray-925" data-test-more-dropdown-content>
+        <DropdownLink
+          @text="Evaluate more solutions"
+          @icon="plus-circle"
+          {{on "click" (fn this.handleEvaluateMoreSolutionsClick dd.actions)}}
+          data-test-evaluate-more-solutions-link
+        />
+      </div>
+    </dd.Content>
+  </BasicDropdown>
+</div>

--- a/app/components/course-admin/code-example-evaluator-page/more-dropdown.ts
+++ b/app/components/course-admin/code-example-evaluator-page/more-dropdown.ts
@@ -1,0 +1,24 @@
+import Component from '@glimmer/component';
+import { action } from '@ember/object';
+
+interface Signature {
+  Element: HTMLButtonElement;
+
+  Args: {
+    onEvaluateMoreSolutionsClick: () => void;
+  };
+}
+
+export default class MoreDropdown extends Component<Signature> {
+  @action
+  handleEvaluateMoreSolutionsClick(dropdownActions: { close: () => void }) {
+    this.args.onEvaluateMoreSolutionsClick();
+    dropdownActions.close();
+  }
+}
+
+declare module '@glint/environment-ember-loose/registry' {
+  export default interface Registry {
+    'CourseAdmin::CodeExampleEvaluatorPage::MoreDropdown': typeof MoreDropdown;
+  }
+}

--- a/app/controllers/course-admin/code-example-evaluator.ts
+++ b/app/controllers/course-admin/code-example-evaluator.ts
@@ -61,7 +61,7 @@ export default class CodeExampleEvaluatorController extends Controller {
     this.router.transitionTo({ queryParams: { languages: language.slug } });
   }
 
-  evaluateSolutionsTask = task({ drop: true }, async (): Promise<void> => {
+  evaluateMoreSolutionsTask = task({ drop: true }, async (): Promise<void> => {
     const dummyRecord = this.store.createRecord('community-solution-evaluation') as CommunitySolutionEvaluationModel;
 
     await dummyRecord.generate({

--- a/app/templates/course-admin/code-example-evaluator.hbs
+++ b/app/templates/course-admin/code-example-evaluator.hbs
@@ -28,9 +28,7 @@
         <div class="text-gray-900 dark:text-gray-100 font-semibold mb-1 text-2xl">Results</div>
 
         <div class="flex items-center gap-3">
-          <SecondaryButton {{on "click" (perform this.evaluateSolutionsTask)}}>
-            Evaluate solutions
-          </SecondaryButton>
+          <CourseAdmin::CodeExampleEvaluatorPage::MoreDropdown @onEvaluateMoreSolutionsClick={{perform this.evaluateMoreSolutionsTask}} />
 
           <CourseStageDropdown
             @course={{@model.course}}


### PR DESCRIPTION
Replace the standalone "Evaluate solutions" button with a new MoreDropdown
component that houses the "Evaluate more solutions" action. This change improves
the UI by grouping related actions in a dropdown, enhancing user experience and
allowing for future extensibility. The dropdown toggles its icon color based on
open state, and closes automatically after triggering the evaluation task.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI refactor that swaps a button for a dropdown and renames the associated concurrency task; core evaluation behavior appears unchanged aside from the dropdown auto-closing.
> 
> **Overview**
> Replaces the standalone "Evaluate solutions" button on `course-admin/code-example-evaluator` with a new `MoreDropdown` (three-dots trigger) that exposes an "Evaluate more solutions" action.
> 
> Renames `evaluateSolutionsTask` to `evaluateMoreSolutionsTask` and wires the dropdown click handler to perform the task and then close the dropdown.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2da98bb860ed656b5b72831c336593c00d699036. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->