### PR TITLE
refactor: simplify code-example-evaluator route model loading

### DIFF
--- a/app/routes/course-admin/code-example-evaluator.ts
+++ b/app/routes/course-admin/code-example-evaluator.ts
@@ -5,20 +5,14 @@ import type CourseModel from 'codecrafters-frontend/models/course';
 import type CommunitySolutionEvaluatorModel from 'codecrafters-frontend/models/community-solution-evaluator';
 import type RouterService from '@ember/routing/router-service';
 import type LanguageModel from 'codecrafters-frontend/models/language';
-import type CommunitySolutionEvaluationModel from 'codecrafters-frontend/models/community-solution-evaluation';
-import type TrustedCommunitySolutionEvaluationModel from 'codecrafters-frontend/models/trusted-community-solution-evaluation';
 import RouteInfoMetadata, { RouteColorScheme } from 'codecrafters-frontend/utils/route-info-metadata';
 
 export type CodeExampleEvaluatorRouteModel = {
   course: CourseModel;
-  languages: LanguageModel[];
+  allLanguages: LanguageModel[];
   evaluator: CommunitySolutionEvaluatorModel;
   filteredLanguageSlugs: string[];
   filteredCourseStageSlugs: string[];
-  trustedEvaluations: TrustedCommunitySolutionEvaluationModel[];
-  passEvaluations: CommunitySolutionEvaluationModel[];
-  failEvaluations: CommunitySolutionEvaluationModel[];
-  unsureEvaluations: CommunitySolutionEvaluationModel[];
 };
 
 export default class CodeExampleEvaluatorRoute extends BaseRoute {
@@ -34,81 +28,8 @@ export default class CodeExampleEvaluatorRoute extends BaseRoute {
     },
   };
 
-  buildContextFilters(_course: CourseModel, languageSlugsFilter: string[], courseStageSlugsFilter: string[]): Record<string, string> {
-    // TODO: Add a course_id filter if the evaluator is course-specific
-    const filters: Record<string, string> = {};
-
-    if (languageSlugsFilter.length > 0) {
-      filters['language_slugs'] = languageSlugsFilter.join(',');
-    }
-
-    if (courseStageSlugsFilter.length > 0) {
-      filters['course_stage_slugs'] = courseStageSlugsFilter.join(',');
-    }
-
-    return filters;
-  }
-
   buildRouteInfoMetadata() {
     return new RouteInfoMetadata({ colorScheme: RouteColorScheme.Both });
-  }
-
-  async loadEvaluations(
-    evaluator: CommunitySolutionEvaluatorModel,
-    course: CourseModel,
-    languageSlugsFilter: string[],
-    courseStageSlugsFilter: string[],
-    resultFilter: string,
-  ): Promise<CommunitySolutionEvaluationModel[]> {
-    const filters = this.buildContextFilters(course, languageSlugsFilter, courseStageSlugsFilter);
-
-    if (resultFilter) {
-      filters['result'] = resultFilter;
-    }
-
-    return (await this.store.query('community-solution-evaluation', {
-      ...filters,
-      ...{
-        evaluator_id: evaluator.id,
-        limit: 30,
-        include: [
-          'community-solution',
-          'community-solution.user',
-          'community-solution.language',
-          'community-solution.course-stage',
-          'community-solution.trusted-evaluations',
-          'community-solution.trusted-evaluations.community-solution',
-          'community-solution.trusted-evaluations.creator',
-          'community-solution.trusted-evaluations.evaluator',
-          'evaluator',
-        ].join(','),
-      },
-    })) as unknown as CommunitySolutionEvaluationModel[];
-  }
-
-  async loadTrustedEvaluations(
-    evaluator: CommunitySolutionEvaluatorModel,
-    course: CourseModel,
-    languageSlugsFilter: string[],
-    courseStageSlugsFilter: string[],
-  ): Promise<TrustedCommunitySolutionEvaluationModel[]> {
-    const filters = this.buildContextFilters(course, languageSlugsFilter, courseStageSlugsFilter);
-
-    return (await this.store.query('trusted-community-solution-evaluation', {
-      ...filters,
-      ...{
-        evaluator_id: evaluator.id,
-        include: [
-          'creator',
-          'community-solution',
-          'community-solution.user',
-          'community-solution.language',
-          'community-solution.course-stage',
-          'community-solution.evaluations',
-          'evaluator',
-        ].join(','),
-      },
-    })) as unknown as TrustedCommunitySolutionEvaluationModel[];
   }
 
   async model(params: { evaluator_slug: string; languages: string; course_stage_slugs: string }): Promise<CodeExampleEvaluatorRouteModel> {
@@ -127,17 +48,10 @@ export default class CodeExampleEvaluatorRoute extends BaseRoute {
       return {} as CodeExampleEvaluatorRouteModel;
     }
 
-    const languageSlugs = params.languages.split(',');
-    const courseStageSlugs = params.course_stage_slugs.split(',');
-
     return {
       course: course,
-      languages: (await this.store.findAll('language')) as unknown as LanguageModel[],
+      allLanguages: (await this.store.findAll('language')) as unknown as LanguageModel[],
       evaluator: evaluator,
-      passEvaluations: await this.loadEvaluations(evaluator, course, languageSlugs, courseStageSlugs, 'pass'),
-      failEvaluations: await this.loadEvaluations(evaluator, course, languageSlugs, courseStageSlugs, 'fail'),
-      unsureEvaluations: await this.loadEvaluations(evaluator, course, languageSlugs, courseStageSlugs, 'unsure'),
-      trustedEvaluations: await this.loadTrustedEvaluations(evaluator, course, languageSlugs, courseStageSlugs),
       filteredLanguageSlugs: params.languages.split(','),
       filteredCourseStageSlugs: params.course_stage_slugs.split(','),
     };

--- a/app/templates/course-admin/code-example-evaluator.hbs
+++ b/app/templates/course-admin/code-example-evaluator.hbs
@@ -56,9 +56,9 @@
 
       <CourseAdmin::CodeExampleEvaluatorPage::EvaluationsSection
         @evaluator={{@model.evaluator}}
-        @passEvaluations={{@model.passEvaluations}}
-        @failEvaluations={{@model.failEvaluations}}
-        @unsureEvaluations={{@model.unsureEvaluations}}
+        @passEvaluations={{this.passEvaluations}}
+        @failEvaluations={{this.failEvaluations}}
+        @unsureEvaluations={{this.unsureEvaluations}}
         class="mt-8"
       />
     </div>


### PR DESCRIPTION
Remove loading and filtering of evaluation subsets (pass, fail, unsure,
trusted) and drop helper methods for building filters and loading evaluations.
Load all languages instead of filtered languages. Streamline the model method
to simplify data requirements and reduce complexity. This change improves
maintainability by removing unused filtering logic and unused related types.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the evaluation data-loading lifecycle from route model hooks to controller-managed async tasks, which can affect when/if results refresh on initial render and query-param changes.
> 
> **Overview**
> **Refactors the `course-admin/code-example-evaluator` page to simplify the route model and shift evaluation fetching into the controller.** The route now only loads `course`, `evaluator`, `allLanguages`, and the parsed filter slugs, removing evaluation/trusted-evaluation types and the route’s filter/query helpers.
> 
> The controller now owns `pass`/`fail`/`unsure` evaluation lists as `@tracked` state and adds a `loadEvaluationsTask` that queries the store (plus trusted evaluations) in parallel and exposes an `isLoadingEvaluations` flag. The template switches to reading evaluations from controller state instead of `@model`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 431f83184a0a0e243df43b45039f7936243b7e96. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->