### PR TITLE
feat(course-admin): add delete button for draft evaluators

### DIFF
--- a/app/controllers/course-admin/code-example-evaluator.ts
+++ b/app/controllers/course-admin/code-example-evaluator.ts
@@ -59,6 +59,12 @@ export default class CodeExampleEvaluatorController extends Controller {
 
   @action
   @waitFor
+  async handleDeleteButtonClick() {
+    await this.deleteTask.perform();
+  }
+
+  @action
+  @waitFor
   async handleDeployButtonClick() {
     await this.deployTask.perform();
   }
@@ -78,6 +84,11 @@ export default class CodeExampleEvaluatorController extends Controller {
     });
 
     dummyRecord.unloadRecord();
+  });
+
+  deleteTask = task({ drop: true }, async (): Promise<void> => {
+    await this.model.evaluator.destroyRecord();
+    this.router.transitionTo('course-admin.code-example-evaluators', this.model.course.slug);
   });
 
   deployTask = task({ drop: true }, async (): Promise<void> => {

--- a/app/mirage/handlers/community-solution-evaluators.js
+++ b/app/mirage/handlers/community-solution-evaluators.js
@@ -21,4 +21,10 @@ export default function (server) {
 
     return evaluator.update({ status: 'live' });
   });
+
+  server.delete('/community-solution-evaluators/:id', function (schema, request) {
+    const evaluator = schema.communitySolutionEvaluators.find(request.params.id);
+
+    return evaluator.destroy();
+  });
 }

--- a/app/templates/course-admin/code-example-evaluator.hbs
+++ b/app/templates/course-admin/code-example-evaluator.hbs
@@ -35,15 +35,21 @@
         </div>
 
         {{#if @model.evaluator.isDraft}}
-          <PrimaryButtonWithSpinner
-            @size="small"
-            @isDisabled={{this.deployTask.isRunning}}
-            @shouldShowSpinner={{this.deployTask.isRunning}}
-            data-test-deploy-button
-            {{on "click" this.handleDeployButtonClick}}
-          >
-            Deploy
-          </PrimaryButtonWithSpinner>
+          <div class="flex items-center gap-2">
+            <DangerButtonWithTimedConfirmation @size="small" @onConfirm={{this.handleDeleteButtonClick}} data-test-delete-button>
+              Delete
+            </DangerButtonWithTimedConfirmation>
+
+            <PrimaryButtonWithSpinner
+              @size="small"
+              @isDisabled={{this.deployTask.isRunning}}
+              @shouldShowSpinner={{this.deployTask.isRunning}}
+              data-test-deploy-button
+              {{on "click" this.handleDeployButtonClick}}
+            >
+              Deploy
+            </PrimaryButtonWithSpinner>
+          </div>
         {{/if}}
       </div>
     </div>

--- a/tests/pages/course-admin/code-example-evaluator-page.ts
+++ b/tests/pages/course-admin/code-example-evaluator-page.ts
@@ -1,10 +1,16 @@
 import { fillIn } from '@ember/test-helpers';
 import EvaluationCard from 'codecrafters-frontend/tests/pages/components/course-admin/code-examples-page/evaluation-card';
-import { clickable, collection, create, fillable, hasClass, isPresent, text, value, visitable } from 'ember-cli-page-object';
+import { clickable, collection, create, fillable, hasClass, isPresent, text, triggerable, value, visitable } from 'ember-cli-page-object';
 
 export default create({
   clickOnDeployButton: clickable('[data-test-deploy-button]'),
+  isDeleteButtonVisible: isPresent('[data-test-delete-button]'),
   isDeployButtonVisible: isPresent('[data-test-deploy-button]'),
+
+  deleteButton: {
+    mousedown: triggerable('mousedown'),
+    scope: '[data-test-delete-button]',
+  },
 
   evaluationsSection: {
     evaluationCards: collection('[data-test-evaluation-card]', EvaluationCard),


### PR DESCRIPTION
Add a DangerButtonWithTimedConfirmation to allow deletion of draft
code example evaluators. Implement a deleteTask that destroys the evaluator
record and transitions back to the evaluators list. This improves user
control by enabling removal of drafts directly from the UI.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces a new destructive UI action and record deletion flow; main risk is unintended deletions or redirect/state edge cases, though it’s gated to draft evaluators and uses confirmation.
> 
> **Overview**
> Adds a **Delete** button (with timed confirmation) to the course admin code example evaluator page when the evaluator is in *draft* status.
> 
> Implements a `deleteTask` that calls `destroyRecord()` on the evaluator and then transitions back to the evaluators list, adds a Mirage `DELETE /community-solution-evaluators/:id` handler to support tests, and extends acceptance/page-object tests to cover draft deletion and to assert the button is hidden for live evaluators.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6c17d2e073da4342b6f36e48f0a0710628f5bbb4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->