### PR TITLE
feat(code-example-insights): add real-time updates and rerun option

### DIFF
--- a/app/components/course-admin/code-example-insights/metadata-container.hbs
+++ b/app/components/course-admin/code-example-insights/metadata-container.hbs
@@ -1,3 +1,14 @@
 <div class="prose prose-sm dark:prose-invert">
   {{markdown-to-html this.markdownContent}}
+
+  {{#each @solution.evaluations as |evaluation|}}
+    <div
+      {{on-action-cable-message
+        (perform this.refreshEvaluationsTask)
+        channel="CommunitySolutionEvaluationChannel"
+        args=(hash community_solution_evaluation_id=evaluation.id)
+      }}
+    >
+    </div>
+  {{/each}}
 </div>

--- a/app/components/course-admin/code-example-insights/more-dropdown.hbs
+++ b/app/components/course-admin/code-example-insights/more-dropdown.hbs
@@ -1,0 +1,17 @@
+<div class="flex items-center justify-center" ...attributes>
+  <BasicDropdown @horizontalPosition="right" as |dd|>
+    <dd.Trigger>
+      {{svg-jar "dots-horizontal" class=(concat "w-4 transform transition-all " (if dd.isOpen "text-teal-500" "text-gray-500"))}}
+    </dd.Trigger>
+    <dd.Content>
+      <div class="py-2 border border-gray-200 dark:border-white/10 rounded-sm shadow-sm bg-white dark:bg-gray-925" data-test-more-dropdown-content>
+        <DropdownLink
+          @text="Re-run evaluators"
+          @icon="play"
+          {{on "click" (fn this.handleReRunEvaluatorsClick dd.actions)}}
+          data-test-rerun-evaluators-link
+        />
+      </div>
+    </dd.Content>
+  </BasicDropdown>
+</div>

--- a/app/components/course-admin/code-example-insights/more-dropdown.ts
+++ b/app/components/course-admin/code-example-insights/more-dropdown.ts
@@ -1,0 +1,24 @@
+import Component from '@glimmer/component';
+import { action } from '@ember/object';
+
+interface Signature {
+  Element: HTMLDivElement;
+
+  Args: {
+    onReRunEvaluatorsClick: () => void;
+  };
+}
+
+export default class MoreDropdown extends Component<Signature> {
+  @action
+  handleReRunEvaluatorsClick(dropdownActions: { close: () => void }) {
+    this.args.onReRunEvaluatorsClick();
+    dropdownActions.close();
+  }
+}
+
+declare module '@glint/environment-ember-loose/registry' {
+  export default interface Registry {
+    'CourseAdmin::CodeExampleInsights::MoreDropdown': typeof MoreDropdown;
+  }
+}

--- a/app/templates/course-admin/code-example-insights.hbs
+++ b/app/templates/course-admin/code-example-insights.hbs
@@ -18,6 +18,7 @@
         </h3>
       </div>
       <div class="flex items-center gap-3">
+        <CourseAdmin::CodeExampleInsights::MoreDropdown @onReRunEvaluatorsClick={{perform this.runEvaluatorsForAllSolutionsTask}} />
         <CourseStageDropdown
           @course={{@model.courseStage.course}}
           @selectedCourseStage={{@model.courseStage}}


### PR DESCRIPTION
Add real-time updates for solution evaluations using Action Cable to 
automatically refresh evaluations when changes occur. Introduce a new 
"More" dropdown menu in the insights UI with an option to re-run all 
evaluators for the current solutions. Implement a new ember-concurrency 
task in the controller to trigger evaluation reruns via creating a dummy 
evaluation record.

These changes improve UX by keeping evaluation data fresh and provide a 
convenient way for admins to manually refresh all evaluations without 
page reloads.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces ActionCable-triggered reloads and a bulk evaluator rerun action, which may increase client/server load or cause race/performance issues if many evaluations/solutions are present.
> 
> **Overview**
> Adds **real-time updates** for Code Example Insights evaluation metadata by subscribing to `CommunitySolutionEvaluationChannel` per evaluation and reloading evaluations via a new `refreshEvaluationsTask`.
> 
> Adds a new `MoreDropdown` with a **“Re-run evaluators”** action, wiring it to a controller `runEvaluatorsForAllSolutionsTask` that bulk-triggers evaluator generation for the currently listed solutions via `community-solution-evaluation.generateForSolutions`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ff376ce480095b4e82cf1ed3d088f594a3e72167. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->