### PR TITLE
feat(promotional-discount): add usage tracking and active status

### DIFF
--- a/app/models/promotional-discount.ts
+++ b/app/models/promotional-discount.ts
@@ -10,10 +10,15 @@ export default class PromotionalDiscountModel extends Model {
 
   @attr('date') createdAt!: Date;
   @attr('date') expiresAt!: Date;
-  @attr('string') type!: 'signup' | 'affiliate_referral' | 'stage_2_completion' | 'membership_expiry';
   @attr('number') percentageOff!: number;
+  @attr('string') type!: 'signup' | 'affiliate_referral' | 'stage_2_completion' | 'membership_expiry';
+  @attr('date') usedAt!: Date | null;
 
   @service declare time: TimeService;
+
+  get isActive() {
+    return !this.isExpired && !this.isUsed;
+  }
 
   get isExpired() {
     // short-circuit, prevent re-computation
@@ -38,6 +43,10 @@ export default class PromotionalDiscountModel extends Model {
 
   get isFromStage2Completion() {
     return this.type === 'stage_2_completion';
+  }
+
+  get isUsed() {
+    return !!this.usedAt;
   }
 
   computeDiscountedPrice(price: number) {

--- a/app/models/user.ts
+++ b/app/models/user.ts
@@ -227,7 +227,7 @@ export default class UserModel extends Model {
     return (
       this.promotionalDiscounts
         .filter((item) => item.type === type)
-        .filter((item) => !item.isExpired)
+        .filter((item) => item.isActive)
         .sort(fieldComparator('createdAt'))
         .reverse()[0] || null
     );

--- a/tests/acceptance/pay-test.js
+++ b/tests/acceptance/pay-test.js
@@ -77,6 +77,23 @@ module('Acceptance | pay-test', function (hooks) {
     assert.strictEqual(this.server.schema.individualCheckoutSessions.first().promotionalDiscount.id, signupDiscount.id);
   });
 
+  test('used signup discount is not shown on pay page', async function (assert) {
+    testScenario(this.server);
+
+    const user = signIn(this.owner, this.server);
+
+    this.server.create('promotional-discount', {
+      userId: user.id,
+      type: 'signup',
+      percentageOff: 40,
+      expiresAt: new Date(new Date().getTime() + 24 * 60 * 60 * 1000),
+      usedAt: new Date(new Date().getTime() - 1 * 60 * 60 * 1000),
+    });
+
+    await payPage.visit();
+    assert.false(payPage.signupDiscountNotice.isVisible, 'should not show signup discount notice for used discount');
+  });
+
   test('user with stage2 discount can start checkout session', async function (assert) {
     testScenario(this.server);
 

--- a/tests/acceptance/view-discount-countdown-test.js
+++ b/tests/acceptance/view-discount-countdown-test.js
@@ -97,4 +97,17 @@ module('Acceptance | view-discount-countdown', function (hooks) {
     await catalogPage.visit();
     assert.notOk(catalogPage.header.discountTimerBadge.isVisible, 'Discount timer badge is not visible without active discount');
   });
+
+  test('discount timer badge is not visible when discount is used', async function (assert) {
+    this.server.schema.promotionalDiscounts.create({
+      user: this.currentUser,
+      type: 'signup',
+      percentageOff: 40,
+      expiresAt: new Date(new Date().getTime() + 1 * 60 * 60 * 1000),
+      usedAt: new Date(new Date().getTime() - 1 * 60 * 60 * 1000),
+    });
+
+    await catalogPage.visit();
+    assert.notOk(catalogPage.header.discountTimerBadge.isVisible, 'Discount timer badge is not visible when discount is used');
+  });
 });


### PR DESCRIPTION
Add usedAt attribute to track when a discount is used and implement isUsed
and isActive getters to determine discount usability. Update user model to
filter active discounts instead of only non-expired ones. This ensures expired
or already used discounts are excluded from active discount queries.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized eligibility change for promotional discounts; primary risk is incorrectly hiding valid discounts if `usedAt` is set unexpectedly or missing in API payloads.
> 
> **Overview**
> Promotional discounts now track usage via a new `usedAt` attribute, with derived `isUsed` and `isActive` getters so a discount is considered active only when *not expired and not used*.
> 
> `UserModel.activePromotionalDiscountForType()` is updated to select only `isActive` discounts (previously only filtered by `!isExpired`), which changes downstream UI/checkout behavior to hide used discounts. Acceptance tests are expanded to ensure used signup discounts don’t show on the pay page and don’t trigger the header discount countdown badge.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6e5160199fa0b88e8d562663c062c438083195be. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->