### PR TITLE
Add extension ideas cta to completed card

### DIFF
--- a/app/components/course-page/configure-extensions-modal/index.ts
+++ b/app/components/course-page/configure-extensions-modal/index.ts
@@ -1,11 +1,9 @@
 import Component from '@glimmer/component';
 import type Owner from '@ember/owner';
-import CourseExtensionIdeaModel from 'codecrafters-frontend/models/course-extension-idea';
 import RepositoryModel from 'codecrafters-frontend/models/repository';
 import type Store from '@ember-data/store';
 import { action } from '@ember/object';
 import { service } from '@ember/service';
-import { tracked } from '@glimmer/tracking';
 import fieldComparator from 'codecrafters-frontend/utils/field-comparator';
 
 interface Signature {
@@ -19,7 +17,6 @@ interface Signature {
 
 export default class ConfigureExtensionsModal extends Component<Signature> {
   @service declare store: Store;
-  @tracked allCourseExtensionIdeas: CourseExtensionIdeaModel[] = [];
 
   constructor(owner: Owner, args: Signature['Args']) {
     super(owner, args);
@@ -27,18 +24,14 @@ export default class ConfigureExtensionsModal extends Component<Signature> {
   }
 
   get orderedCourseExtensionIdeas() {
-    return this.allCourseExtensionIdeas
-      .filter((item) => !item.isArchived)
-      .filter((item) => item.course === this.args.repository.course)
-      .filter((item) => item.developmentStatus !== 'released')
-      .sort(fieldComparator('sortPositionForRoadmapPage'));
+    return this.args.repository.course.votableExtensionIdeas.sort(fieldComparator('sortPositionForRoadmapPage'));
   }
 
   @action
   async loadAllCourseExtensionIdeas() {
-    this.allCourseExtensionIdeas = (await this.store.findAll('course-extension-idea', {
+    await this.store.findAll('course-extension-idea', {
       include: 'course,current-user-votes,current-user-votes.user',
-    })) as unknown as CourseExtensionIdeaModel[];
+    });
   }
 }
 

--- a/app/components/course-page/course-completed-card.hbs
+++ b/app/components/course-page/course-completed-card.hbs
@@ -1,4 +1,4 @@
-<CoursePage::InstructionsCard ...attributes data-test-course-completed-card>
+<CoursePage::InstructionsCard ...attributes data-test-course-completed-card {{did-insert this.handleDidInsert}}>
   <:header>
     <div class="flex items-center mb-6 border-b border-gray-200 dark:border-white/5 pb-2">
       <img src={{this.congratulationsImage}} alt="Congratulations!" class="mr-3 w-10 h-10" />
@@ -40,6 +40,20 @@
         {{markdown-to-html @repository.course.completionMessageMarkdown}}
       {{/if}}
     </div>
+
+    {{#if (gt @repository.course.votableExtensionIdeas.length 0)}}
+      <div class="mt-4">
+        <div class="prose dark:prose-invert">
+          <p>
+            Vote and let us know what extensions you'd like to see for this challenge:
+          </p>
+        </div>
+
+        <PrimaryLinkButton @route="roadmap.course-extension-ideas" @query={{hash course=@repository.course.slug}} class="mt-4">
+          Vote on extension ideas
+        </PrimaryLinkButton>
+      </div>
+    {{/if}}
   </:content>
 </CoursePage::InstructionsCard>
 

--- a/app/components/course-page/course-completed-card.ts
+++ b/app/components/course-page/course-completed-card.ts
@@ -1,7 +1,11 @@
+import { action } from '@ember/object';
+import { service } from '@ember/service';
+import { task } from 'ember-concurrency';
 import { tracked } from '@glimmer/tracking';
 import Component from '@glimmer/component';
 import congratulationsImage from '/assets/images/icons/congratulations.png';
 import type RepositoryModel from 'codecrafters-frontend/models/repository';
+import type Store from '@ember-data/store';
 
 interface Signature {
   Element: HTMLDivElement;
@@ -12,9 +16,23 @@ interface Signature {
 }
 
 export default class CourseCompletedCard extends Component<Signature> {
+  @service declare store: Store;
+
   congratulationsImage = congratulationsImage;
 
   @tracked configureGithubIntegrationModalIsOpen = false;
+
+  loadExtensionIdeasTask = task({ drop: true }, async (): Promise<void> => {
+    await this.store.query('course-extension-idea', {
+      course_id: this.args.repository.course.id,
+      include: 'course,current-user-votes,current-user-votes.user',
+    });
+  });
+
+  @action
+  handleDidInsert() {
+    this.loadExtensionIdeasTask.perform();
+  }
 }
 
 declare module '@glint/environment-ember-loose/registry' {

--- a/app/controllers/course/completed.js
+++ b/app/controllers/course/completed.js
@@ -1,7 +1,0 @@
-import Controller from '@ember/controller';
-
-export default class CourseSetupController extends Controller {
-  get currentStep() {
-    return this.model.stepList.steps[this.model.stepList.steps.length - 1];
-  }
-}

--- a/app/controllers/course/completed.ts
+++ b/app/controllers/course/completed.ts
@@ -1,0 +1,6 @@
+import Controller from '@ember/controller';
+import type { ModelType as CourseRouteModelType } from 'codecrafters-frontend/routes/course';
+
+export default class CourseCompletedController extends Controller {
+  declare model: CourseRouteModelType;
+}

--- a/app/models/course.ts
+++ b/app/models/course.ts
@@ -217,6 +217,10 @@ export default class CourseModel extends Model {
     return `https://github.com/${this.testerRepositoryFullName}`;
   }
 
+  get votableExtensionIdeas() {
+    return this.extensionIdeas.filter((idea) => !idea.developmentStatusIsReleased && !idea.isArchived);
+  }
+
   availableLanguageConfigurationsForUser(user: UserModel) {
     return this.languageConfigurations.filter((languageConfiguration) => languageConfiguration.isAvailableForUser(user));
   }

--- a/app/templates/course/completed.hbs
+++ b/app/templates/course/completed.hbs
@@ -1,4 +1,3 @@
-{{! @glint-nocheck: not typesafe yet !}}
 <div class="pt-8 pb-16 px-3 md:px-6 lg:px-10">
   <CoursePage::CourseCompletedCard @repository={{@model.activeRepository}} />
 </div>


### PR DESCRIPTION
Introduce a typed CourseCompletedController to provide better type safety
for the model received from the course route. Remove the outdated and unused
CourseSetupController to clean up the codebase. Also remove a non-typesafe
annotation from the completed course template to streamline template code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new client-side fetch on course completion to conditionally render a CTA, which can impact perceived performance or fail if the API/query params change; otherwise changes are localized to UI/model logic.
> 
> **Overview**
> Adds a **new call-to-action on the course completed page** that prompts users to vote on extension ideas, shown only when the course has any non-archived, non-released ideas.
> 
> To support this, the completed card now triggers a `course-extension-idea` query on insert, and `CourseModel` gains `votableExtensionIdeas` which is reused by both the completed card and the extensions configuration modal (removing local filtering/state there).
> 
> Also replaces the old `course/completed` controller with a typed `CourseCompletedController` and removes a `@glint-nocheck` from `course/completed.hbs`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 876331ecf58724e7a6745ec927af59fe224d4668. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->