### PR TITLE
refactor: remove canViewAutofixFlow feature flag usage

### DIFF
--- a/app/components/course-page/test-results-bar/index.ts
+++ b/app/components/course-page/test-results-bar/index.ts
@@ -7,7 +7,6 @@ import { StepDefinition } from 'codecrafters-frontend/utils/course-page-step-lis
 import { tracked } from '@glimmer/tracking';
 import type AuthenticatorService from 'codecrafters-frontend/services/authenticator';
 import type CoursePageStateService from 'codecrafters-frontend/services/course-page-state';
-import type FeatureFlagsService from 'codecrafters-frontend/services/feature-flags';
 import type CourseStageStep from 'codecrafters-frontend/utils/course-page-step-list/course-stage-step';
 import type RepositoryModel from 'codecrafters-frontend/models/repository';
 import fade from 'ember-animated/transitions/fade';
@@ -32,7 +31,6 @@ export default class TestResultsBar extends Component<Signature> {
 
   @service declare authenticator: AuthenticatorService;
   @service declare coursePageState: CoursePageStateService;
-  @service declare featureFlags: FeatureFlagsService;
   @service declare screen: ScreenService;
 
   @tracked activeTabSlugForLeftPane = 'logs'; // 'logs' | 'autofix'
@@ -64,13 +62,11 @@ export default class TestResultsBar extends Component<Signature> {
       if (courseStageStep.courseStage.isFirst) {
         return ['logs'];
       } else {
-        if (this.featureFlags.canViewAutofixFlow && this.autofixRequestForActiveStep) {
+        if (this.autofixRequestForActiveStep) {
           return ['logs', 'autofix'];
         } else {
           return ['logs'];
         }
-
-        // return ['logs'];
       }
     } else {
       return ['logs'];

--- a/app/controllers/course/stage/instructions.ts
+++ b/app/controllers/course/stage/instructions.ts
@@ -3,7 +3,6 @@ import { service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 import type AuthenticatorService from 'codecrafters-frontend/services/authenticator';
 import type CoursePageStateService from 'codecrafters-frontend/services/course-page-state';
-import type FeatureFlagsService from 'codecrafters-frontend/services/feature-flags';
 import type CourseStageModel from 'codecrafters-frontend/models/course-stage';
 import type RepositoryModel from 'codecrafters-frontend/models/repository';
 import type CourseStageStep from 'codecrafters-frontend/utils/course-page-step-list/course-stage-step';
@@ -14,7 +13,6 @@ import type Store from '@ember-data/store';
 export default class CourseStageInstructionsController extends Controller {
   @service declare authenticator: AuthenticatorService;
   @service declare coursePageState: CoursePageStateService;
-  @service declare featureFlags: FeatureFlagsService;
   @service declare router: RouterService;
   @service declare store: Store;
 
@@ -64,26 +62,19 @@ export default class CourseStageInstructionsController extends Controller {
 
   @action
   handleDidUpdateTestsStatus(_element: HTMLDivElement, [newTestsStatus]: [CourseStageStep['testsStatus']]) {
-    if (this.featureFlags.canViewAutofixFlow) {
-      // For tests passed, let's collapse the test results bar and scroll all the way to the top
-      if (newTestsStatus === 'passed') {
-        this.coursePageState.testResultsBarIsExpanded = false;
-        document.getElementById('course-page-scrollable-area')?.scrollTo({ top: 0, behavior: 'smooth' });
-      }
+    // For tests passed, let's collapse the test results bar and scroll all the way to the top
+    if (newTestsStatus === 'passed') {
+      this.coursePageState.testResultsBarIsExpanded = false;
+      document.getElementById('course-page-scrollable-area')?.scrollTo({ top: 0, behavior: 'smooth' });
+    }
 
-      // When tests are run, let's expand the test results bar. It'll automatically collapse when tests pass.
-      if (
-        newTestsStatus === 'evaluating' &&
-        this.model.activeRepository.lastSubmission &&
-        !this.model.activeRepository.lastSubmission.clientTypeIsSystem
-      ) {
-        this.coursePageState.testResultsBarIsExpanded = true;
-      }
-    } else {
-      // For tests passed, let's scroll all the way to the top
-      if (newTestsStatus === 'passed') {
-        document.getElementById('course-page-scrollable-area')?.scrollTo({ top: 0, behavior: 'smooth' });
-      }
+    // When tests are run, let's expand the test results bar. It'll automatically collapse when tests pass.
+    if (
+      newTestsStatus === 'evaluating' &&
+      this.model.activeRepository.lastSubmission &&
+      !this.model.activeRepository.lastSubmission.clientTypeIsSystem
+    ) {
+      this.coursePageState.testResultsBarIsExpanded = true;
     }
   }
 

--- a/app/services/feature-flags.ts
+++ b/app/services/feature-flags.ts
@@ -14,10 +14,6 @@ export default class FeatureFlagsService extends Service {
     this.notifiedFeatureFlags = new Set();
   }
 
-  get canViewAutofixFlow(): boolean {
-    return !!(this.getFeatureFlagValue('can-view-autofix-flow') === 'test' || this.currentUser?.isStaff);
-  }
-
   get currentUser(): User | null {
     return this.authenticator.currentUser;
   }


### PR DESCRIPTION
Remove the canViewAutofixFlow flag from feature-flags service and all
consuming code in course stage instructions controller and test results
bar component. Simplify test status update handling by always collapsing
the test results bar on passed tests and expanding on evaluating status
when appropriate, without conditional feature flag checks. This cleanup
removes dead code and streamlines feature flag usage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small refactor removing a dead feature-flag gate; behavior changes are limited to when the Autofix tab and test-results-bar auto-expand/collapse logic triggers.
> 
> **Overview**
> Removes the `canViewAutofixFlow` computed flag from `FeatureFlagsService` and drops all injections/usages of `featureFlags` in the course stage instructions controller and `TestResultsBar`.
> 
> Autofix UI is now shown whenever an `autofixRequestForActiveStep` exists (instead of being feature-flag gated), and test status handling is simplified to always collapse the results bar on `passed` (with scroll-to-top) and expand on `evaluating` for non-system submissions.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7d5c7dc95f8d733df3eec982774bdb310ccea254. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->