### PR TITLE
Next stage status messages

### DIFF
--- a/app/utils/course-page-step-list/course-stage-step.ts
+++ b/app/utils/course-page-step-list/course-stage-step.ts
@@ -78,19 +78,10 @@ Check the [How to pass this stage](#first-stage-tutorial-heading) section for in
 
   get progressIndicator(): ProgressIndicator | null {
     if (this.testsStatus === 'evaluating') {
-      if (this.lastSubmissionIsSystemInitiated) {
-        return {
-          dotColor: 'yellow',
-          dotType: 'blinking',
-          text: 'Checking next stage\u2026',
-          textColor: 'yellow',
-        };
-      }
-
       return {
         dotColor: 'yellow',
         dotType: 'blinking',
-        text: 'Running tests...',
+        text: this.lastSubmissionIsSystemInitiated ? 'Checking next stage...' : 'Running tests...',
         textColor: 'yellow',
       };
     } else if (this.status === 'complete') {
@@ -115,19 +106,10 @@ Check the [How to pass this stage](#first-stage-tutorial-heading) section for in
         explanationMarkdown: this.courseStage.isFirst ? this.firstStageTestFailureExplanationMarkdown : undefined,
       };
     } else if (this.testsStatus === 'passed') {
-      if (this.lastSubmissionIsSystemInitiated) {
-        return {
-          dotColor: 'green',
-          dotType: 'static',
-          text: 'Next stage already implemented!',
-          textColor: 'green',
-        };
-      }
-
       return {
         dotColor: 'green',
         dotType: 'static',
-        text: 'Tests passed!',
+        text: this.lastSubmissionIsSystemInitiated ? 'Next stage already implemented!' : 'Tests passed!',
         textColor: 'green',
       };
     } else if (this.status === 'in_progress') {

--- a/tests/acceptance/course-page/attempt-course-stage-test.js
+++ b/tests/acceptance/course-page/attempt-course-stage-test.js
@@ -134,7 +134,7 @@ module('Acceptance | course-page | attempt-course-stage', function (hooks) {
 
     assert.strictEqual(
       coursePage.testResultsBar.progressIndicatorText,
-      'Checking next stage\u2026',
+      'Checking next stage...',
       'footer text is checking next stage for system-initiated evaluating submission',
     );
   });


### PR DESCRIPTION
**Checklist**:

- [x] I've thoroughly self-reviewed my changes
- [x] I've added tests for my changes, unless they affect admin-only areas (or are otherwise not worth testing)
- [ ] I've verified any visual changes using Percy (add a commit with `[percy]` in the message to trigger)

This PR implements distinct progress indicator messages for system-initiated submissions (`clientType: 'system'`) on the course page.

**Why these changes?**
To provide clearer UI feedback to users when the system is automatically evaluating their progress or providing solutions, differentiating it from user-initiated (git/CLI) submissions.

**What's changed?**
- Introduced a `lastSubmissionIsSystemInitiated` getter in `course-stage-step.ts`.
- Updated the `progressIndicator` getter to display specific messages for system-initiated submissions:
    - **Evaluating**: "Checking next stage…"
    - **Failed**: "Ready to run tests"
    - **Passed**: "Next stage already implemented!"
- Added new acceptance tests to `attempt-course-stage-test.js` to cover these system-initiated scenarios.

---
[Slack Thread](https://codecrafters-io.slack.com/archives/C07H9EY1Z6X/p1770087178138279?thread_ts=1770087178.138279&cid=C07H9EY1Z6X)

<p><a href="https://cursor.com/background-agent?bcId=bc-1a62d22b-448c-5f2d-89dc-c3243ec84ce3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-1a62d22b-448c-5f2d-89dc-c3243ec84ce3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI copy changes gated on `clientTypeIsSystem`, plus new acceptance coverage; minimal behavioral impact outside course page progress indicator text.
> 
> **Overview**
> Course page progress indicator messaging now differentiates *system-initiated* submissions (`clientType: 'system'`) from user-initiated runs. When the latest submission is system-triggered, the footer text changes to **"Checking next stage..."** (evaluating), **"Ready to run tests"** (failed), and **"Next stage already implemented!"** (passed), while preserving existing messaging for other submission types.
> 
> Adds acceptance tests covering the evaluating/failed/passed system-initiated scenarios to prevent regressions.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit be1e8a5484806e17fabace8d1ee4cbaa52337184. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->