### PR TITLE
feat(evaluator): add deploy action and UI support

### DIFF
--- a/app/controllers/course-admin/code-example-evaluator.ts
+++ b/app/controllers/course-admin/code-example-evaluator.ts
@@ -1,14 +1,15 @@
 import Controller from '@ember/controller';
-import { action } from '@ember/object';
-import type RouterService from '@ember/routing/router-service';
-import { service } from '@ember/service';
-import type Store from '@ember-data/store';
+import fieldComparator from 'codecrafters-frontend/utils/field-comparator';
 import type CommunitySolutionEvaluationModel from 'codecrafters-frontend/models/community-solution-evaluation';
 import type CourseStageModel from 'codecrafters-frontend/models/course-stage';
 import type LanguageModel from 'codecrafters-frontend/models/language';
+import type RouterService from '@ember/routing/router-service';
+import type Store from '@ember-data/store';
 import type { CodeExampleEvaluatorRouteModel } from 'codecrafters-frontend/routes/course-admin/code-example-evaluator';
-import fieldComparator from 'codecrafters-frontend/utils/field-comparator';
+import { action } from '@ember/object';
+import { service } from '@ember/service';
 import { task } from 'ember-concurrency';
+import { waitFor } from '@ember/test-waiters';
 
 export default class CodeExampleEvaluatorController extends Controller {
   declare model: CodeExampleEvaluatorRouteModel;
@@ -57,6 +58,12 @@ export default class CodeExampleEvaluatorController extends Controller {
   }
 
   @action
+  @waitFor
+  async handleDeployButtonClick() {
+    await this.deployTask.perform();
+  }
+
+  @action
   handleRequestedLanguageChange(language: LanguageModel) {
     this.router.transitionTo({ queryParams: { languages: language.slug } });
   }
@@ -71,6 +78,10 @@ export default class CodeExampleEvaluatorController extends Controller {
     });
 
     dummyRecord.unloadRecord();
+  });
+
+  deployTask = task({ drop: true }, async (): Promise<void> => {
+    await this.model.evaluator.deploy({});
   });
 
   regenerateAllEvaluationsTask = task({ drop: true }, async (): Promise<void> => {

--- a/app/mirage/handlers/community-solution-evaluators.js
+++ b/app/mirage/handlers/community-solution-evaluators.js
@@ -15,4 +15,10 @@ export default function (server) {
 
     return evaluator.update(attrs);
   });
+
+  server.post('/community-solution-evaluators/:id/deploy', function (schema, request) {
+    const evaluator = schema.communitySolutionEvaluators.find(request.params.id);
+
+    return evaluator.update({ status: 'live' });
+  });
 }

--- a/app/models/community-solution-evaluator.ts
+++ b/app/models/community-solution-evaluator.ts
@@ -28,8 +28,18 @@ export default class CommunitySolutionEvaluatorModel extends Model {
     return this.status === 'live';
   }
 
+  declare deploy: (this: Model, payload: unknown) => Promise<void>;
   declare regenerateAllEvaluations: (this: Model, payload: unknown) => Promise<void>;
 }
+
+CommunitySolutionEvaluatorModel.prototype.deploy = memberAction({
+  path: 'deploy',
+  type: 'post',
+
+  after(response) {
+    this.store.pushPayload(response);
+  },
+});
 
 CommunitySolutionEvaluatorModel.prototype.regenerateAllEvaluations = memberAction({
   path: 'regenerate_all_evaluations',

--- a/app/templates/course-admin/code-example-evaluator.hbs
+++ b/app/templates/course-admin/code-example-evaluator.hbs
@@ -12,11 +12,39 @@
       </TertiaryLinkButton>
 
       <div class="flex items-center justify-between">
-        <EditableTextField @value={{@model.evaluator.slug}} @onUpdate={{perform this.updateSlugTask}}>
-          <h3 class="text-xl font-bold text-gray-900 dark:text-gray-100 {{if this.updateSlugTask.isRunning 'animate-pulse'}}">
-            {{@model.evaluator.slug}}
-          </h3>
-        </EditableTextField>
+        <div class="flex items-center gap-3">
+          <EditableTextField @value={{@model.evaluator.slug}} @onUpdate={{perform this.updateSlugTask}}>
+            <h3 class="text-xl font-bold text-gray-900 dark:text-gray-100 {{if this.updateSlugTask.isRunning 'animate-pulse'}}">
+              {{@model.evaluator.slug}}
+            </h3>
+          </EditableTextField>
+
+          {{#if @model.evaluator.isDraft}}
+            <span
+              class="inline-flex items-center rounded-md bg-yellow-50 dark:bg-yellow-400/10 px-2 py-1 text-xs font-medium text-yellow-800 dark:text-yellow-500 ring-1 ring-inset ring-yellow-600/20 dark:ring-yellow-400/20"
+            >
+              Draft
+            </span>
+          {{else}}
+            <span
+              class="inline-flex items-center rounded-md bg-green-50 dark:bg-green-500/10 px-2 py-1 text-xs font-medium text-green-700 dark:text-green-400 ring-1 ring-inset ring-green-600/20 dark:ring-green-500/20"
+            >
+              Live
+            </span>
+          {{/if}}
+        </div>
+
+        {{#if @model.evaluator.isDraft}}
+          <PrimaryButtonWithSpinner
+            @size="small"
+            @isDisabled={{this.deployTask.isRunning}}
+            @shouldShowSpinner={{this.deployTask.isRunning}}
+            data-test-deploy-button
+            {{on "click" this.handleDeployButtonClick}}
+          >
+            Deploy
+          </PrimaryButtonWithSpinner>
+        {{/if}}
       </div>
     </div>
 

--- a/tests/acceptance/course-admin/evaluators/deploy-test.js
+++ b/tests/acceptance/course-admin/evaluators/deploy-test.js
@@ -1,0 +1,45 @@
+import codeExampleEvaluatorPage from 'codecrafters-frontend/tests/pages/course-admin/code-example-evaluator-page';
+import testScenario from 'codecrafters-frontend/mirage/scenarios/test';
+import { module, test } from 'qunit';
+import { setupApplicationTest } from 'codecrafters-frontend/tests/helpers';
+import { signInAsStaff } from 'codecrafters-frontend/tests/support/authentication-helpers';
+
+module('Acceptance | course-admin | evaluators | deploy-test', function (hooks) {
+  setupApplicationTest(hooks);
+
+  hooks.beforeEach(function () {
+    testScenario(this.server);
+    signInAsStaff(this.owner, this.server);
+
+    this.course = this.server.schema.courses.findBy({ slug: 'redis' });
+  });
+
+  test('can deploy draft evaluator', async function (assert) {
+    this.evaluator = this.server.create('community-solution-evaluator', {
+      slug: 'relevance',
+      promptTemplate: 'Is the code example relevant to the prompt?',
+      status: 'draft',
+    });
+
+    await codeExampleEvaluatorPage.visit({ course_slug: this.course.slug, evaluator_slug: this.evaluator.slug });
+
+    assert.true(codeExampleEvaluatorPage.isDeployButtonVisible, 'Deploy button is visible for draft evaluator');
+
+    await codeExampleEvaluatorPage.clickOnDeployButton();
+
+    assert.strictEqual(this.evaluator.reload().status, 'live', 'Evaluator status is updated to live');
+    assert.false(codeExampleEvaluatorPage.isDeployButtonVisible, 'Deploy button is hidden after deployment');
+  });
+
+  test('deploy button is hidden for live evaluators', async function (assert) {
+    this.evaluator = this.server.create('community-solution-evaluator', {
+      slug: 'relevance',
+      promptTemplate: 'Is the code example relevant to the prompt?',
+      status: 'live',
+    });
+
+    await codeExampleEvaluatorPage.visit({ course_slug: this.course.slug, evaluator_slug: this.evaluator.slug });
+
+    assert.false(codeExampleEvaluatorPage.isDeployButtonVisible, 'Deploy button is hidden for live evaluator');
+  });
+});

--- a/tests/pages/course-admin/code-example-evaluator-page.ts
+++ b/tests/pages/course-admin/code-example-evaluator-page.ts
@@ -1,8 +1,11 @@
 import { fillIn } from '@ember/test-helpers';
 import EvaluationCard from 'codecrafters-frontend/tests/pages/components/course-admin/code-examples-page/evaluation-card';
-import { clickable, collection, create, fillable, hasClass, text, value, visitable } from 'ember-cli-page-object';
+import { clickable, collection, create, fillable, hasClass, isPresent, text, value, visitable } from 'ember-cli-page-object';
 
 export default create({
+  clickOnDeployButton: clickable('[data-test-deploy-button]'),
+  isDeployButtonVisible: isPresent('[data-test-deploy-button]'),
+
   evaluationsSection: {
     evaluationCards: collection('[data-test-evaluation-card]', EvaluationCard),
     scope: '[data-test-evaluations-section]',


### PR DESCRIPTION
Add a new deploy action to community solution evaluators that updates
their status to 'live'. Implement a corresponding server handler and
expose a deployTask in the evaluator controller to trigger deployment.

Update the evaluator page with a deploy button that is visible only for
draft evaluators and hides after deployment to live. Add acceptance tests
to verify deploy button visibility and status update behavior.

This enables course admins to transition evaluators from draft to live,
improving workflow and clarity on evaluator status.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces a new state-transition API call and UI workflow that changes evaluator `status`; risk is mainly around ensuring the endpoint response shape and client store updates keep UI/state consistent.
> 
> **Overview**
> Course admins can now **deploy** a draft community-solution evaluator via a new `POST /community-solution-evaluators/:id/deploy` member action that flips the evaluator `status` to `live` and pushes the updated payload into the Ember Data store.
> 
> The evaluator admin page now shows a *Draft/Live* status badge and conditionally renders a Deploy button for draft evaluators, wired through a new controller `deployTask` (with `@waitFor` click handler) to trigger the deploy action.
> 
> Adds Mirage support for the deploy endpoint plus acceptance tests and page-object helpers to verify deploy button visibility and that status updates to `live` after deployment.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 317854b430903ce7b7243504065addcd3a84274e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- BUGBOT_STATUS --><sup><a href="https://cursor.com/dashboard?tab=bugbot">Cursor Bugbot</a> reviewed your changes and found no issues for commit <u>317854b</u></sup><!-- /BUGBOT_STATUS -->