### PR TITLE
Revert "Add maintenance redirect to vercel.json for downtime management"

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -2,7 +2,6 @@
   "buildCommand": "scripts/build-vercel-output.sh",
   "installCommand": "bun install --frozen-lockfile --ignore-scripts",
   "redirects": [
-    { "source": "/(.*)", "destination": "https://codecrafters.io/heroku_pages/maintenance.html", "permanent": false },
     { "source": "/_empty.html", "destination": "/404" },
     { "source": "/_empty_notags.html", "destination": "/404" },
     { "source": "/package.json", "destination": "/404" },


### PR DESCRIPTION
Reverts codecrafters-io/frontend#3744

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk config-only change that simply stops forcing all routes to a maintenance page; impact is limited to routing behavior during intended downtime windows.
> 
> **Overview**
> Removes the catch-all redirect in `vercel.json` that sent all requests to a maintenance HTML page.
> 
> As a result, normal redirects/rewrites apply again instead of globally overriding routing during downtime.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c44353e06c81079ff8468da28a84ac30e962cf57. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->