### PR TITLE
Add maintenance redirect to vercel.json for all routes.

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -2,6 +2,7 @@
   "buildCommand": "scripts/build-vercel-output.sh",
   "installCommand": "bun install --frozen-lockfile --ignore-scripts",
   "redirects": [
+    { "source": "/(.*)", "destination": "https://codecrafters.io/heroku_pages/maintenance.html", "permanent": false },
     { "source": "/_empty.html", "destination": "/404" },
     { "source": "/_empty_notags.html", "destination": "/404" },
     { "source": "/package.json", "destination": "/404" },


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Low code risk but high operational impact since the catch-all redirect will take precedence and effectively disable normal routing for the site.
> 
> **Overview**
> Adds a catch-all Vercel redirect (`/(.*)`) to send all requests to an external maintenance page (`https://codecrafters.io/heroku_pages/maintenance.html`) as a *temporary (non-permanent)* redirect.
> 
> Because this rule is first in `redirects`, it effectively overrides all existing redirects/rewrites and forces the entire site into maintenance mode until removed.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5280c8730b1b99cb76aee1a41a5d215f6df43a93. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->