### PR TITLE
Update CLI command references from `cc test` to `cc submit`

### DIFF
--- a/app/components/course-page/course-stage-step/first-stage-your-task-card/submit-code-step.hbs
+++ b/app/components/course-page/course-stage-step/first-stage-your-task-card/submit-code-step.hbs
@@ -1,6 +1,6 @@
 {{#if this.featureFlags.canViewCLIPingFlow}}
   <div>
-    <CopyableTerminalCommand @commands={{array "codecrafters test"}} class="mb-1.5" />
+    <CopyableTerminalCommand @commands={{array "codecrafters submit"}} class="mb-1.5" />
 
     <div class="flex items-center gap-0.5 pl-0.5">
       {{svg-jar "question-mark-circle" class="w-3 h-3 fill-current text-blue-500"}}

--- a/app/components/course-page/course-stage-step/test-runner-card/run-tests-instructions.ts
+++ b/app/components/course-page/course-stage-step/test-runner-card/run-tests-instructions.ts
@@ -30,7 +30,7 @@ export default class RunTestsInstructions extends Component<Signature> {
   get commandVariants(): CopyableTerminalCommandVariant[] {
     const cliVariant = {
       label: 'codecrafters cli',
-      commands: ['codecrafters test # Visit https://codecrafters.io/cli to install'],
+      commands: ['codecrafters submit # Visit https://codecrafters.io/cli to install'],
     };
 
     const gitVariant = {

--- a/app/components/course-page/setup-step-complete-modal/workflow-tutorial-step2-screen.hbs
+++ b/app/components/course-page/setup-step-complete-modal/workflow-tutorial-step2-screen.hbs
@@ -6,7 +6,7 @@
   <div class="px-3 sm:px-6 py-6 bg-gray-50 dark:bg-gray-925 rounded-sm border border-gray-200 dark:border-gray-700 mb-6">
     <div class="mb-4 font-bold text-lg text-gray-700 dark:text-gray-100 text-center text-pretty">
       {{#if this.featureFlags.canViewCLIPingFlow}}
-        Run `codecrafters test`
+        Run `codecrafters submit`
       {{else}}
         `git push` to submit
       {{/if}}
@@ -15,7 +15,7 @@
     <div class="prose prose-sm dark:prose-invert mb-4 text-center text-pretty">
       <p>
         {{#if this.featureFlags.canViewCLIPingFlow}}
-          Once you're ready to test your code, simply run `codecrafters test`.
+          Once you're ready to test your code, simply run `codecrafters submit`.
         {{else}}
           When you're ready to test, commit your changes and run `git push`.
         {{/if}}

--- a/tests/acceptance/course-page/test-runner-card-test.js
+++ b/tests/acceptance/course-page/test-runner-card-test.js
@@ -54,7 +54,7 @@ module('Acceptance | course-page | test-runner-card', function (hooks) {
 
     assert.strictEqual(
       coursePage.testRunnerCard.copyableTerminalCommands[0].copyableText,
-      'codecrafters test # Visit https://codecrafters.io/cli to install',
+      'codecrafters submit # Visit https://codecrafters.io/cli to install',
       'copyable text mentions cli after switching back',
     );
   });
@@ -90,7 +90,7 @@ module('Acceptance | course-page | test-runner-card', function (hooks) {
 
     assert.strictEqual(
       coursePage.testRunnerCard.copyableTerminalCommands[0].copyableText,
-      'codecrafters test # Visit https://codecrafters.io/cli to install',
+      'codecrafters submit # Visit https://codecrafters.io/cli to install',
       'copyable text mentions cli by default',
     );
 
@@ -106,7 +106,7 @@ module('Acceptance | course-page | test-runner-card', function (hooks) {
 
     assert.strictEqual(
       coursePage.testRunnerCard.copyableTerminalCommands[0].copyableText,
-      'codecrafters test # Visit https://codecrafters.io/cli to install',
+      'codecrafters submit # Visit https://codecrafters.io/cli to install',
       'copyable text mentions cli after switching back',
     );
   });


### PR DESCRIPTION
**Checklist**:

- [x] I've thoroughly self-reviewed my changes
- [ ] I've added tests for my changes, unless they affect admin-only areas (or are otherwise not worth testing)
- [ ] I've verified any visual changes using Percy (add a commit with `[percy]` in the message to trigger)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk string-only changes to instructional UI and related acceptance test expectations; no functional logic or data-flow changes beyond the displayed CLI command.
> 
> **Overview**
> Updates the course page and setup workflow copy to instruct CLI users to run `codecrafters submit` instead of `codecrafters test` (including the copyable terminal command and tutorial text).
> 
> Adjusts the test runner’s CLI command variant and the acceptance tests to expect `codecrafters submit` in the generated copyable command text.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 770d75fd20e1c3e72397482dcfe98332c8d538af. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->