### PR TITLE
feat(course-admin): add coverage statistic to evaluators page

### DIFF
--- a/app/components/course-admin/code-example-evaluator-page/accuracy-section.hbs
+++ b/app/components/course-admin/code-example-evaluator-page/accuracy-section.hbs
@@ -1,9 +1,8 @@
 <div data-test-evaluations-section ...attributes>
   {{! TODO: Use a "generic" statistic component? }}
-  <div class="mt-6 grid grid-cols-1 gap-5 sm:grid-cols-2 lg:grid-cols-4 mb-6">
-    <CourseAdmin::StageInsightsPage::StatisticCard @statistic={{this.passRateStatistic}} />
+  <div class="mt-6 grid grid-cols-1 gap-5 sm:grid-cols-2 lg:grid-cols-3 mb-6">
+    <CourseAdmin::StageInsightsPage::StatisticCard @statistic={{this.coverageStatistic}} />
     <CourseAdmin::StageInsightsPage::StatisticCard @statistic={{this.falsePositiveRateStatistic}} />
-    <CourseAdmin::StageInsightsPage::StatisticCard @statistic={{this.failRateStatistic}} />
     <CourseAdmin::StageInsightsPage::StatisticCard @statistic={{this.falseNegativeRateStatistic}} />
   </div>
 

--- a/app/components/course-admin/code-example-evaluator-page/accuracy-section.ts
+++ b/app/components/course-admin/code-example-evaluator-page/accuracy-section.ts
@@ -21,42 +21,38 @@ export default class AccuracySection extends Component<Signature> {
     return this.args.evaluator.evaluations;
   }
 
-  get evaluationsWithTrustedEvaluation() {
-    return this.allEvaluations.filter((evaluation) => {
-      return evaluation.trustedEvaluation;
-    });
-  }
+  get coverageColor(): 'green' | 'yellow' | 'red' | 'gray' {
+    const percentage = this.args.evaluator.failRatePercentage;
 
-  get failRateColor(): 'green' | 'yellow' | 'red' | 'gray' {
-    if (this.failRatePercentage === null) {
+    if (percentage === null) {
       return 'gray';
     }
 
-    if (this.failRatePercentage < 5) {
+    if (percentage < 5) {
       return 'red';
-    } else if (this.failRatePercentage < 10) {
+    } else if (percentage < 10) {
       return 'yellow';
     } else {
       return 'green';
     }
   }
 
-  get failRatePercentage() {
-    if (this.args.evaluator.totalEvaluationsCount === 0) {
-      return null;
-    }
+  get coverageStatistic(): CourseStageParticipationAnalysisStatistic {
+    const percentage = this.args.evaluator.failRatePercentage;
 
-    return parseFloat(((100 * this.args.evaluator.failedEvaluationsCount) / this.args.evaluator.totalEvaluationsCount).toFixed(2));
-  }
-
-  get failRateStatistic(): CourseStageParticipationAnalysisStatistic {
     return {
-      title: 'Fail Rate',
-      label: 'fails',
-      value: this.failRatePercentage !== null ? `${this.failRatePercentage}%` : 'No evaluations',
-      color: this.failRateColor,
+      title: 'Coverage',
+      label: 'coverage',
+      value: percentage !== null ? `${percentage}%` : 'No evaluations',
+      color: this.coverageColor,
       explanationMarkdown: 'The percentage of evaluations that resulted in "fail".',
     };
+  }
+
+  get evaluationsWithTrustedEvaluation() {
+    return this.allEvaluations.filter((evaluation) => {
+      return evaluation.trustedEvaluation;
+    });
   }
 
   get falseNegativeEvaluations() {
@@ -119,38 +115,6 @@ export default class AccuracySection extends Component<Signature> {
     return this.allEvaluations.filter((evaluation) => {
       return evaluation.result === 'fail' && evaluation.trustedEvaluation;
     });
-  }
-
-  get passRateColor(): 'green' | 'yellow' | 'red' | 'gray' {
-    if (this.passRatePercentage === null) {
-      return 'gray';
-    }
-
-    if (this.passRatePercentage < 90) {
-      return 'green';
-    } else if (this.passRatePercentage < 95) {
-      return 'yellow';
-    } else {
-      return 'red';
-    }
-  }
-
-  get passRatePercentage() {
-    if (this.args.evaluator.totalEvaluationsCount === 0) {
-      return null;
-    }
-
-    return parseFloat(((100 * this.args.evaluator.passedEvaluationsCount) / this.args.evaluator.totalEvaluationsCount).toFixed(2));
-  }
-
-  get passRateStatistic(): CourseStageParticipationAnalysisStatistic {
-    return {
-      title: 'Pass Rate',
-      label: 'passes',
-      value: this.passRatePercentage !== null ? `${this.passRatePercentage}%` : 'No evaluations',
-      color: this.passRateColor,
-      explanationMarkdown: 'The percentage of evaluations that resulted in "pass".',
-    };
   }
 
   get positiveEvaluationsWithTrustedEvaluation() {

--- a/app/components/course-admin/code-example-evaluators-page/coverage-statistic.hbs
+++ b/app/components/course-admin/code-example-evaluators-page/coverage-statistic.hbs
@@ -1,0 +1,1 @@
+<CourseAdmin::CodeExampleInsightsIndexPage::StageListItem::Statistic @statistic={{this.coverageStatistic}} />

--- a/app/components/course-admin/code-example-evaluators-page/coverage-statistic.ts
+++ b/app/components/course-admin/code-example-evaluators-page/coverage-statistic.ts
@@ -1,0 +1,47 @@
+import Component from '@glimmer/component';
+import type CommunitySolutionEvaluatorModel from 'codecrafters-frontend/models/community-solution-evaluator';
+import type { CommunitySolutionsAnalysisStatistic } from 'codecrafters-frontend/models/community-solutions-analysis';
+
+interface Signature {
+  Element: HTMLDivElement;
+
+  Args: {
+    evaluator: CommunitySolutionEvaluatorModel;
+  };
+}
+
+export default class CoverageStatistic extends Component<Signature> {
+  get coverageColor(): 'green' | 'yellow' | 'red' | 'gray' {
+    const percentage = this.args.evaluator.failRatePercentage;
+
+    if (percentage === null) {
+      return 'gray';
+    }
+
+    if (percentage >= 10) {
+      return 'green';
+    } else if (percentage >= 5) {
+      return 'yellow';
+    } else {
+      return 'red';
+    }
+  }
+
+  get coverageStatistic(): CommunitySolutionsAnalysisStatistic {
+    const percentage = this.args.evaluator.failRatePercentage;
+
+    return {
+      title: 'Coverage',
+      label: 'coverage',
+      value: percentage !== null ? `${Math.round(percentage)}%` : null,
+      color: this.coverageColor,
+      explanationMarkdown: 'The percentage of evaluations that resulted in "fail" (issues detected).',
+    };
+  }
+}
+
+declare module '@glint/environment-ember-loose/registry' {
+  export default interface Registry {
+    'CourseAdmin::CodeExampleEvaluatorsPage::CoverageStatistic': typeof CoverageStatistic;
+  }
+}

--- a/app/components/course-admin/code-example-insights-index-page/stage-list-item/statistic.hbs
+++ b/app/components/course-admin/code-example-insights-index-page/stage-list-item/statistic.hbs
@@ -8,7 +8,7 @@
       -
     {{/if}}
   </div>
-  <div class="text-gray-400 dark:text-gray-500">
+  <div class="text-gray-400 dark:text-gray-600">
     {{#if @statistic}}
       {{@statistic.label}}
     {{else if @fallbackLabel}}

--- a/app/models/community-solution-evaluator.ts
+++ b/app/models/community-solution-evaluator.ts
@@ -23,12 +23,28 @@ export default class CommunitySolutionEvaluatorModel extends Model {
   @attr('string') declare status: 'draft' | 'live';
   @attr('number') declare unsureEvaluationsCount: number;
 
+  get failRatePercentage(): number | null {
+    if (this.totalEvaluationsCount === 0) {
+      return null;
+    }
+
+    return parseFloat(((100 * this.failedEvaluationsCount) / this.totalEvaluationsCount).toFixed(2));
+  }
+
   get isDraft() {
     return this.status === 'draft';
   }
 
   get isLive() {
     return this.status === 'live';
+  }
+
+  get passRatePercentage(): number | null {
+    if (this.totalEvaluationsCount === 0) {
+      return null;
+    }
+
+    return parseFloat(((100 * this.passedEvaluationsCount) / this.totalEvaluationsCount).toFixed(2));
   }
 
   get totalEvaluationsCount() {

--- a/app/templates/course-admin/code-example-evaluators.hbs
+++ b/app/templates/course-admin/code-example-evaluators.hbs
@@ -46,14 +46,7 @@
                 </div>
               </div>
               <div class="flex flex-none items-center gap-x-4">
-                <TertiaryLinkButton
-                  @size="small"
-                  @route="course-admin.code-example-evaluator"
-                  @models={{array @model.course.slug evaluator.slug}}
-                  data-test-view-evaluator-button
-                >
-                  View evaluator
-                </TertiaryLinkButton>
+                <CourseAdmin::CodeExampleEvaluatorsPage::CoverageStatistic @evaluator={{evaluator}} />
               </div>
             </LinkTo>
           </li>

--- a/tests/pages/course-admin/code-example-evaluators-page.js
+++ b/tests/pages/course-admin/code-example-evaluators-page.js
@@ -9,15 +9,11 @@ export default create({
       return [...this.evaluators].find((evaluator) => evaluator.slug === evaluatorSlug);
     });
 
-    await [...this.evaluators].find((evaluator) => evaluator.slug === evaluatorSlug).viewEvaluatorButton.click();
+    await [...this.evaluators].find((evaluator) => evaluator.slug === evaluatorSlug).click();
   },
 
   evaluators: collection('[data-test-evaluator-item]', {
     slug: text('[data-test-evaluator-slug]'),
-
-    viewEvaluatorButton: {
-      scope: '[data-test-view-evaluator-button]',
-    },
   }),
 
   visit: visitable('/courses/:course_slug/admin/code-example-evaluators'),


### PR DESCRIPTION
Introduce CoverageStatistic component to display fail rate coverage
for community solution evaluators with color-coded status. Move
failRatePercentage and passRatePercentage getters to the evaluator model
for reuse. Replace "View evaluator" link with the new coverage stat on
the evaluators list, improving visibility of evaluation quality. Update
failRateColor and failRateStatistic to use the centralized evaluator
getter. Adjust color styling for consistency. These changes enhance
evaluation insights and UI clarity.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only changes plus small model getter refactor; main risk is incorrect percentage/color thresholds or null-handling affecting displayed stats.
> 
> **Overview**
> Adds a new *Coverage* statistic (based on evaluator fail-rate) to the code example evaluators list, replacing the per-row “View evaluator” button with a color-coded tooltip statistic component.
> 
> Refactors percentage calculations by moving `failRatePercentage`/`passRatePercentage` onto `CommunitySolutionEvaluatorModel`, and updates the evaluator accuracy section UI to show Coverage instead of Pass/Fail rate cards (with updated grid layout). Also tweaks dark-mode label styling and updates the page-object test helper to click the list row instead of the removed button.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c7556f673307c8c09440901ff8d1bf479379bd28. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->