### PR TITLE
style: remove redundant width and max-width classes from modal

### DIFF
--- a/app/components/course-page/setup-step-complete-modal.hbs
+++ b/app/components/course-page/setup-step-complete-modal.hbs
@@ -3,7 +3,6 @@
   @shouldShowCloseButton={{true}}
   @onClose={{@onClose}}
   data-test-setup-step-complete-modal
-  class="w-full max-w-sm"
   ...attributes
 >
   <AnimatedContainer>


### PR DESCRIPTION
Eliminate unnecessary "w-full max-w-sm" classes from the setup
step complete modal component to simplify styling and rely on
existing layout constraints. This cleanup helps maintain consistent
styles and reduces potential conflicts in the UI.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Styling-only change that removes container sizing classes; main risk is minor layout/regression in the modal’s width on some screens.
> 
> **Overview**
> Removes the `class="w-full max-w-sm"` sizing on `ModalBody` in `course-page/setup-step-complete-modal.hbs`, relying on existing layout constraints instead.
> 
> Per-screen child components keep their own `w-full` and calculated `max-w[...]` constraints, so only the modal container’s outer width behavior changes.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 70d9d4582b2d035c2e3b9391739472349a13e6bc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->