### PR TITLE
style: update border color of submission logs preview

### DIFF
--- a/app/components/course-page/test-results-bar/index.hbs
+++ b/app/components/course-page/test-results-bar/index.hbs
@@ -29,7 +29,7 @@
           @activeTabSlug={{this.activeTabSlugForLeftPane}}
           @onActiveTabSlugChange={{fn (mut this.activeTabSlugForLeftPane)}}
           @availableTabSlugs={{this.availableTabSlugsForLeftPane}}
-          class="transition-width duration-200 ease-out {{if this.shouldShowRightPane 'w-1/2' 'w-full'}} grow"
+          class="transition-width duration-200 ease-out w-full grow"
         >
           {{#if (eq this.activeTabSlugForLeftPane "logs")}}
             <CoursePage::TestResultsBar::LogsSection
@@ -50,7 +50,7 @@
           @activeTabSlug={{this.activeTabSlugForRightPane}}
           @onActiveTabSlugChange={{fn (mut this.activeTabSlugForRightPane)}}
           @availableTabSlugs={{this.availableTabSlugsForRightPane}}
-          class="transition-[width,opacity] duration-200 ease-out {{if this.shouldShowRightPane 'w-1/2 pl-6 opacity-100' 'w-[0] opacity-0'}} grow"
+          class="transition-[width,opacity] duration-200 ease-out {{if this.shouldShowRightPane 'w-full pl-4 opacity-100 grow' 'w-0 opacity-0'}}"
         >
           {{! Extra if convinces glint that autofixRequest is not null }}
           {{#if this.autofixRequestForActiveStep}}

--- a/app/components/submission-logs-preview.hbs
+++ b/app/components/submission-logs-preview.hbs
@@ -1,5 +1,5 @@
 <div
-  class="bg-gray-900 dark:bg-gray-900 border border-gray-700 p-4 text-white font-mono text-xs leading-relaxed rounded-sm overflow-y-auto"
+  class="bg-gray-900 dark:bg-gray-900 border border-white/10 p-4 text-white font-mono text-xs leading-relaxed rounded-sm overflow-y-auto"
   {{did-insert this.handleDidInsert}}
   {{did-update this.handleDidUpdateLogs this.evaluation.logsFileContents}}
   {{did-update this.handleDidUpdateEvaluation this.evaluation.id}}


### PR DESCRIPTION
Change the border color from gray-700 to white with 10% opacity in the
submission-logs-preview component. This improves the visual contrast and
aligns the border style with the dark theme design for better readability.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Purely presentational Tailwind class changes affecting layout transitions and border styling; no business logic or data handling is modified.
> 
> **Overview**
> Updates `CoursePage::TestResultsBar` pane sizing so the left pane stays `w-full` and the right pane toggles between `w-full` (with padding/grow) and `w-0` when shown/hidden, changing the split-view width behavior and transitions.
> 
> Tweaks `submission-logs-preview` styling by changing the border from `border-gray-700` to `border-white/10` for better contrast in dark theme.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 450229d12d48072cbec60869437daf87b8781b3a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->