### PR TITLE
feat: track source URLs for fetched file contents

### DIFF
--- a/app/components/course-admin/code-example-evaluator-page/context-section.hbs
+++ b/app/components/course-admin/code-example-evaluator-page/context-section.hbs
@@ -8,12 +8,12 @@
       {{#if @evaluator.isDraft}}
         <Toggle
           @isDisabled={{this.updateContextTask.isRunning}}
-          @isOn={{this.isUsingChangedFiles}}
+          @isOn={{this.isUsingHighlightedLines}}
           {{on "click" this.handleToggle}}
           data-test-context-toggle
         />
       {{else}}
-        <Toggle @isOn={{this.isUsingChangedFiles}} @isDisabled={{true}} data-test-context-toggle />
+        <Toggle @isOn={{this.isUsingHighlightedLines}} @isDisabled={{true}} data-test-context-toggle />
       {{/if}}
 
       <span class="text-sm text-gray-700 dark:text-gray-300 {{if this.updateContextTask.isRunning 'animate-pulse'}}">
@@ -23,7 +23,7 @@
 
     <div class="prose dark:prose-invert prose-xs mt-4 {{if this.updateContextTask.isRunning 'animate-pulse'}}">
       <p class="text-gray-600 dark:text-gray-400">
-        {{#if this.isUsingChangedFiles}}
+        {{#if this.isUsingHighlightedLines}}
           The criteria will only be applied to highlighted lines.
         {{else}}
           The criteria will be applied to all lines (within files that contain highlighted lines).

--- a/app/components/course-admin/code-example-evaluator-page/context-section.ts
+++ b/app/components/course-admin/code-example-evaluator-page/context-section.ts
@@ -12,8 +12,8 @@ export interface Signature {
 }
 
 export default class ContextSection extends Component<Signature> {
-  get isUsingChangedFiles() {
-    return this.args.evaluator.context === 'changed_files';
+  get isUsingHighlightedLines() {
+    return this.args.evaluator.context === 'highlighted_lines';
   }
 
   @action
@@ -22,7 +22,7 @@ export default class ContextSection extends Component<Signature> {
       return;
     }
 
-    this.args.evaluator.context = this.isUsingChangedFiles ? 'diff' : 'changed_files';
+    this.args.evaluator.context = this.isUsingHighlightedLines ? 'highlighted_files' : 'highlighted_lines';
     this.updateContextTask.perform();
   }
 

--- a/app/models/community-solution-evaluation.ts
+++ b/app/models/community-solution-evaluation.ts
@@ -20,7 +20,9 @@ export default class CommunitySolutionEvaluationModel extends Model {
   @attr('date') declare updatedAt: Date;
 
   @tracked logsFileContents: string | null = null;
+  @tracked logsFileContentsSource: string | null = null; // The url used to fetch the logs file contents
   @tracked promptFileContents: string | null = null;
+  @tracked promptFileContentsSource: string | null = null; // The url used to fetch the prompt file contents
 
   get oppositeResult(): 'pass' | 'fail' {
     switch (this.result) {
@@ -38,11 +40,11 @@ export default class CommunitySolutionEvaluationModel extends Model {
   }
 
   async fetchLogsFileContentsIfNeeded(): Promise<void> {
-    return fetchFileContentsIfNeeded(this, 'logsFileUrl', 'logsFileContents');
+    return fetchFileContentsIfNeeded(this, this.logsFileUrl, 'logsFileContents', 'logsFileContentsSource');
   }
 
   async fetchPromptFileContentsIfNeeded(): Promise<void> {
-    return fetchFileContentsIfNeeded(this, 'promptFileUrl', 'promptFileContents');
+    return fetchFileContentsIfNeeded(this, this.promptFileUrl, 'promptFileContents', 'promptFileContentsSource');
   }
 
   declare generate: (this: Model, payload: { evaluator_id: string; course_stage_id?: string; language_id?: string }) => Promise<void>;

--- a/app/models/community-solution-evaluator.ts
+++ b/app/models/community-solution-evaluator.ts
@@ -15,7 +15,7 @@ export default class CommunitySolutionEvaluatorModel extends Model {
   @hasMany('trusted-community-solution-evaluation', { async: false, inverse: 'evaluator' })
   declare trustedEvaluations: TrustedCommunitySolutionEvaluationModel[];
 
-  @attr('string') declare context: 'diff' | 'changed_files';
+  @attr('string') declare context: 'highlighted_lines' | 'highlighted_files';
   @attr('string') declare promptTemplate: string;
   @attr('string') declare slug: string;
   @attr('string') declare status: 'draft' | 'live';

--- a/app/models/submission-evaluation.ts
+++ b/app/models/submission-evaluation.ts
@@ -9,8 +9,9 @@ export default class SubmissionEvaluationModel extends Model {
   @attr('string') declare logsFileUrl: string;
 
   @tracked logsFileContents: string | null = null;
+  @tracked logsFileContentsSource: string | null = null;
 
   async fetchLogsFileContentsIfNeeded(): Promise<void> {
-    return fetchFileContentsIfNeeded(this, 'logsFileUrl', 'logsFileContents');
+    return fetchFileContentsIfNeeded(this, this.logsFileUrl, 'logsFileContents', 'logsFileContentsSource');
   }
 }

--- a/app/utils/fetch-file-contents-if-needed.ts
+++ b/app/utils/fetch-file-contents-if-needed.ts
@@ -1,24 +1,26 @@
 import * as Sentry from '@sentry/ember';
 import Model from '@ember-data/model';
 
-export async function fetchFileContentsIfNeeded<U extends string, C extends string>(
-  model: Model & { [key in U]: string } & { [key in C]: string | null },
-  fileUrlProperty: U,
+export async function fetchFileContentsIfNeeded<S extends string, C extends string>(
+  model: Model & { [key in S]: string | null } & { [key in C]: string | null },
+  fileUrl: string,
   fileContentsProperty: C,
+  fileContentsSourceProperty: S,
 ) {
-  if (model[fileContentsProperty]) {
+  if (model[fileContentsProperty] && model[fileContentsSourceProperty] && model[fileContentsSourceProperty] === fileUrl) {
     return;
   }
 
-  if (!model[fileUrlProperty]) {
+  if (!fileUrl) {
     return;
   }
 
   try {
-    const response = await fetch(model[fileUrlProperty]!);
+    const response = await fetch(fileUrl);
 
     if (response.status === 200) {
       (model[fileContentsProperty] as string) = (await response.text()) as string;
+      (model[fileContentsSourceProperty] as string) = fileUrl;
     } else {
       Sentry.captureMessage(`Failed to fetch logs file for submission evaluation`, {
         extra: { response_status: response.status, response_body: await response.text(), model_id: model.id },


### PR DESCRIPTION
Add tracked properties to store the URLs used to fetch logs and prompt
file contents in community solution and submission evaluations. Update
fetchFileContentsIfNeeded to accept and check these source URLs, avoiding
unnecessary refetching when the URL hasn't changed.

Also, rename context toggling in code-example-evaluator-page from
'changed_files' to 'highlighted_lines' to better reflect intended usage
and update related UI bindings accordingly.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes persisted `CommunitySolutionEvaluatorModel.context` values and the toggle logic, which can break compatibility with existing records/API expectations. The fetch change is low risk but alters caching behavior and could mask updates if URLs change without content source tracking being reset.
> 
> **Overview**
> Updates file-content fetching to be **source-aware**: `fetchFileContentsIfNeeded` now takes the URL directly and stores it in a new tracked “source” property, avoiding refetches only when the cached contents match the same URL.
> 
> Renames the code example evaluator context toggle from `diff/changed_files` to `highlighted_lines/highlighted_files`, updating the `ContextSection` UI bindings and `CommunitySolutionEvaluatorModel.context` union accordingly.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5fe84086bbf48b463d0bc8a1d471c72731bf12cb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->