### PR TITLE
Votable ideas archived filter

### DIFF
--- a/app/models/course.ts
+++ b/app/models/course.ts
@@ -218,7 +218,7 @@ export default class CourseModel extends Model {
   }
 
   get votableExtensionIdeas() {
-    return this.extensionIdeas.filter((idea) => !idea.developmentStatusIsReleased);
+    return this.extensionIdeas.filter((idea) => !idea.isArchived && !idea.developmentStatusIsReleased);
   }
 
   availableLanguageConfigurationsForUser(user: UserModel) {


### PR DESCRIPTION
**Checklist**:

- [x] I've thoroughly self-reviewed my changes
- [ ] I've added tests for my changes, unless they affect admin-only areas (or are otherwise not worth testing)
- [ ] I've verified any visual changes using Percy (add a commit with `[percy]` in the message to trigger)

Fixes a bug where archived extension ideas were included in the `votableExtensionIdeas` count. This change ensures consistency with other parts of the application by excluding archived ideas, providing users with an accurate count of truly votable ideas.

---

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: a single filter condition change on a computed list that only affects UI counts/visibility of extension ideas.
> 
> **Overview**
> Fixes `CourseModel.votableExtensionIdeas` to exclude archived extension ideas (in addition to already excluding released ones), so places that rely on `votableExtensionIdeas.length` show an accurate count of ideas users can still vote on.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2d77485c80d6a7cff59d64ef5353bcf1ca56e0e7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->