### PR TITLE
Concept cards UI styling

### DIFF
--- a/app/components/concept-card/progress-bar.hbs
+++ b/app/components/concept-card/progress-bar.hbs
@@ -1,23 +1,15 @@
 <div class="flex items-center" data-test-concept-card-progress ...attributes>
-  <div class="rounded-sm overflow-hidden mr-2">
-    <div
-      class="{{if (eq @latestConceptEngagement.currentProgressPercentage 100) 'bg-teal-100 dark:bg-teal-900' 'bg-blue-100 dark:bg-blue-900'}}
-        h-3 w-16 flex items-stretch"
-    >
-      <div
-        class="{{if (eq @latestConceptEngagement.currentProgressPercentage 100) 'bg-teal-500 dark:bg-teal-600' 'bg-blue-500 dark:bg-blue-600'}}"
-        style={{html-safe (concat "width: " @latestConceptEngagement.currentProgressPercentage "%")}}
-        data-test-concept-card-progress-bar
-      ></div>
-    </div>
+  <div class="size-5 mr-1.5">
+    <ProgressDonut
+      @total={{100}}
+      @completed={{@latestConceptEngagement.currentProgressPercentage}}
+      @color="teal"
+      data-test-concept-card-progress-bar
+      data-test-concept-card-progress-donut
+    />
   </div>
 
-  <div
-    class="text-xs
-      {{if (eq @latestConceptEngagement.currentProgressPercentage 100) 'text-teal-500 dark:text-teal-600' 'text-blue-500 dark:text-blue-600'}}
-      mr-3"
-    data-test-concept-card-progress-text
-  >
+  <div class="text-xs text-teal-500 mr-3" data-test-concept-card-progress-text>
     <b class="font-bold">{{@latestConceptEngagement.currentProgressPercentage}}%</b>
     complete
   </div>

--- a/app/components/concepts-page/concept-card.hbs
+++ b/app/components/concepts-page/concept-card.hbs
@@ -33,7 +33,7 @@
     <div class="flex items-center">
       {{#if (and this.latestConceptEngagement (gt this.latestConceptEngagement.currentProgressPercentage 0))}}
         {{#if (eq this.latestConceptEngagement.currentProgressPercentage 100)}}
-          {{svg-jar "check-circle" class="w-4 mr-1 fill-current text-teal-500"}}
+          {{svg-jar "check-circle" class="size-5 text-teal-500 mr-1"}}
 
           <span class="text-xs text-teal-500">
             completed


### PR DESCRIPTION
This pull request contains changes generated by a Cursor Cloud Agent

<a href="https://cursor.com/background-agent?bcId=bc-5d9c0dae-31d8-4ba7-b5b3-ab6bb11fd1f6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-5d9c0dae-31d8-4ba7-b5b3-ab6bb11fd1f6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk visual-only template changes; main impact is progress/completion styling consistency and potential CSS/layout regressions.
> 
> **Overview**
> Concept cards now render in-progress completion using the shared `ProgressDonut` component (replacing the custom linear bar) and always display the progress text in teal.
> 
> The completed state icon styling is adjusted (size/class changes) to better match the new progress indicator.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 268bab578725348cf6aa3bc045aeaeada0d3b26b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->