### PR TITLE
feat(evaluations): add run evaluators action and generation APIs

### DIFF
--- a/app/components/course-page/course-stage-step/community-solution-card/more-dropdown.hbs
+++ b/app/components/course-page/course-stage-step/community-solution-card/more-dropdown.hbs
@@ -22,6 +22,12 @@
 
       {{#if (current-user-is-staff)}}
         <DropdownLink @text="Copy ID" @icon="clipboard-copy" {{on "click" (fn this.handleCopyIdLinkClick dd.actions)}} data-test-copy-id-link />
+        <DropdownLink
+          @text="Run evaluators"
+          @icon="play"
+          {{on "click" (fn this.handleRunEvaluatorsClick dd.actions)}}
+          data-test-run-evaluators-link
+        />
       {{/if}}
     </div>
   </dd.Content>

--- a/app/controllers/course-admin/code-example-evaluator.ts
+++ b/app/controllers/course-admin/code-example-evaluator.ts
@@ -64,7 +64,7 @@ export default class CodeExampleEvaluatorController extends Controller {
   evaluateMoreSolutionsTask = task({ drop: true }, async (): Promise<void> => {
     const dummyRecord = this.store.createRecord('community-solution-evaluation') as CommunitySolutionEvaluationModel;
 
-    await dummyRecord.generate({
+    await dummyRecord.generateForEvaluator({
       evaluator_id: this.model.evaluator.id,
       course_stage_id: this.currentCourseStage?.id,
       language_id: this.currentLanguage?.id,

--- a/app/mirage/handlers/community-solution-evaluations.js
+++ b/app/mirage/handlers/community-solution-evaluations.js
@@ -18,6 +18,14 @@ export default function (server) {
     return evaluation;
   });
 
+  server.post('/community-solution-evaluations/generate_for_evaluator', (schema) => {
+    return schema.communitySolutionEvaluations.all();
+  });
+
+  server.post('/community-solution-evaluations/generate_for_solutions', (schema) => {
+    return schema.communitySolutionEvaluations.all();
+  });
+
   server.get('/fake-community-solution-evaluation-logs', () => {
     return new Response(200, {}, 'Test log');
   });

--- a/app/models/community-solution-evaluation.ts
+++ b/app/models/community-solution-evaluation.ts
@@ -47,12 +47,22 @@ export default class CommunitySolutionEvaluationModel extends Model {
     return fetchFileContentsIfNeeded(this, this.promptFileUrl, 'promptFileContents', 'promptFileContentsSource');
   }
 
-  declare generate: (this: Model, payload: { evaluator_id: string; course_stage_id?: string; language_id?: string }) => Promise<void>;
+  declare generateForEvaluator: (this: Model, payload: { evaluator_id: string; course_stage_id?: string; language_id?: string }) => Promise<void>;
+  declare generateForSolutions: (this: Model, payload: { solution_ids: string[] }) => Promise<void>;
   declare regenerate: (this: Model, payload: unknown) => Promise<void>;
 }
 
-CommunitySolutionEvaluationModel.prototype.generate = collectionAction({
-  path: 'generate',
+CommunitySolutionEvaluationModel.prototype.generateForEvaluator = collectionAction({
+  path: 'generate_for_evaluator',
+  type: 'post',
+
+  after(response) {
+    this.store.pushPayload(response);
+  },
+});
+
+CommunitySolutionEvaluationModel.prototype.generateForSolutions = collectionAction({
+  path: 'generate_for_solutions',
   type: 'post',
 
   after(response) {

--- a/tests/acceptance/course-page/code-examples/toggle-diff-source-test.js
+++ b/tests/acceptance/course-page/code-examples/toggle-diff-source-test.js
@@ -34,14 +34,14 @@ module('Acceptance | course-page | code-examples | toggle-diff-source', function
     const moreDropdown = codeExamplesPage.solutionCards[0].moreDropdown;
 
     await codeExamplesPage.solutionCards[0].toggleMoreDropdown();
-    await waitUntil(() => moreDropdown.links.length === 3);
+    await waitUntil(() => moreDropdown.links.length >= 3);
     assert.ok(moreDropdown.hasLink('View full diff'), 'expected View full diff link to be present');
     assert.notOk(moreDropdown.hasLink('View highlighted files'), 'expected View highlighted files link to not be present');
 
     await moreDropdown.clickOnLink('View full diff');
 
     await codeExamplesPage.solutionCards[0].toggleMoreDropdown();
-    await waitUntil(() => moreDropdown.links.length === 3);
+    await waitUntil(() => moreDropdown.links.length >= 3);
     assert.notOk(moreDropdown.hasLink('View full diff'), 'expected View full diff link to be removed');
     assert.ok(moreDropdown.hasLink('View highlighted files'), 'expected View highlighted files link to be present');
   });


### PR DESCRIPTION
Add POST endpoints and model actions to generate community solution
evaluations for evaluator or solution IDs. Implement a new task in the
MoreDropdown component to trigger evaluation generation for the current
solution. Add a "Run evaluators" dropdown link for staff users to easily
invoke this task from the UI. These changes enable on-demand triggering
of evaluation runs, improving workflow efficiency for evaluation tasks.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new evaluation-generation endpoints and wires them into staff UI actions, which can trigger server-side evaluation work and relies on new API contracts. Risk is moderate due to new side-effecting POST flows, but scope is limited to staff tooling and evaluation generation.
> 
> **Overview**
> Adds two new community-solution evaluation generation actions: `generate_for_evaluator` (used by the admin evaluator page) and `generate_for_solutions` (used for ad-hoc runs on specific solution IDs), replacing the prior generic `generate` action.
> 
> Exposes the new capability in the course page code examples UI for staff by adding a **Run evaluators** option to the solution card “More” dropdown, backed by a `runEvaluatorsTask` that posts `solution_ids`. Updates Mirage handlers for the new endpoints and relaxes an acceptance test assertion to allow the dropdown to contain additional links.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e9b06652516c8c71c9011cae599cfb339a92b444. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->