### PR TITLE
feat(challenge-logos): add Claude Code logo to course model

### DIFF
--- a/app/models/course.ts
+++ b/app/models/course.ts
@@ -11,6 +11,7 @@ import Model, { attr, hasMany } from '@ember-data/model';
 import TimeService from 'codecrafters-frontend/services/time';
 import UserModel from 'codecrafters-frontend/models/user';
 import bittorrentLogo from '/assets/images/challenge-logos/challenge-logo-bittorrent.svg';
+import claudeCodeLogo from '/assets/images/challenge-logos/challenge-logo-claude-code.svg';
 import dnsServerLogo from '/assets/images/challenge-logos/challenge-logo-dns-server.svg';
 import dockerLogo from '/assets/images/challenge-logos/challenge-logo-docker.svg';
 import gitLogo from '/assets/images/challenge-logos/challenge-logo-git.svg';
@@ -153,6 +154,7 @@ export default class CourseModel extends Model {
     return (
       {
         bittorrent: bittorrentLogo,
+        'claude-code': claudeCodeLogo,
         'dns-server': dnsServerLogo,
         docker: dockerLogo,
         git: gitLogo,


### PR DESCRIPTION
**Checklist**:

- [x] I've thoroughly self-reviewed my changes
- [ ] I've added tests for my changes, unless they affect admin-only areas (or are otherwise not worth testing)
- [ ] I've verified any visual changes using Percy (add a commit with `[percy]` in the message to trigger)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a new static asset import and a `slug`→logo mapping entry, with no behavioral changes beyond logo selection for the new course slug.
> 
> **Overview**
> Adds support for rendering a Claude Code course logo by importing `challenge-logo-claude-code.svg` and mapping the `claude-code` course `slug` to it in `CourseModel.logoUrl`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 386e9b3c71d195136f853935a9783f921f6454e0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->