### PR TITLE
feat(context-section): add tooltip for disabled toggle in non-draft mode

### DIFF
--- a/app/components/course-admin/code-example-evaluator-page/context-section.hbs
+++ b/app/components/course-admin/code-example-evaluator-page/context-section.hbs
@@ -13,7 +13,10 @@
           data-test-context-toggle
         />
       {{else}}
-        <Toggle @isOn={{this.isUsingHighlightedLines}} @isDisabled={{true}} data-test-context-toggle />
+        <span>
+          <Toggle @isOn={{this.isUsingHighlightedLines}} @isDisabled={{true}} data-test-context-toggle />
+          <EmberTooltip @text="Only available for draft evaluators" />
+        </span>
       {{/if}}
 
       <span class="text-sm text-gray-700 dark:text-gray-300 {{if this.updateContextTask.isRunning 'animate-pulse'}}">
@@ -30,11 +33,5 @@
         {{/if}}
       </p>
     </div>
-
-    {{#unless @evaluator.isDraft}}
-      <p class="text-xs text-gray-400 dark:text-gray-600 mt-2">
-        Only available for draft evaluators
-      </p>
-    {{/unless}}
   </:content>
 </ConceptAdmin::FormSection>


### PR DESCRIPTION
Display an EmberTooltip explaining that the toggle is only available
for draft evaluators when the toggle is disabled. Remove redundant
text message that previously indicated this below the toggle to 
improve clarity and reduce UI clutter.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only change: adds a tooltip and removes redundant helper text without affecting evaluator logic or persistence.
> 
> **Overview**
> In `context-section.hbs`, when the evaluator is not a draft, the disabled `Toggle` is now wrapped with an `EmberTooltip` explaining it’s **only available for draft evaluators**.
> 
> Removes the separate below-toggle hint text that previously conveyed the same message, reducing UI clutter while keeping the toggle state unchanged.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f14244d5a744d5583c293f1bb9de05d48cc3b465. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->