### PR TITLE
feat: add ember-animated-tools v2.0.0 dependency

### DIFF
--- a/app/templates/application.hbs
+++ b/app/templates/application.hbs
@@ -21,6 +21,9 @@
   {{#if this.beacon.shouldShowBeacon}}
     <HelpscoutBeacon />
   {{/if}}
+
+  {{! Enable this to debug ember-animated animations }}
+  {{! <AnimatedTools /> }}
 </div>
 
 <LoadingIndicatorRemover />

--- a/bun.lock
+++ b/bun.lock
@@ -13,6 +13,7 @@
         "ansi_up": "^6.0.6",
         "array-to-sentence": "^2.0.0",
         "dompurify": "^3.3.1",
+        "ember-animated-tools": "^2.0.0",
         "escape-html": "^1.0.3",
         "fuse.js": "^7.0.0",
         "lottie-web": "^5.13.0",
@@ -1821,6 +1822,8 @@
     "electron-to-chromium": ["electron-to-chromium@1.5.267", "", {}, "sha512-0Drusm6MVRXSOJpGbaSVgcQsuB4hEkMpHXaVstcPmhu5LIedxs1xNK/nIxmQIU/RPC0+1/o0AVZfBTkTNJOdUw=="],
 
     "ember-animated": ["ember-animated@2.2.0", "", { "dependencies": { "@embroider/addon-shim": "^1.8.9", "@embroider/macros": "^1.13.3", "assert-never": "^1.2.1", "decorator-transforms": "^2.2.2", "ember-element-helper": ">=0.6.1" }, "peerDependencies": { "@ember/test-helpers": "^2.6.0 || ^3.0.0 || >= 4.0.0" } }, "sha512-5B1cuGiVwkzpPEFSFtH8WyFpHwJtH+lXWZTob6jmel7xYRdrvjpRx8QV/FRnE/IJ/wQvqjk7Q7O2Xtm8LRI5OA=="],
+
+    "ember-animated-tools": ["ember-animated-tools@2.0.0", "", { "dependencies": { "@embroider/addon-shim": "^1.8.7", "decorator-transforms": "^1.0.3", "ember-animated": "^1.0.0 || ^2.0.0" } }, "sha512-BEMUHw36pce+aKAaTKRn3/6p83+s/5IrIykKQWBH2vcY65jixvBbud9mjIU6zBmn2BU58no1vaqcGopLmKXkQQ=="],
 
     "ember-api-actions": ["ember-api-actions@git+ssh://git@github.com/codecrafters-io/ember-api-actions.git#906edb93b9af383ee8190ac8072c5e153563482a", { "dependencies": { "ember-cli-babel": "^7.1.3", "ember-cli-typescript": "^3.0.0" } }, "906edb93b9af383ee8190ac8072c5e153563482a"],
 
@@ -4410,6 +4413,8 @@
 
     "ember-animated/@embroider/addon-shim": ["@embroider/addon-shim@1.10.0", "", { "dependencies": { "@embroider/shared-internals": "^3.0.0", "broccoli-funnel": "^3.0.8", "common-ancestor-path": "^1.0.1", "semver": "^7.3.8" } }, "sha512-gcJuHiXgnrzaU8NyU+2bMbtS6PNOr5v5B8OXBqaBvTCsMpXLvKo8OBOQFCoUN0rPX2J6VaFqrbi/371sMvzZug=="],
 
+    "ember-animated-tools/decorator-transforms": ["decorator-transforms@1.2.1", "", { "dependencies": { "@babel/plugin-syntax-decorators": "^7.23.3", "babel-import-util": "^2.0.1" } }, "sha512-UUtmyfdlHvYoX3VSG1w5rbvBQ2r5TX1JsE4hmKU9snleFymadA3VACjl6SRfi9YgBCSjBbfQvR1bs9PRW9yBKw=="],
+
     "ember-api-actions/ember-cli-babel": ["ember-cli-babel@7.26.11", "", { "dependencies": { "@babel/core": "^7.12.0", "@babel/helper-compilation-targets": "^7.12.0", "@babel/plugin-proposal-class-properties": "^7.16.5", "@babel/plugin-proposal-decorators": "^7.13.5", "@babel/plugin-proposal-private-methods": "^7.16.5", "@babel/plugin-proposal-private-property-in-object": "^7.16.5", "@babel/plugin-transform-modules-amd": "^7.13.0", "@babel/plugin-transform-runtime": "^7.13.9", "@babel/plugin-transform-typescript": "^7.13.0", "@babel/polyfill": "^7.11.5", "@babel/preset-env": "^7.16.5", "@babel/runtime": "7.12.18", "amd-name-resolver": "^1.3.1", "babel-plugin-debug-macros": "^0.3.4", "babel-plugin-ember-data-packages-polyfill": "^0.1.2", "babel-plugin-ember-modules-api-polyfill": "^3.5.0", "babel-plugin-module-resolver": "^3.2.0", "broccoli-babel-transpiler": "^7.8.0", "broccoli-debug": "^0.6.4", "broccoli-funnel": "^2.0.2", "broccoli-source": "^2.1.2", "calculate-cache-key-for-tree": "^2.0.0", "clone": "^2.1.2", "ember-cli-babel-plugin-helpers": "^1.1.1", "ember-cli-version-checker": "^4.1.0", "ensure-posix-path": "^1.0.2", "fixturify-project": "^1.10.0", "resolve-package-path": "^3.1.0", "rimraf": "^3.0.1", "semver": "^5.5.0" } }, "sha512-JJYeYjiz/JTn34q7F5DSOjkkZqy8qwFOOxXfE6pe9yEJqWGu4qErKxlz8I22JoVEQ/aBUO+OcKTpmctvykM9YA=="],
 
     "ember-api-actions/ember-cli-typescript": ["ember-cli-typescript@3.1.4", "", { "dependencies": { "@babel/plugin-proposal-nullish-coalescing-operator": "^7.4.4", "@babel/plugin-proposal-optional-chaining": "^7.6.0", "@babel/plugin-transform-typescript": "~7.8.0", "ansi-to-html": "^0.6.6", "broccoli-stew": "^3.0.0", "debug": "^4.0.0", "ember-cli-babel-plugin-helpers": "^1.0.0", "execa": "^3.0.0", "fs-extra": "^8.0.0", "resolve": "^1.5.0", "rsvp": "^4.8.1", "semver": "^6.3.0", "stagehand": "^1.0.0", "walk-sync": "^2.0.0" } }, "sha512-HJ73kL45OGRmIkPhBNFt31I1SGUvdZND+LCH21+qpq3pPlFpJG8GORyXpP+2ze8PbnITNLzwe5AwUrpyuRswdQ=="],
@@ -5699,6 +5704,8 @@
     "data-urls/whatwg-url/tr46": ["tr46@5.1.1", "", { "dependencies": { "punycode": "^2.3.1" } }, "sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw=="],
 
     "decorator-transforms/@babel/plugin-syntax-decorators/@babel/helper-plugin-utils": ["@babel/helper-plugin-utils@7.27.1", "", {}, "sha512-1gn1Up5YXka3YYAHGKpbideQ5Yjf1tDa9qYcgysz+cNCXukyLl6DjPXhD3VRwSb8c0J9tA4b2+rHEZtc6R0tlw=="],
+
+    "ember-animated-tools/decorator-transforms/@babel/plugin-syntax-decorators": ["@babel/plugin-syntax-decorators@7.27.1", "", { "dependencies": { "@babel/helper-plugin-utils": "^7.27.1" }, "peerDependencies": { "@babel/core": "^7.0.0-0" } }, "sha512-YMq8Z87Lhl8EGkmb0MwYkt36QnxC+fzCgrl66ereamPlYToRpIk5nUjKUY3QKLWq8mwUB1BgbeXcTJhZOCDg5A=="],
 
     "ember-animated/@embroider/addon-shim/@embroider/shared-internals": ["@embroider/shared-internals@3.0.2", "", { "dependencies": { "babel-import-util": "^3.0.1", "debug": "^4.3.2", "ember-rfc176-data": "^0.3.17", "fs-extra": "^9.1.0", "is-subdir": "^1.2.0", "js-string-escape": "^1.0.1", "lodash": "^4.17.21", "minimatch": "^3.0.4", "pkg-entry-points": "^1.1.1", "resolve-package-path": "^4.0.1", "resolve.exports": "^2.0.2", "semver": "^7.3.5", "typescript-memoize": "^1.0.1" } }, "sha512-/SusdG+zgosc3t+9sPFVKSFOYyiSgLfXOT6lYNWoG1YtnhWDxlK4S8leZ0jhcVjemdaHln5rTyxCnq8oFLxqpQ=="],
 
@@ -7453,6 +7460,8 @@
     "core-object/chalk/ansi-styles/color-convert": ["color-convert@1.9.3", "", { "dependencies": { "color-name": "1.1.3" } }, "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg=="],
 
     "core-object/chalk/supports-color/has-flag": ["has-flag@3.0.0", "", {}, "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw=="],
+
+    "ember-animated-tools/decorator-transforms/@babel/plugin-syntax-decorators/@babel/helper-plugin-utils": ["@babel/helper-plugin-utils@7.27.1", "", {}, "sha512-1gn1Up5YXka3YYAHGKpbideQ5Yjf1tDa9qYcgysz+cNCXukyLl6DjPXhD3VRwSb8c0J9tA4b2+rHEZtc6R0tlw=="],
 
     "ember-animated/@embroider/addon-shim/@embroider/shared-internals/babel-import-util": ["babel-import-util@3.0.1", "", {}, "sha512-2copPaWQFUrzooJVIVZA/Oppx/S/KOoZ4Uhr+XWEQDMZ8Rvq/0SNQpbdIyMBJ8IELWt10dewuJw+tX4XjOo7Rg=="],
 

--- a/package.json
+++ b/package.json
@@ -219,6 +219,7 @@
     "ansi_up": "^6.0.6",
     "array-to-sentence": "^2.0.0",
     "dompurify": "^3.3.1",
+    "ember-animated-tools": "^2.0.0",
     "escape-html": "^1.0.3",
     "fuse.js": "^7.0.0",
     "lottie-web": "^5.13.0",


### PR DESCRIPTION
Add ember-animated-tools@2.0.0 package with its dependencies and
integrate it into the bun.lock manifest. This update enables the use
of the latest ember-animated-tools features and ensures compatibility
with ember-animated versions 1.x and 2.x. It also updates decorator-
transforms to support ember-animated-tools requirements.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dependency-only change plus a commented template snippet; runtime behavior is unchanged unless the debug component is manually enabled.
> 
> **Overview**
> Adds `ember-animated-tools@^2.0.0` to `package.json` and updates `bun.lock` with the new package and its transitive dependencies.
> 
> Also adds a commented-out `<AnimatedTools />` snippet in `application.hbs` as an opt-in hook to enable animation debugging when needed.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit dea7b25377835380a1f4d369025002b480ae5c8b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->