### PR TITLE
Course stage messaging consistency

### DIFF
--- a/app/utils/course-page-step-list/course-stage-step.ts
+++ b/app/utils/course-page-step-list/course-stage-step.ts
@@ -104,7 +104,7 @@ Check the [How to pass this stage](#first-stage-tutorial-heading) section for in
       return {
         dotColor: 'gray',
         dotType: 'blinking',
-        text: this.courseStage.isFirst ? 'Listening for a git push...' : 'Ready to run tests...',
+        text: this.courseStage.isFirst ? 'Listening for ping...' : 'Ready to run tests...',
       };
     } else if (this.status === 'locked') {
       return {


### PR DESCRIPTION
**Checklist**:

- [x] I've thoroughly self-reviewed my changes
- [ ] I've added tests for my changes, unless they affect admin-only areas (or are otherwise not worth testing)
- [ ] I've verified any visual changes using Percy (add a commit with `[percy]` in the message to trigger)

Fixes an inconsistency where the first course stage step still displayed "Listening for a git push..." while the setup step had been updated to "Listening for ping...". This change ensures consistent messaging across the setup and initial course stages, reflecting the CLI ping flow.

---

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Single string copy change in the course stage progress indicator; no logic or data flow changes.
> 
> **Overview**
> Updates the first course stage in-progress progress indicator text to say **"Listening for ping..."** instead of **"Listening for a git push..."**, aligning messaging with the setup step and current CLI ping flow.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8b02ade9e1b0737106b79d771174f331c7edc82c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->