### PR TITLE
fix(ui): simplify leaderboard rank text in language section

### DIFF
--- a/app/components/course-page/current-step-complete-modal/language-leaderboard-rank-section.hbs
+++ b/app/components/course-page/current-step-complete-modal/language-leaderboard-rank-section.hbs
@@ -11,9 +11,7 @@
     {{svg-jar "presentation-chart-line" class="w-8 h-8 fill-current text-teal-500/90 mb-2"}}
 
     <span class="text-teal-700 dark:text-teal-400 text-xs mb-0.5 text-center">
-      Your
-      {{@language.name}}
-      leaderboard rank is
+      Your leaderboard rank is
     </span>
 
     <AnimatedContainer>


### PR DESCRIPTION
Remove redundant language name from the leaderboard rank text to 
make the message clearer and more concise for users in the 
current-step-complete modal. This improves readability and UI 
clarity.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small UI copy change in a template with no behavioral, data, or security impact; low risk aside from minor wording expectations/tests.
> 
> **Overview**
> Simplifies the copy in the current-step-complete modal’s language leaderboard rank section by removing the embedded language name and showing a shorter message: `Your leaderboard rank is`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 70f178b47bc1062a641a4dfef421a11186f803c2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->