### PR TITLE
fix(ui): move solution prompt inside solution conditional

### DIFF
--- a/app/components/course-page/course-stage-step/second-stage-your-task-card/implement-solution-step.hbs
+++ b/app/components/course-page/course-stage-step/second-stage-your-task-card/implement-solution-step.hbs
@@ -1,15 +1,3 @@
-{{#unless this.solution}}
-  <div class="prose dark:prose-invert prose-compact mb-3">
-    <p>
-      Head over to your editor / IDE and implement your solution.
-    </p>
-    <p>
-      If you want a quick look at what functions to use or how to structure your code, we recommend looking at
-      <LinkTo @route="course.stage.code-examples">Code Examples</LinkTo>.
-    </p>
-  </div>
-{{/unless}}
-
 {{#if this.solution}}
   {{#if (gt this.solution.hintsJson.length 0)}}
     {{#each this.solution.hintsJson as |hint hintIndex|}}
@@ -74,4 +62,14 @@
       </div>
     {{/animated-if}}
   </AnimatedContainer>
+{{else}}
+  <div class="prose dark:prose-invert prose-compact mb-3">
+    <p>
+      Head over to your editor / IDE and implement your solution.
+    </p>
+    <p>
+      If you want a quick look at what functions to use or how to structure your code, we recommend looking at
+      <LinkTo @route="course.stage.code-examples">Code Examples</LinkTo>.
+    </p>
+  </div>
 {{/if}}


### PR DESCRIPTION
Relocate the prompt encouraging users to implement their solution
and refer to code examples into the else branch of the solution
check. This ensures the message only appears when there is no
existing solution, improving conditional rendering clarity and
avoiding confusion for users who already have a solution.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small template-only conditional rendering change with no data/model logic impacted.
> 
> **Overview**
> Moves the “implement your solution / see Code Examples” guidance text in `implement-solution-step.hbs` into the `{{else}}` branch of `{{#if this.solution}}`, so it only renders when no solution exists.
> 
> This avoids showing the prompt alongside an already-present solution, clarifying the UI state.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f41365d0bd3453864b84647a1b0c833757536968. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->