### PR TITLE
fix(modal): adjust max width for tests passed modal

### DIFF
--- a/app/components/course-page/course-stage-step/tests-passed-modal/index.hbs
+++ b/app/components/course-page/course-stage-step/tests-passed-modal/index.hbs
@@ -1,5 +1,6 @@
 <ModalBody
-  class="w-full max-w-2xs"
+  {{! in-between max-w-sm and max-w-md }}
+  class="w-full max-w-104"
   @shouldCloseOnOutsideClick={{true}}
   @shouldShowCloseButton={{true}}
   @onClose={{@onClose}}


### PR DESCRIPTION
Increase max width from 2xs to a custom max-w-104 to better fit content
between max-w-sm and max-w-md. This improves modal appearance and avoids
excessive whitespace on larger screens.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Simple template/CSS class tweak limited to modal sizing with no logic, data, or security impact.
> 
> **Overview**
> Updates `course-stage-step/tests-passed-modal` to use a larger custom `max-w-104` modal width (with an inline note) instead of the previous `max-w-2xs`, improving layout for wider content.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 52515498c11ccc9f5fdccc990eb7cba17c9d3272. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->