### PR TITLE
feat(code-example-evaluator): add loading state to evaluations display

### DIFF
--- a/app/components/course-admin/code-example-evaluator-page/evaluations-section.hbs
+++ b/app/components/course-admin/code-example-evaluator-page/evaluations-section.hbs
@@ -12,10 +12,16 @@
   </div>
 
   <Tabs @size="regular" @tabs={{this.tabs}} @activeTabSlug={{this.activeTabSlug}} @onTabChange={{this.handleTabChange}}>
-    <div class="mt-6" {{did-insert this.handleDidInsertTabContents}}>
-      {{#each this.sortedEvaluations as |evaluation|}}
-        <CourseAdmin::CodeExamplePage::EvaluationCard @evaluation={{evaluation}} class="mb-4" />
-      {{/each}}
+    <div class="mt-6">
+      {{#if @isLoading}}
+        <div class="text-gray-400 dark:text-gray-600 text-sm py-8 text-center">
+          Loading evaluations...
+        </div>
+      {{else}}
+        {{#each this.sortedEvaluations as |evaluation|}}
+          <CourseAdmin::CodeExamplePage::EvaluationCard @evaluation={{evaluation}} class="mb-4" />
+        {{/each}}
+      {{/if}}
     </div>
   </Tabs>
 </div>

--- a/app/components/course-admin/code-example-evaluator-page/evaluations-section.ts
+++ b/app/components/course-admin/code-example-evaluator-page/evaluations-section.ts
@@ -11,6 +11,7 @@ export interface Signature {
 
   Args: {
     evaluator: CommunitySolutionEvaluatorModel;
+    isLoading: boolean;
     passEvaluations: CommunitySolutionEvaluationModel[];
     failEvaluations: CommunitySolutionEvaluationModel[];
     unsureEvaluations: CommunitySolutionEvaluationModel[];
@@ -19,7 +20,6 @@ export interface Signature {
 
 export default class EvaluationsSection extends Component<Signature> {
   @tracked activeTabSlug: 'fail' | 'pass' | 'unsure' = 'fail';
-  @tracked sortedEvaluations: CommunitySolutionEvaluationModel[] = [];
 
   get filteredEvaluations() {
     if (this.activeTabSlug === 'fail') {
@@ -31,6 +31,10 @@ export default class EvaluationsSection extends Component<Signature> {
     } else {
       throw new Error(`Invalid tab: ${this.activeTabSlug}`);
     }
+  }
+
+  get sortedEvaluations() {
+    return this.filteredEvaluations.toSorted(fieldComparator('updatedAt')).reverse();
   }
 
   get tabs() {
@@ -54,14 +58,8 @@ export default class EvaluationsSection extends Component<Signature> {
   }
 
   @action
-  handleDidInsertTabContents() {
-    this.sortedEvaluations = this.filteredEvaluations.toSorted(fieldComparator('updatedAt')).reverse();
-  }
-
-  @action
   handleTabChange(tab: Tab) {
     this.activeTabSlug = tab.slug as 'fail' | 'pass' | 'unsure';
-    this.handleDidInsertTabContents();
   }
 }
 

--- a/app/templates/course-admin/code-example-evaluator.hbs
+++ b/app/templates/course-admin/code-example-evaluator.hbs
@@ -97,9 +97,10 @@
 
       <CourseAdmin::CodeExampleEvaluatorPage::EvaluationsSection
         @evaluator={{@model.evaluator}}
-        @passEvaluations={{@model.passEvaluations}}
-        @failEvaluations={{@model.failEvaluations}}
-        @unsureEvaluations={{@model.unsureEvaluations}}
+        @passEvaluations={{this.passEvaluations}}
+        @failEvaluations={{this.failEvaluations}}
+        @unsureEvaluations={{this.unsureEvaluations}}
+        @isLoading={{this.loadEvaluationsTask.isRunning}}
         class="mt-8"
       />
     </div>


### PR DESCRIPTION
Update the evaluations section to show a loading indicator while evaluations
are being fetched. Pass isLoading from the page component to the evaluations
section and conditionally render a loading message instead of evaluation cards.

Remove unused code and imports in the route related to filtering and loading
evaluations, simplifying evaluation data handling and improving UI responsiveness.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes when/where evaluation records are fetched (route -> controller async task), which can affect loading timing, query-param refresh behavior, and potential UI empty states if the task isn’t triggered as expected.
> 
> **Overview**
> **Adds a loading state to the Recent Evaluations tabs** by passing `@isLoading` and rendering a "Loading evaluations..." placeholder instead of cards while data is fetched.
> 
> Refactors evaluation data loading so the route no longer queries evaluation/trusted-evaluation records in `model()`, and the controller now owns tracked `pass`/`fail`/`unsure` (and trusted) evaluation lists populated via a restartable `loadEvaluationsTask` kicked off in `setupController`. The evaluations list sorting is simplified to a computed getter (removing a `did-insert`-based update).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 420c98af69111537f917836ffa7efd14eb2fa433. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->