### PR TITLE
feat(danger-button): add size attribute to timed confirmation button

### DIFF
--- a/app/components/danger-button-with-timed-confirmation.hbs
+++ b/app/components/danger-button-with-timed-confirmation.hbs
@@ -1,4 +1,5 @@
 <DangerButton
+  @size={{@size}}
   class="relative border-0 overflow-hidden"
   {{! template-lint-disable no-pointer-down-event-binding }}
   {{on "mousedown" this.startProgress}}


### PR DESCRIPTION
Pass the @size argument to the DangerButton component to allow
customization of its size. This change improves flexibility and
enables consistent styling across different usages of the button.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small template-only change that just passes through an existing argument; low chance of behavioral impact beyond minor styling differences.
> 
> **Overview**
> `DangerButtonWithTimedConfirmation` now forwards its optional `@size` argument down to the underlying `DangerButton`, allowing callers to control the rendered button size consistently with other `DangerButton` usages.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7389b6000856a7201236ff116f5b8ec5a20e1a1c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->