### PR TITLE
feat: add "regenerate all evaluations" action and improve stats display

### DIFF
--- a/app/components/course-admin/code-example-evaluator-page/accuracy-section.ts
+++ b/app/components/course-admin/code-example-evaluator-page/accuracy-section.ts
@@ -66,18 +66,12 @@ export default class AccuracySection extends Component<Signature> {
     return {
       title: 'False Negative Rate',
       label: 'false negatives',
-      value:
-        this.falseNegativePercentage !== null
-          ? `${this.falseNegativePercentage}%`
-          : `${this.negativeEvaluationsWithTrustedEvaluation.length} datapoints (need 10)`,
-      color:
-        this.falseNegativePercentage !== null && this.falseNegativePercentage < 10
-          ? 'green'
-          : this.negativeEvaluationsWithTrustedEvaluation.length >= 10
-            ? 'red'
-            : 'gray',
+      value: this.falseNegativePercentage !== null ? `${this.falseNegativePercentage}%` : null,
+      color: this.falseNegativePercentage !== null && this.falseNegativePercentage < 10 ? 'green' : 'red',
       explanationMarkdown:
-        'The percentage of "fail" evaluations that did not match human values. \n\nNeeds at least 10 trusted evaluations for comparison.',
+        this.falseNegativePercentage !== null
+          ? `The percentage of "fail" evaluations that did not match human values.\n\nTotal datapoints: ${this.negativeEvaluationsWithTrustedEvaluation.length}`
+          : `The percentage of "fail" evaluations that did not match human values.\n\nOnly ${this.negativeEvaluationsWithTrustedEvaluation.length}/10 datapoints available`,
     };
   }
 
@@ -100,18 +94,12 @@ export default class AccuracySection extends Component<Signature> {
     return {
       title: 'False Positive Rate',
       label: 'false positives',
-      value:
-        this.falsePositivePercentage !== null
-          ? `${this.falsePositivePercentage}%`
-          : `${this.positiveEvaluationsWithTrustedEvaluation.length} datapoints (need 10)`,
-      color:
-        this.falsePositivePercentage !== null && this.falsePositivePercentage < 10
-          ? 'green'
-          : this.positiveEvaluationsWithTrustedEvaluation.length >= 10
-            ? 'red'
-            : 'gray',
+      value: this.falsePositivePercentage !== null ? `${this.falsePositivePercentage}%` : null,
+      color: this.falsePositivePercentage !== null && this.falsePositivePercentage < 10 ? 'green' : 'red',
       explanationMarkdown:
-        'The percentage of "pass" evaluations that did not match human values. \n\nNeeds at least 10 trusted evaluations for comparison.',
+        this.falsePositivePercentage !== null
+          ? `The percentage of "pass" evaluations that did not match human values.\n\nTotal datapoints: ${this.positiveEvaluationsWithTrustedEvaluation.length}`
+          : `The percentage of "pass" evaluations that did not match human values.\n\nOnly ${this.positiveEvaluationsWithTrustedEvaluation.length}/10 datapoints available`,
     };
   }
 

--- a/app/components/course-admin/code-example-evaluator-page/more-dropdown.hbs
+++ b/app/components/course-admin/code-example-evaluator-page/more-dropdown.hbs
@@ -11,6 +11,12 @@
           {{on "click" (fn this.handleEvaluateMoreSolutionsClick dd.actions)}}
           data-test-evaluate-more-solutions-link
         />
+        <DropdownLink
+          @text="Regenerate all evaluations"
+          @icon="refresh"
+          {{on "click" (fn this.handleRegenerateAllEvaluationsClick dd.actions)}}
+          data-test-regenerate-all-evaluations-link
+        />
       </div>
     </dd.Content>
   </BasicDropdown>

--- a/app/components/course-admin/code-example-evaluator-page/more-dropdown.ts
+++ b/app/components/course-admin/code-example-evaluator-page/more-dropdown.ts
@@ -6,6 +6,7 @@ interface Signature {
 
   Args: {
     onEvaluateMoreSolutionsClick: () => void;
+    onRegenerateAllEvaluationsClick: () => void;
   };
 }
 
@@ -13,6 +14,12 @@ export default class MoreDropdown extends Component<Signature> {
   @action
   handleEvaluateMoreSolutionsClick(dropdownActions: { close: () => void }) {
     this.args.onEvaluateMoreSolutionsClick();
+    dropdownActions.close();
+  }
+
+  @action
+  handleRegenerateAllEvaluationsClick(dropdownActions: { close: () => void }) {
+    this.args.onRegenerateAllEvaluationsClick();
     dropdownActions.close();
   }
 }

--- a/app/components/course-admin/stage-insights-page/statistic-card.hbs
+++ b/app/components/course-admin/stage-insights-page/statistic-card.hbs
@@ -15,6 +15,10 @@
   </div>
 
   <div class="mt-1 text-4xl font-semibold tracking-tight {{this.valueColorClasses}}">
-    {{@statistic.value}}
+    {{#if @statistic.value}}
+      {{@statistic.value}}
+    {{else}}
+      -
+    {{/if}}
   </div>
 </div>

--- a/app/controllers/course-admin/code-example-evaluator.ts
+++ b/app/controllers/course-admin/code-example-evaluator.ts
@@ -73,6 +73,10 @@ export default class CodeExampleEvaluatorController extends Controller {
     dummyRecord.unloadRecord();
   });
 
+  regenerateAllEvaluationsTask = task({ drop: true }, async (): Promise<void> => {
+    await this.model.evaluator.regenerateAllEvaluations({});
+  });
+
   updateSlugTask = task({ drop: true }, async (newSlug: string): Promise<void> => {
     this.model.evaluator.slug = newSlug;
     await this.model.evaluator.save();

--- a/app/models/community-solution-evaluator.ts
+++ b/app/models/community-solution-evaluator.ts
@@ -1,4 +1,5 @@
 import Model, { attr, belongsTo, hasMany } from '@ember-data/model';
+import { memberAction } from 'ember-api-actions';
 import type CourseModel from './course';
 import type LanguageModel from './language';
 import type CommunitySolutionEvaluationModel from './community-solution-evaluation';
@@ -26,4 +27,11 @@ export default class CommunitySolutionEvaluatorModel extends Model {
   get isLive() {
     return this.status === 'live';
   }
+
+  declare regenerateAllEvaluations: (this: Model, payload: unknown) => Promise<void>;
 }
+
+CommunitySolutionEvaluatorModel.prototype.regenerateAllEvaluations = memberAction({
+  path: 'regenerate_all_evaluations',
+  type: 'post',
+});

--- a/app/templates/course-admin/code-example-evaluator.hbs
+++ b/app/templates/course-admin/code-example-evaluator.hbs
@@ -28,7 +28,10 @@
         <div class="text-gray-900 dark:text-gray-100 font-semibold mb-1 text-2xl">Results</div>
 
         <div class="flex items-center gap-3">
-          <CourseAdmin::CodeExampleEvaluatorPage::MoreDropdown @onEvaluateMoreSolutionsClick={{perform this.evaluateMoreSolutionsTask}} />
+          <CourseAdmin::CodeExampleEvaluatorPage::MoreDropdown
+            @onEvaluateMoreSolutionsClick={{perform this.evaluateMoreSolutionsTask}}
+            @onRegenerateAllEvaluationsClick={{perform this.regenerateAllEvaluationsTask}}
+          />
 
           <CourseStageDropdown
             @course={{@model.course}}


### PR DESCRIPTION
Add a member action to CommunitySolutionEvaluatorModel to trigger
regeneration of all evaluations via API. Update the code example evaluator
UI to include a dropdown link that calls this new action.

Simplify false positive/negative rate display by showing percentages only
when available, otherwise show datapoint counts as explanatory text with
improved clarity. Change color logic to only green/red to better reflect
thresholds.

Modify statistic card to show '-' when no value is present, preventing
empty display areas and improving UI consistency.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new API-triggering action to regenerate all evaluations, which can have high operational impact if invoked unintentionally or frequently. Remaining changes are UI-only display tweaks for statistics.
> 
> **Overview**
> Adds a new **“Regenerate all evaluations”** action in the code example evaluator UI that triggers a new `POST` member action (`regenerate_all_evaluations`) on `CommunitySolutionEvaluatorModel`, wired via a controller task.
> 
> Refines accuracy statistics: false positive/negative cards now show a percentage only once the 10-datapoint threshold is met (otherwise show `-`), move datapoint counts into the tooltip explanation, and simplify coloring to green/red. The statistic card component now renders `-` when `@statistic.value` is null/empty.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 502924159c3dec3c493181b7df5dfad4cac83d79. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->