### PR TITLE
fix(modal): reduce max width from 104 to 102

### DIFF
--- a/app/components/course-page/course-stage-step/tests-passed-modal/index.hbs
+++ b/app/components/course-page/course-stage-step/tests-passed-modal/index.hbs
@@ -1,6 +1,6 @@
 <ModalBody
   {{! in-between max-w-sm and max-w-md }}
-  class="w-full max-w-104"
+  class="w-full max-w-102"
   @shouldCloseOnOutsideClick={{true}}
   @shouldShowCloseButton={{true}}
   @onClose={{@onClose}}


### PR DESCRIPTION
Adjust the max width of the ModalBody in tests-passed-modal to 102
to better fit the design requirements and improve visual alignment.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-class UI sizing tweak limited to one modal; no behavioral, data, or security impact.
> 
> **Overview**
> Adjusts the `tests-passed-modal` layout by reducing the `ModalBody` Tailwind max-width utility from `max-w-104` to `max-w-102` to better match design sizing.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 223f7570994cd2a3167d5cd075538e82440531df. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->