### PR TITLE
feat(ui): add dark mode styles to code example page components

### DIFF
--- a/app/components/course-admin/code-example-page/comparison-card.hbs
+++ b/app/components/course-admin/code-example-page/comparison-card.hbs
@@ -1,5 +1,6 @@
 <div
-  class="border border-gray-200 rounded-md p-4 mb-4 {{if this.isCollapsed 'hover:border-gray-300 hover:bg-gray-100'}}"
+  class="border border-gray-200 dark:border-white/5 rounded-md p-4 mb-4
+    {{if this.isCollapsed 'hover:border-gray-300 dark:hover:border-gray-600 hover:bg-gray-100 dark:hover:bg-gray-900'}}"
   role={{if this.isCollapsed "button" "presentation"}}
   {{! template-lint-disable no-invalid-interactive }}
   {{on "click" (if this.isCollapsed this.handleExpandButtonClick (noop))}}
@@ -20,25 +21,25 @@
             Tied
           </Pill>
         {{else}}
-          <div class="text-red-500 font-bold">
+          <div class="text-red-500 dark:text-red-400 font-bold">
             Unknown ({{this.result}})
           </div>
         {{/if}}
       </div>
 
-      <div class="text-sm text-gray-600 ml-1.5 mr-1.5">
+      <div class="text-sm text-gray-600 dark:text-gray-300 ml-1.5 mr-1.5">
         against
       </div>
 
-      <AvatarImage @user={{this.secondUser}} class="w-6 h-6 border border-gray-300 shadow-xs mr-1.5 rounded-full" />
-      <span class="text-sm text-gray-600">
+      <AvatarImage @user={{this.secondUser}} class="w-6 h-6 border border-gray-300 dark:border-gray-700 shadow-xs mr-1.5 rounded-full" />
+      <span class="text-sm text-gray-600 dark:text-gray-300">
         {{this.secondUser.username}}
       </span>
     </div>
     <div class="flex items-center gap-3">
       {{#if this.isExpanded}}
         <button
-          class="shrink-0 border border-gray-200 hover:bg-gray-100 hover:border-gray-300 transition-colors px-2 py-1.5 text-gray-700 font-bold text-xs rounded-sm flex items-center"
+          class="shrink-0 border border-gray-200 dark:border-gray-700 hover:bg-gray-100 dark:hover:bg-gray-800 hover:border-gray-300 dark:hover:border-gray-600 transition-colors px-2 py-1.5 text-gray-700 dark:text-gray-200 font-bold text-xs rounded-sm flex items-center"
           type="button"
           {{on "click" this.handleCopyIdToClipboardButtonClick}}
         >
@@ -46,7 +47,7 @@
           Copy ID
         </button>
         <button
-          class="shrink-0 border border-gray-200 hover:bg-gray-100 hover:border-gray-300 transition-colors px-2 py-1.5 text-gray-700 font-bold text-xs rounded-sm flex items-center"
+          class="shrink-0 border border-gray-200 dark:border-gray-700 hover:bg-gray-100 dark:hover:bg-gray-800 hover:border-gray-300 dark:hover:border-gray-600 transition-colors px-2 py-1.5 text-gray-700 dark:text-gray-200 font-bold text-xs rounded-sm flex items-center"
           type="button"
           {{on "click" this.handleCollapseButtonClick}}
         >

--- a/app/routes/course-admin/code-example.ts
+++ b/app/routes/course-admin/code-example.ts
@@ -5,6 +5,7 @@ import CommunityCourseStageSolutionModel from 'codecrafters-frontend/models/comm
 import type SolutionComparisonModel from 'codecrafters-frontend/models/solution-comparison';
 import type CommunitySolutionEvaluationModel from 'codecrafters-frontend/models/community-solution-evaluation';
 import type CourseModel from 'codecrafters-frontend/models/course';
+import RouteInfoMetadata, { RouteColorScheme } from 'codecrafters-frontend/utils/route-info-metadata';
 
 export type CodeExampleRouteModel = {
   course: CourseModel;
@@ -15,6 +16,10 @@ export type CodeExampleRouteModel = {
 
 export default class CodeExampleRoute extends BaseRoute {
   @service declare store: Store;
+
+  buildRouteInfoMetadata() {
+    return new RouteInfoMetadata({ colorScheme: RouteColorScheme.Both });
+  }
 
   async model(params: { code_example_id: string }): Promise<CodeExampleRouteModel> {
     // @ts-expect-error modelFor not typed

--- a/app/templates/course-admin/code-example.hbs
+++ b/app/templates/course-admin/code-example.hbs
@@ -1,9 +1,9 @@
-<div class="bg-white min-h-screen">
+<div class="bg-white dark:bg-gray-950 min-h-screen">
   <div class="container mx-auto pt-4 pb-10 px-6">
-    <div class="py-3 border-b border-gray-200 mb-6">
+    <div class="py-3 border-b border-gray-200 dark:border-white/5 mb-6">
       <TertiaryLinkButton @route="course.stage.code-examples" @models={{array @model.solution.courseStage.slug}} @size="small" class="pl-1.5 mb-3">
         <div class="flex items-center">
-          {{svg-jar "arrow-circle-left" class="w-4 h-4 mr-1.5 text-gray-500"}}
+          {{svg-jar "arrow-circle-left" class="w-4 h-4 mr-1.5 text-gray-500 dark:text-gray-400"}}
 
           <span>
             Back
@@ -13,7 +13,7 @@
 
       <div class="flex items-start justify-between">
         <div>
-          <h3 class="text-lg font-bold text-gray-900">
+          <h3 class="text-lg font-bold text-gray-900 dark:text-gray-100">
             {{@model.solution.user.username}}'s
             {{@model.solution.language.name}}
             code example for
@@ -24,7 +24,7 @@
         <div class="flex flex-col items-end">
           <Toggle @isOn={{@model.solution.isPinned}} {{on "click" this.handlePinCodeExampleToggled}} data-test-pin-code-example-toggle />
 
-          <div class="text-xs text-gray-400 mt-2">
+          <div class="text-xs text-gray-400 dark:text-gray-500 mt-2">
             Editor's choice
           </div>
         </div>
@@ -33,8 +33,8 @@
 
     <CoursePage::CourseStageStep::CommunitySolutionCard @solution={{@model.solution}} @isExpanded={{true}} class="mb-8" />
 
-    <div class="border-b border-gray-200 mb-4 pb-2">
-      <h3 class="text-lg font-bold text-gray-900">
+    <div class="border-b border-gray-200 dark:border-white/5 mb-4 pb-2">
+      <h3 class="text-lg font-bold text-gray-900 dark:text-gray-100">
         Evaluations ({{@model.evaluations.length}})
       </h3>
     </div>
@@ -43,8 +43,8 @@
       <CourseAdmin::CodeExamplePage::EvaluationCard @evaluation={{evaluation}} class="mb-4" />
     {{/each}}
 
-    <div class="border-b border-gray-200 mb-4 pb-2">
-      <h3 class="text-lg font-bold text-gray-900">
+    <div class="border-b border-gray-200 dark:border-white/5 mb-4 pb-2">
+      <h3 class="text-lg font-bold text-gray-900 dark:text-gray-100">
         Comparisons ({{@model.comparisons.length}})
       </h3>
     </div>


### PR DESCRIPTION
Update ComparisonCard, code-example template, and buttons to support 
dark mode with appropriate border, text, and background color changes. 
Enhance visual consistency and accessibility when dark theme is enabled.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Primarily Tailwind class changes for dark-theme styling plus a route metadata tweak; minimal logic changes and low risk aside from potential visual regressions in dark mode.
> 
> **Overview**
> Adds **dark mode styling** to the course admin code example page, including page backgrounds, borders, text colors, and hover states.
> 
> Updates `ComparisonCard` and related action buttons to use dark-theme variants, and sets the `course-admin/code-example` route metadata to `RouteColorScheme.Both` so the page can render appropriately in either theme.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b2ef321c8f91108247205bbba1e9cade664b26a0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->