### PR TITLE
Bun linting performance

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -94,13 +94,11 @@ export default defineConfig([
       'import/no-unresolved': 'off',
 
       // These import/* module-resolution rules are redundant with TypeScript/Glint
-      // type checking and are extremely expensive (~9s of ESLint's ~19s cold runtime).
-      // `import/namespace` alone accounts for 63.6% of ESLint rule time.
+      // type checking for .ts files, and are extremely expensive.
+      // `import/namespace` alone accounts for 63.6% of ESLint rule time (7.4s).
       'import/namespace': 'off',
       'import/named': 'off',
       'import/default': 'off',
-      'import/no-named-as-default': 'off',
-      'import/no-named-as-default-member': 'off',
 
       '@stylistic/padding-line-between-statements': [
         'error',

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "lint": "concurrently \"bun run lint:css\" \"bun run lint:hbs\" \"bun run lint:js\" \"bun run lint:types\" \"bun run lint:glint\" --names \"lint:css,lint:hbs,lint:js,lint:types,lint:glint\" --prefixColors auto",
     "lint:css": "stylelint \"**/*.css\"",
     "lint:css:fix": "bun run lint:css -- --fix",
-    "lint:fix": "concurrently \"bun run lint:css:fix\" \"bun run lint:hbs:fix\" \"bun run lint:js:fix\" \"bun run lint:glint:fix\" \"bun run format\" --names \"fix:css,fix:hbs,fix:js,fix:glint,format\" --prefixColors auto",
+    "lint:fix": "concurrently \"bun run lint:css:fix\" \"bun run lint:hbs:fix\" \"bun run lint:js:fix\" \"bun run lint:glint:fix\" --names \"fix:css,fix:hbs,fix:js,fix:glint\" --prefixColors auto && bun run format",
     "lint:format": "prettier . --cache --check",
     "lint:hbs": "ember-template-lint .",
     "lint:hbs:fix": "ember-template-lint . --fix",


### PR DESCRIPTION
**Checklist**:

- [ ] I've thoroughly self-reviewed my changes
- [ ] I've added tests for my changes, unless they affect admin-only areas (or are otherwise not worth testing)
- [ ] I've verified any visual changes using Percy (add a commit with `[percy]` in the message to trigger)

**Why**:
`bun run lint:fix` was slow. Benchmarking revealed the `import/namespace` ESLint rule alone took 7.4 seconds (63.6% of ESLint's time). This, along with `import/named` and `import/default`, is redundant for `.ts`/`.gts` files as TypeScript/Glint already perform these checks.

**What**:
- Disabled the `import/namespace`, `import/named`, and `import/default` ESLint rules. These are genuinely redundant with TypeScript/Glint for `.ts`/`.gts` files.
- Reverted `format` (prettier) to run sequentially after other linters to ensure it processes any fixes made by them.

**Impact**:
Significant speedup for `lint:fix`, primarily from disabling the `import/namespace` rule.

---
<p><a href="https://cursor.com/background-agent?bcId=bc-9b4cbca3-f3eb-42c8-bb2f-957abf8c5df9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-9b4cbca3-f3eb-42c8-bb2f-957abf8c5df9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Config-only change that trades a few ESLint import validations for TypeScript/Glint checks; low functional risk aside from potentially missing issues in non-TS files.
> 
> **Overview**
> Improves linting performance by disabling the expensive `eslint-plugin-import` rules `import/namespace`, `import/named`, and `import/default` (kept `import/no-unresolved` off), with comments noting these checks are redundant with TypeScript/Glint.
> 
> This reduces ESLint work during `bun run lint:fix` while leaving other stylistic and Ember rule enforcement unchanged.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6662aa8c36c222434f190b09760cc65ea9d35e2c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->