### PR TITLE
fix(modal-body): make allowManualClose prop required

### DIFF
--- a/app/components/affiliate-page/create-payout-modal/index.hbs
+++ b/app/components/affiliate-page/create-payout-modal/index.hbs
@@ -1,4 +1,4 @@
-<ModalBody @allowManualClose={{true}} @onClose={{@onClose}} class="w-full max-w-xl" data-test-create-payout-modal>
+<ModalBody @shouldCloseOnOutsideClick={{true}} @shouldShowCloseButton={{true}} @onClose={{@onClose}} class="w-full max-w-xl" data-test-create-payout-modal>
   <div class="mb-8 font-semibold text-2xl text-gray-600 mr-6">
     Initiate payout
   </div>

--- a/app/components/concept-admin/delete-concept-modal.hbs
+++ b/app/components/concept-admin/delete-concept-modal.hbs
@@ -1,4 +1,4 @@
-<ModalBody @allowManualClose={{true}} @onClose={{@onClose}} class="w-full max-w-xl" data-test-delete-concept-modal>
+<ModalBody @shouldCloseOnOutsideClick={{true}} @shouldShowCloseButton={{true}} @onClose={{@onClose}} class="w-full max-w-xl" data-test-delete-concept-modal>
   <div class="mb-6 font-semibold text-2xl text-gray-600 mr-8">
     Delete Concept
   </div>

--- a/app/components/course-page/configure-extensions-modal/index.hbs
+++ b/app/components/course-page/configure-extensions-modal/index.hbs
@@ -1,4 +1,4 @@
-<ModalBody @allowManualClose={{true}} @onClose={{@onClose}} class="w-full max-w-(--breakpoint-lg)" data-test-configure-extensions-modal>
+<ModalBody @shouldCloseOnOutsideClick={{true}} @shouldShowCloseButton={{true}} @onClose={{@onClose}} class="w-full max-w-(--breakpoint-lg)" data-test-configure-extensions-modal>
   <div class="mb-6 font-semibold text-2xl text-gray-900 dark:text-gray-50 mr-8">
     Configure Extensions
   </div>

--- a/app/components/course-page/configure-github-integration-modal/index.hbs
+++ b/app/components/course-page/configure-github-integration-modal/index.hbs
@@ -1,4 +1,4 @@
-<ModalBody @allowManualClose={{true}} @onClose={{@onClose}} class="w-full max-w-xl" data-test-configure-github-integration-modal>
+<ModalBody @shouldCloseOnOutsideClick={{true}} @shouldShowCloseButton={{true}} @onClose={{@onClose}} class="w-full max-w-xl" data-test-configure-github-integration-modal>
   <div class="mb-6 font-semibold text-2xl text-gray-900 dark:text-gray-50 mr-8">
     Publish to GitHub
   </div>

--- a/app/components/course-page/course-stage-step/first-stage-your-task-card/submit-code-step.hbs
+++ b/app/components/course-page/course-stage-step/first-stage-your-task-card/submit-code-step.hbs
@@ -38,7 +38,7 @@
 
 {{#if this.isCommitModalOpen}}
   <ModalBackdrop class="cursor-pointer">
-    <ModalBody @allowManualClose={{true}} @onClose={{this.handleCommitModalClose}} class="w-fit cursor-default max-w-(--breakpoint-lg)">
+    <ModalBody @shouldCloseOnOutsideClick={{true}} @shouldShowCloseButton={{true}} @onClose={{this.handleCommitModalClose}} class="w-fit cursor-default max-w-(--breakpoint-lg)">
       <div class="mb-6 font-semibold text-2xl text-gray-900 dark:text-gray-200 mr-8">
         Commit changes
       </div>
@@ -110,7 +110,7 @@
 
 {{#if this.isPushModalOpen}}
   <ModalBackdrop class="cursor-pointer">
-    <ModalBody @allowManualClose={{true}} @onClose={{this.handlePushModalClose}} class="w-fit cursor-default max-w-(--breakpoint-lg)">
+    <ModalBody @shouldCloseOnOutsideClick={{true}} @shouldShowCloseButton={{true}} @onClose={{this.handlePushModalClose}} class="w-fit cursor-default max-w-(--breakpoint-lg)">
       <div class="mb-6 font-semibold text-2xl text-gray-900 dark:text-gray-200 mr-8">
         Push changes
       </div>

--- a/app/components/course-page/course-stage-step/stage-incomplete-modal.hbs
+++ b/app/components/course-page/course-stage-step/stage-incomplete-modal.hbs
@@ -1,4 +1,4 @@
-<ModalBody @allowManualClose={{false}} @onClose={{@onClose}} class="w-full max-w-xl" data-test-stage-incomplete-modal>
+<ModalBody @shouldCloseOnOutsideClick={{false}} @shouldShowCloseButton={{false}} @onClose={{@onClose}} class="w-full max-w-xl" data-test-stage-incomplete-modal>
   <div class="mb-4 font-semibold text-2xl text-gray-900 dark:text-gray-100 mr-6">
     Stage incomplete
   </div>

--- a/app/components/course-page/course-stage-step/tests-passed-modal/index.hbs
+++ b/app/components/course-page/course-stage-step/tests-passed-modal/index.hbs
@@ -1,4 +1,4 @@
-<ModalBody class="w-full max-w-xl" @allowManualClose={{false}} @onClose={{@onClose}} data-test-tests-passed-modal ...attributes>
+<ModalBody class="w-full max-w-xl" @shouldCloseOnOutsideClick={{false}} @shouldShowCloseButton={{false}} @onClose={{@onClose}} data-test-tests-passed-modal ...attributes>
   <AnimatedContainer>
     <div class="flex flex-col items-center w-full">
       {{#animated-if (eq this.action "choose_action")}}

--- a/app/components/course-page/current-step-complete-modal.hbs
+++ b/app/components/course-page/current-step-complete-modal.hbs
@@ -1,4 +1,4 @@
-<ModalBody @allowManualClose={{false}} @onClose={{@onClose}} data-test-current-step-complete-modal class="max-w-xl" ...attributes>
+<ModalBody @shouldCloseOnOutsideClick={{false}} @shouldShowCloseButton={{false}} @onClose={{@onClose}} data-test-current-step-complete-modal class="max-w-xl" ...attributes>
   <div class="flex flex-col items-center w-full">
     <div class="text-[60px]">
       🎉

--- a/app/components/course-page/delete-repository-modal.hbs
+++ b/app/components/course-page/delete-repository-modal.hbs
@@ -1,4 +1,4 @@
-<ModalBody @allowManualClose={{true}} @onClose={{@onClose}} class="w-full max-w-xl" data-test-delete-repository-modal>
+<ModalBody @shouldCloseOnOutsideClick={{true}} @shouldShowCloseButton={{true}} @onClose={{@onClose}} class="w-full max-w-xl" data-test-delete-repository-modal>
   <div class="mb-6 font-semibold text-2xl text-gray-900 dark:text-gray-200 mr-8">
     Delete Repository
   </div>

--- a/app/components/course-page/previous-steps-incomplete-modal.hbs
+++ b/app/components/course-page/previous-steps-incomplete-modal.hbs
@@ -1,4 +1,4 @@
-<ModalBody @allowManualClose={{false}} @onClose={{@onClose}} data-test-previous-steps-incomplete-modal class="max-w-xl" ...attributes>
+<ModalBody @shouldCloseOnOutsideClick={{false}} @shouldShowCloseButton={{false}} @onClose={{@onClose}} data-test-previous-steps-incomplete-modal class="max-w-xl" ...attributes>
   <div class="flex flex-col items-center w-full max-w-2xs">
     <div class="w-16 h-16 mb-3">
       <RiveAnimation @src="/assets/animations/warning_icon.riv" />

--- a/app/components/course-page/progress-banner-modal.hbs
+++ b/app/components/course-page/progress-banner-modal.hbs
@@ -1,4 +1,4 @@
-<ModalBody @allowManualClose={{true}} @onClose={{@onClose}} class="w-full max-w-xl" data-test-progress-banner-modal>
+<ModalBody @shouldCloseOnOutsideClick={{true}} @shouldShowCloseButton={{true}} @onClose={{@onClose}} class="w-full max-w-xl" data-test-progress-banner-modal>
   <div class="mb-6 font-semibold text-2xl text-gray-600 mr-6">
     Progress Banner
   </div>

--- a/app/components/course-page/setup-step-complete-modal.hbs
+++ b/app/components/course-page/setup-step-complete-modal.hbs
@@ -1,4 +1,4 @@
-<ModalBody @allowManualClose={{false}} @onClose={{@onClose}} data-test-setup-step-complete-modal class="px-0! py-0! max-w-xl" ...attributes>
+<ModalBody @shouldCloseOnOutsideClick={{false}} @shouldShowCloseButton={{false}} @onClose={{@onClose}} data-test-setup-step-complete-modal class="px-0! py-0! max-w-xl" ...attributes>
   <AnimatedContainer>
     <div class="flex flex-col items-center py-8 px-4 sm:px-8" {{did-insert this.handleDidInsert}}>
       {{#animated-value this.currentScreen use=this.transition duration=500 as |currentScreen|}}

--- a/app/components/course-page/setup-step/repository-setup-card/troubleshooting-modal.hbs
+++ b/app/components/course-page/setup-step/repository-setup-card/troubleshooting-modal.hbs
@@ -1,4 +1,4 @@
-<ModalBody @allowManualClose={{true}} @onClose={{@onClose}} class="w-fit cursor-default max-w-xl" data-test-troubleshooting-modal>
+<ModalBody @shouldCloseOnOutsideClick={{true}} @shouldShowCloseButton={{true}} @onClose={{@onClose}} class="w-fit cursor-default max-w-xl" data-test-troubleshooting-modal>
   <div class="mb-6 font-semibold text-2xl text-gray-900 dark:text-gray-200 mr-8">
     Need help?
   </div>

--- a/app/components/course-page/share-progress-modal/index.hbs
+++ b/app/components/course-page/share-progress-modal/index.hbs
@@ -1,4 +1,4 @@
-<ModalBody @allowManualClose={{true}} @onClose={{@onClose}} class="w-full max-w-xl" data-test-share-progress-modal>
+<ModalBody @shouldCloseOnOutsideClick={{true}} @shouldShowCloseButton={{true}} @onClose={{@onClose}} class="w-full max-w-xl" data-test-share-progress-modal>
   <div class="mb-6 font-semibold text-2xl text-gray-900 dark:text-gray-50 mr-6">
     Share your progress with friends
   </div>

--- a/app/components/institution-page/campus-program-application-modal.hbs
+++ b/app/components/institution-page/campus-program-application-modal.hbs
@@ -1,4 +1,4 @@
-<ModalBody @allowManualClose={{true}} @onClose={{@onClose}} class="w-full max-w-xl" data-test-campus-program-application-modal>
+<ModalBody @shouldCloseOnOutsideClick={{true}} @shouldShowCloseButton={{true}} @onClose={{@onClose}} class="w-full max-w-xl" data-test-campus-program-application-modal>
   <div class="mb-6 font-semibold text-2xl text-gray-900 dark:text-gray-200 mr-8">
     Campus Program Application
   </div>

--- a/app/components/modal-body.hbs
+++ b/app/components/modal-body.hbs
@@ -3,7 +3,7 @@
   {{on-click-outside this.handleClickOutside}}
   ...attributes
 >
-  {{#if (and @allowManualClose (not @shouldHideCloseButton))}}
+  {{#if @shouldShowCloseButton}}
     <button
       class="absolute right-6 top-6 sm:right-12 sm:top-12 opacity-60 hover:opacity-100"
       type="button"

--- a/app/components/modal-body.ts
+++ b/app/components/modal-body.ts
@@ -5,9 +5,9 @@ interface Signature {
   Element: HTMLDivElement;
 
   Args: {
-    allowManualClose?: boolean;
+    shouldCloseOnOutsideClick: boolean;
+    shouldShowCloseButton: boolean;
     onClose?: () => void;
-    shouldHideCloseButton?: boolean;
   };
 
   Blocks: {
@@ -18,7 +18,7 @@ interface Signature {
 export default class ModalBody extends Component<Signature> {
   @action
   handleClickOutside() {
-    if (this.args.allowManualClose) {
+    if (this.args.shouldCloseOnOutsideClick) {
       this.handleCloseButtonClick();
     }
   }

--- a/app/components/pay-page/choose-membership-plan-modal.hbs
+++ b/app/components/pay-page/choose-membership-plan-modal.hbs
@@ -1,6 +1,6 @@
 <ModalBody
-  @allowManualClose={{true}}
-  @shouldHideCloseButton={{true}}
+  @shouldCloseOnOutsideClick={{true}}
+  @shouldShowCloseButton={{false}}
   @onClose={{@onClose}}
   class="w-full max-w-xl"
   data-test-choose-membership-plan-modal

--- a/app/components/settings/delete-account-modal.hbs
+++ b/app/components/settings/delete-account-modal.hbs
@@ -1,4 +1,4 @@
-<ModalBody @allowManualClose={{true}} @onClose={{@onClose}} class="w-full max-w-xl" data-test-delete-account-modal>
+<ModalBody @shouldCloseOnOutsideClick={{true}} @shouldShowCloseButton={{true}} @onClose={{@onClose}} class="w-full max-w-xl" data-test-delete-account-modal>
   <div class="mb-6 font-semibold text-2xl text-gray-600 mr-8">
     Delete Account
   </div>


### PR DESCRIPTION
Change allowManualClose from optional to required in the modal-body
component. This ensures explicit control over the manual close behavior
and prevents potential undefined states when closing the modal.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mechanical API rename across templates with small behavioral risk limited to modal close interactions (outside click / close button visibility).
> 
> **Overview**
> Standardizes `ModalBody` close semantics by **removing** `@allowManualClose` and `@shouldHideCloseButton` and **requiring** callers to pass `@shouldCloseOnOutsideClick` and `@shouldShowCloseButton`.
> 
> Updates all existing modal templates to use the new API, including cases where outside-click closing is disabled and/or the close button is hidden (e.g. membership plan modal).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2d76726afe8d94eadbb30eefb4f7154f7876257e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->