### PR TITLE
CC-2160: Fix selection background for code blocks in dark theme

### DIFF
--- a/app/styles/prism-dark-theme.css
+++ b/app/styles/prism-dark-theme.css
@@ -28,16 +28,6 @@
   hyphens: none;
 }
 
-.has-prism-highlighting pre[class*='language-']:is(.dark *)::-moz-selection,
-.has-prism-highlighting pre[class*='language-']:is(.dark *) ::-moz-selection {
-  background: rgba(37, 99, 235, 0.45);
-}
-
-.has-prism-highlighting pre[class*='language-']:is(.dark *)::selection,
-.has-prism-highlighting pre[class*='language-']:is(.dark *) ::selection {
-  background: rgba(37, 99, 235, 0.45);
-}
-
 @media print {
   .has-prism-highlighting code[class*='language-']:is(.dark *),
   .has-prism-highlighting pre[class*='language-']:is(.dark *) {
@@ -59,8 +49,6 @@
   border-radius: 0.5em; */
   /* box-shadow: 1px 1px 0.5em black inset; */
 }
-
-
 
 /* Inline code */
 .has-prism-highlighting :not(pre) > code[class*='language-']:is(.dark *) {

--- a/app/styles/prism-light-theme.css
+++ b/app/styles/prism-light-theme.css
@@ -27,18 +27,6 @@
   hyphens: none;
 }
 
-.has-prism-highlighting pre[class*='language-']::-moz-selection,
-.has-prism-highlighting pre[class*='language-'] ::-moz-selection {
-  text-shadow: none;
-  background: #b3d4fc;
-}
-
-.has-prism-highlighting pre[class*='language-']::selection,
-.has-prism-highlighting pre[class*='language-'] ::selection {
-  text-shadow: none;
-  background: #b3d4fc;
-}
-
 @media print {
   .has-prism-highlighting pre[class*='language-'] {
     text-shadow: none;


### PR DESCRIPTION
**Picked a dark blue color suggested by cursor:**

<img width="2720" height="816" alt="image" src="https://github.com/user-attachments/assets/160e07e8-2894-4298-887c-61f7c47a1210" />

---

<img width="2694" height="952" alt="image" src="https://github.com/user-attachments/assets/865cce2b-c90d-4571-8ed0-1fc0bccfbc57" />


---

**Mirroring the placement of CSS in prism-light-theme.css:**

<img width="3424" height="2190" alt="image" src="https://github.com/user-attachments/assets/7b424d86-0238-47fe-912b-a5061d07eb2e" />

---

**Checklist**:

- [x] I've thoroughly self-reviewed my changes
- [ ] I've added tests for my changes, unless they affect admin-only areas (or are otherwise not worth testing)
- [ ] I've verified any visual changes using Percy (add a commit with `[percy]` in the message to trigger)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CSS-only changes scoped to theming/Prism highlighting; risk is limited to potential visual regressions in selection/highlight colors across browsers.
> 
> **Overview**
> Fixes code-block text selection styling in dark mode by explicitly setting `color-scheme: light` on `:root` and switching to `color-scheme: dark` only under `.dark`.
> 
> Removes Prism light theme’s custom `::selection`/`::-moz-selection` background overrides so selection colors follow the active scheme instead of forcing a single highlight color.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 761ab9ae5903c77f17049d05672e8a613920c3e8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->