### PR TITLE
feat(code-mirror): add YAML language support to editor

### DIFF
--- a/app/components/code-mirror.ts
+++ b/app/components/code-mirror.ts
@@ -36,6 +36,7 @@ import {
 } from '@codemirror/language';
 import { languages } from '@codemirror/language-data';
 import { markdown } from '@codemirror/lang-markdown';
+import { yaml } from '@codemirror/lang-yaml';
 import { highlightNewlines } from 'codecrafters-frontend/utils/code-mirror-highlight-newlines';
 import { highlightRanges } from 'codecrafters-frontend/utils/code-mirror-highlight-ranges';
 import { collapseRanges } from 'codecrafters-frontend/utils/code-mirror-collapse-ranges';
@@ -118,6 +119,9 @@ const OPTION_HANDLERS: { [key: string]: OptionHandler } = {
       switch (detectedLanguage.name.toLowerCase()) {
         case 'markdown':
           loadedLanguage = markdown({ codeLanguages: languages });
+          break;
+        case 'yaml':
+          loadedLanguage = yaml();
           break;
         default:
           loadedLanguage = await detectedLanguage.load();


### PR DESCRIPTION
Import the YAML language module and update the language loader
to handle YAML files. This enables syntax highlighting and proper
language features for YAML content in the code editor component.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, isolated editor enhancement that only adds a new language module and a narrow loader branch; low chance of impacting other languages beyond bundle/dependency issues.
> 
> **Overview**
> The `CodeMirror` component now explicitly supports YAML by importing `@codemirror/lang-yaml` and special-casing detected `yaml` files in the `languageOrFilename` option handler to load `yaml()` (similar to the existing Markdown handling), enabling YAML-aware highlighting/features when a YAML filename or language is provided.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d75554fba6d4781d5b860cbf05487295ee471794. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->