### PR TITLE
feat(code-example-evaluator): add dynamic colors for pass/fail rates

### DIFF
--- a/app/components/course-admin/code-example-evaluator-page/accuracy-section.ts
+++ b/app/components/course-admin/code-example-evaluator-page/accuracy-section.ts
@@ -27,6 +27,20 @@ export default class AccuracySection extends Component<Signature> {
     });
   }
 
+  get failRateColor(): 'green' | 'yellow' | 'red' | 'gray' {
+    if (this.failRatePercentage === null) {
+      return 'gray';
+    }
+
+    if (this.failRatePercentage < 5) {
+      return 'red';
+    } else if (this.failRatePercentage < 10) {
+      return 'yellow';
+    } else {
+      return 'green';
+    }
+  }
+
   get failRatePercentage() {
     if (this.args.evaluator.totalEvaluationsCount === 0) {
       return null;
@@ -40,7 +54,7 @@ export default class AccuracySection extends Component<Signature> {
       title: 'Fail Rate',
       label: 'fails',
       value: this.failRatePercentage !== null ? `${this.failRatePercentage}%` : 'No evaluations',
-      color: 'gray',
+      color: this.failRateColor,
       explanationMarkdown: 'The percentage of evaluations that resulted in "fail".',
     };
   }
@@ -107,6 +121,20 @@ export default class AccuracySection extends Component<Signature> {
     });
   }
 
+  get passRateColor(): 'green' | 'yellow' | 'red' | 'gray' {
+    if (this.passRatePercentage === null) {
+      return 'gray';
+    }
+
+    if (this.passRatePercentage < 90) {
+      return 'green';
+    } else if (this.passRatePercentage < 95) {
+      return 'yellow';
+    } else {
+      return 'red';
+    }
+  }
+
   get passRatePercentage() {
     if (this.args.evaluator.totalEvaluationsCount === 0) {
       return null;
@@ -120,7 +148,7 @@ export default class AccuracySection extends Component<Signature> {
       title: 'Pass Rate',
       label: 'passes',
       value: this.passRatePercentage !== null ? `${this.passRatePercentage}%` : 'No evaluations',
-      color: 'gray',
+      color: this.passRateColor,
       explanationMarkdown: 'The percentage of evaluations that resulted in "pass".',
     };
   }


### PR DESCRIPTION
Assign color codes to pass and fail rates based on defined thresholds
to provide visual feedback on evaluation accuracy. This improves the
clarity of the evaluation metrics by highlighting performance levels
with green, yellow, red, or gray when data is unavailable.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only change that adjusts how existing pass/fail rates are color-coded; no data flow, auth, or persistence changes.
> 
> **Overview**
> The `AccuracySection` pass/fail rate statistic cards now use **dynamic, threshold-based colors** instead of a fixed `gray`.
> 
> This introduces `passRateColor` and `failRateColor` getters that return `green`/`yellow`/`red` based on rate thresholds, with `gray` when no evaluations are available, and wires them into `passRateStatistic`/`failRateStatistic`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c30371622096d6ab94c43259036095f1775fc141. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->