### PR TITLE
Duplicate JavaScript files deletion

### DIFF
--- a/app/components/course-page/configure-github-integration-modal/step.js
+++ b/app/components/course-page/configure-github-integration-modal/step.js
@@ -1,3 +1,0 @@
-import Component from '@glimmer/component';
-
-export default class Step extends Component {}

--- a/app/components/course-page/progress-banner-modal.js
+++ b/app/components/course-page/progress-banner-modal.js
@@ -1,3 +1,0 @@
-import Component from '@glimmer/component';
-
-export default class ProgressBannerModal extends Component {}

--- a/app/components/course-page/solution-language-dropdown-link.js
+++ b/app/components/course-page/solution-language-dropdown-link.js
@@ -1,3 +1,0 @@
-import Component from '@glimmer/component';
-
-export default class SolutionLanguageDropdownLink extends Component {}


### PR DESCRIPTION
**Checklist**:

- [ ] I've thoroughly self-reviewed my changes
- [ ] I've added tests for my changes, unless they affect admin-only areas (or are otherwise not worth testing)
- [ ] I've verified any visual changes using Percy (add a commit with `[percy]` in the message to trigger)

**Description**:

This PR fixes a bug where new TypeScript backing files were created for `progress-banner-modal`, `solution-language-dropdown-link`, and `configure-github-integration-modal/step` without deleting their existing JavaScript counterparts. This caused module resolution ambiguity, preventing the new Glint type safety from taking effect.

The fix involves deleting the redundant `.js` files, ensuring the `.ts` files are correctly used for type enforcement.

---

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: this only deletes redundant `.js` Glimmer component stubs so Ember/Glint resolves the existing `.ts` backing classes unambiguously, with no runtime logic changes.
> 
> **Overview**
> Removes duplicate `.js` backing files for `CoursePage::ProgressBannerModal`, `CoursePage::SolutionLanguageDropdownLink`, and `CoursePage::ConfigureGithubIntegrationModal::Step` so the TypeScript/Glint component classes are the sole source of module resolution.
> 
> This eliminates ambiguity between `.js` and `.ts` files and ensures the typed signatures/registry entries are applied for these components.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ea7fb8448c46403c718e5c5619f48827de05ecb6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->