### PR TITLE
style: update dark mode code block background to gray-850

### DIFF
--- a/app/styles/app.css
+++ b/app/styles/app.css
@@ -185,7 +185,7 @@ body {
 }
 
 .has-prism-highlighting pre[class*='language-']:is(.dark *) {
-  background-color: oklch(21% 0.034 264.665deg); /* gray-900 */
+  background-color: oklch(24.4% 0.0335 260.76deg); /* gray-850 */
 }
 
 .sortable-item {

--- a/app/tailwind.config.js
+++ b/app/tailwind.config.js
@@ -120,7 +120,7 @@ module.exports = {
             '--tw-prose-invert-code': colors.gray[300],
             '--tw-prose-invert-headings': colors.gray[200],
             '--tw-prose-invert-links': colors.sky[500],
-            '--tw-prose-invert-pre-bg': colors.gray[900],
+            '--tw-prose-invert-pre-bg': mixOklch(colors.gray[800], colors.gray[900], 0.5), // gray-850
             maxWidth: '90ch', // Default is 65ch
             a: {
               fontWeight: '600',


### PR DESCRIPTION
Adjust the background color for dark mode code blocks to use a 
more precise gray-850 shade in app.css. Modify the Tailwind config 
to blend gray-800 and gray-900 for the inverted prose pre background, 
ensuring consistent styling. These changes improve visual harmony 
and readability in dark mode.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CSS/theme-only color adjustments with minimal behavioral impact; main risk is minor visual regressions in dark-mode code block contrast.
> 
> **Overview**
> Updates dark-mode code block backgrounds to a more precise `gray-850` shade.
> 
> This changes the Prism-highlighted `pre` background in `app.css` and aligns Tailwind Typography’s `--tw-prose-invert-pre-bg` by mixing `gray[800]` and `gray[900]` (50/50) for consistent inverted prose styling.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2d668dbcb8d8046267533d69ea82ccb6a9a5d16b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->