### PR TITLE
refactor: improve filters and enhance insights metadata display

### DIFF
--- a/app/components/course-admin/code-example-insights/metadata-container.ts
+++ b/app/components/course-admin/code-example-insights/metadata-container.ts
@@ -23,7 +23,11 @@ export default class CodeExampleInsightsMetadata extends Component<Signature> {
         } else if (evaluation.result === 'fail') {
           results.push(`❌ Failed \`${evaluation.evaluator.slug}\` check`);
         } else {
-          results.push(`⚠️ ${evaluation.result}ed \`${evaluation.evaluator.slug}\` check`);
+          results.push(`⚠️ ${evaluation.result} \`${evaluation.evaluator.slug}\` check`);
+        }
+
+        if (evaluation.evaluator.isDraft) {
+          results[results.length - 1] += ' (draft)';
         }
       }
 

--- a/app/routes/course-admin/code-example-evaluator.ts
+++ b/app/routes/course-admin/code-example-evaluator.ts
@@ -34,10 +34,9 @@ export default class CodeExampleEvaluatorRoute extends BaseRoute {
     },
   };
 
-  buildContextFilters(course: CourseModel, languageSlugsFilter: string[], courseStageSlugsFilter: string[]): Record<string, string> {
-    const filters: Record<string, string> = {
-      course_id: course.id,
-    };
+  buildContextFilters(_course: CourseModel, languageSlugsFilter: string[], courseStageSlugsFilter: string[]): Record<string, string> {
+    // TODO: Add a course_id filter if the evaluator is course-specific
+    const filters: Record<string, string> = {};
 
     if (languageSlugsFilter.length > 0) {
       filters['language_slugs'] = languageSlugsFilter.join(',');

--- a/app/routes/course-admin/code-example-insights-index.ts
+++ b/app/routes/course-admin/code-example-insights-index.ts
@@ -1,5 +1,6 @@
 import { service } from '@ember/service';
 import BaseRoute from 'codecrafters-frontend/utils/base-route';
+import RouteInfoMetadata, { RouteColorScheme } from 'codecrafters-frontend/utils/route-info-metadata';
 import Store from '@ember-data/store';
 import type CourseModel from 'codecrafters-frontend/models/course';
 import type LanguageModel from 'codecrafters-frontend/models/language';
@@ -15,6 +16,10 @@ export type ModelType = {
 
 export default class CodeExampleInsightsIndexRoute extends BaseRoute {
   @service declare store: Store;
+
+  buildRouteInfoMetadata() {
+    return new RouteInfoMetadata({ colorScheme: RouteColorScheme.Both });
+  }
 
   queryParams = {
     language_slug: {


### PR DESCRIPTION
Remove the course_id filter from buildContextFilters to allow for
more flexible evaluator filtering; add a TODO to revisit this for
course-specific evaluators. Update metadata-container to correctly
display evaluation results without misleading suffixes and append
"(draft)" to indicate draft evaluators clearly. Add consistent route
color scheme metadata in the code-example-insights-index route for
better UI theming and user experience.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because removing the `course_id` filter broadens evaluator/trusted-evaluation queries and could change which records show up. Other changes are UI/metadata-only and low impact.
> 
> **Overview**
> Updates the insights metadata text to avoid misleading “`result`ed” suffixes and to label draft evaluators by appending “(draft)” to the relevant evaluation line.
> 
> Relaxes `code-example-evaluator` query filtering by removing the default `course_id` constraint (with a TODO to re-add it for course-specific evaluators), and adds `RouteInfoMetadata` color scheme settings to `code-example-insights-index` for consistent theming.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5ef8426285d84eb16353e55e2b55f871ff4063da. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->