### PR TITLE
fix(tests-passed-modal): update action button title text

### DIFF
--- a/app/components/course-page/course-stage-step/tests-passed-modal/choose-action-step.hbs
+++ b/app/components/course-page/course-stage-step/tests-passed-modal/choose-action-step.hbs
@@ -17,7 +17,7 @@
     <div class="flex flex-col gap-2 w-full">
       <CoursePage::CourseStageStep::TestsPassedModal::ActionButton
         @icon="check"
-        @title="Marking stage as complete..."
+        @title="Marking stage complete..."
         @description="This should be quick"
         @isProcessing={{true}}
         data-test-mark-stage-as-complete-button


### PR DESCRIPTION
Simplify the action button title from "Marking stage as complete..." to
"Marking stage complete..." for clearer and more concise UI feedback.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> String-only UI copy change in a template; no logic, data, or security behavior is modified.
> 
> **Overview**
> Updates the tests-passed modal’s processing-state action button copy by changing the title from `Marking stage as complete...` to `Marking stage complete...` while the stage completion is being created.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 43f8aebb1a25e80972f648f23d83dddaeeffc26f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->