### PR TITLE
feat(evaluation): add UI for handling unsure evaluation results

### DIFF
--- a/app/components/course-admin/code-example-page/evaluation-card/trusted-evaluation-tab.hbs
+++ b/app/components/course-admin/code-example-page/evaluation-card/trusted-evaluation-tab.hbs
@@ -35,6 +35,37 @@
     >
       Edit Trusted Evaluation
     </TertiaryButton>
+  {{else if (eq @evaluation.result "unsure")}}
+    <div class="prose dark:prose-invert mb-6">
+      <p>
+        The evaluation is
+        <b class="uppercase">unsure</b>. What's the correct answer?
+      </p>
+
+      <div class="flex items-center flex-wrap gap-3 mb-6">
+        <PrimaryButtonWithSpinner
+          @shouldShowSpinner={{this.upsertTrustedEvaluationTask.isRunning}}
+          {{on "click" (perform this.upsertTrustedEvaluationTask "pass")}}
+          data-test-correct-button
+        >
+          <div class="flex items-center gap-2">
+            {{svg-jar "check" class="w-4 h-4"}}
+            <span>Pass</span>
+          </div>
+        </PrimaryButtonWithSpinner>
+
+        <PrimaryButtonWithSpinner
+          @shouldShowSpinner={{this.upsertTrustedEvaluationTask.isRunning}}
+          {{on "click" (perform this.upsertTrustedEvaluationTask "fail")}}
+          data-test-wrong-button
+        >
+          <div class="flex items-center gap-2">
+            {{svg-jar "x" class="w-4 h-4"}}
+            <span>Fail</span>
+          </div>
+        </PrimaryButtonWithSpinner>
+      </div>
+    </div>
   {{else}}
     <div class="prose dark:prose-invert mb-6">
       Is the


### PR DESCRIPTION
Add a new UI state for evaluations marked as "unsure" to allow users
to explicitly mark them as "pass" or "fail". This provides clearer
feedback and helps improve the accuracy of trusted evaluations.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only change that adds a new render branch and reuses existing `upsertTrustedEvaluationTask`; main risk is minor UX/test-selector regressions around button behavior.
> 
> **Overview**
> Adds a dedicated **"unsure" evaluation** UI state in `trusted-evaluation-tab.hbs`. When `@evaluation.result` is `"unsure"`, the tab now prompts for the correct answer and provides **Pass**/**Fail** actions that call `upsertTrustedEvaluationTask` with explicit values, instead of the generic Correct/Wrong flow.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c1984a88a72a7bf39b4ceb3335e2442daef0689d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->