### PR TITLE
refactor(code-examples): remove staff-only sorting toggle

### DIFF
--- a/app/controllers/course/stage/code-examples.ts
+++ b/app/controllers/course/stage/code-examples.ts
@@ -21,7 +21,6 @@ export default class CodeExamplesController extends Controller {
   @service declare store: Store;
 
   rippleSpinnerImage = rippleSpinnerImage;
-  @tracked order: 'recommended' | 'experimental' = 'recommended';
   @tracked isLoading = true;
   @tracked requestedLanguage: LanguageModel | null = null; // This shouldn't be state on the controller, see if we can move it to a query param or so?
   @tracked solutions: CommunityCourseStageSolutionModel[] = [];
@@ -66,18 +65,6 @@ export default class CodeExamplesController extends Controller {
   }
 
   @action
-  handleOrderToggle() {
-    // For now we only support toggling between these two
-    if (this.order === 'recommended') {
-      this.order = 'experimental';
-    } else {
-      this.order = 'recommended';
-    }
-
-    this.loadSolutions();
-  }
-
-  @action
   handleRequestedLanguageChange(language: LanguageModel | undefined) {
     if (!language) {
       return;
@@ -104,7 +91,6 @@ export default class CodeExamplesController extends Controller {
       course_stage_id: this.courseStage.id,
       language_id: this.currentLanguage.id,
       include: CommunityCourseStageSolutionModel.defaultIncludedResources.join(','),
-      order: this.order,
     })) as unknown as CommunityCourseStageSolutionModel[]; // TODO: Doesn't store.query support model type inference?
 
     this.isLoading = false;

--- a/app/templates/course/stage/code-examples.hbs
+++ b/app/templates/course/stage/code-examples.hbs
@@ -26,18 +26,6 @@
     </div>
 
     <div class="shrink-0 flex items-center gap-3">
-      {{#if (or (current-user-is-staff) (current-user-is-course-author @model.courseStage.course))}}
-        <div class="flex items-center gap-2">
-          <div class="text-xs text-gray-400 dark:text-gray-500">
-            Use ratings
-          </div>
-
-          <Toggle @isOn={{eq this.order "experimental"}} {{on "click" this.handleOrderToggle}} class="shrink-0" />
-
-          <EmberTooltip @text="Only visible to staff & challenge authors. Toggle to sort by rankings." />
-        </div>
-      {{/if}}
-
       <LanguageDropdown
         @languages={{this.sortedLanguagesForDropdown}}
         @requestedLanguage={{this.requestedLanguage}}


### PR DESCRIPTION
Remove the "Use ratings" toggle that allowed staff and course authors to
sort code examples by ranking (experimental order). This feature was
rarely used and added unnecessary complexity. The code examples now
load solutions using the default recommended order only, simplifying
the UI and controller logic.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI/controller simplification; removes an optional staff-only query param so behavior now always uses the backend default ordering.
> 
> **Overview**
> Removes the staff/course-author-only "Use ratings" toggle from the code examples page and deletes the associated controller state/action.
> 
> `loadSolutions()` no longer sends an `order` parameter to the `community-course-stage-solution` query, so solutions always load using the default (recommended) API ordering.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 97de1e4f7fd0b81013d092e3dc0fdd135a2c1776. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->