### PR TITLE
remove maintenance redirect from vercel configuration

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -2,7 +2,6 @@
   "buildCommand": "scripts/build-vercel-output.sh",
   "installCommand": "bun install --frozen-lockfile --ignore-scripts",
   "redirects": [
-    { "source": "/(.*)", "destination": "https://codecrafters.io/heroku_pages/maintenance.html", "permanent": false },
     { "source": "/_empty.html", "destination": "/404" },
     { "source": "/_empty_notags.html", "destination": "/404" },
     { "source": "/package.json", "destination": "/404" },


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Single config change limited to routing behavior; risk is mainly accidental exposure of the site if maintenance mode was still intended.
> 
> **Overview**
> Removes the `/(.*)` catch-all redirect to the external maintenance page from `vercel.json`, so requests will now follow the normal redirect/rewrite rules (e.g., `/` to `/catalog` and other specific redirects).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ec0c10b3063a3fa300b550ced5e2bd9728e02586. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->