### PR TITLE
docs(testing): add guidelines for using page objects in assertions

### DIFF
--- a/.cursor/rules/formatting-test-files.mdc
+++ b/.cursor/rules/formatting-test-files.mdc
@@ -54,6 +54,25 @@ module('Acceptance | concepts-test', function (hooks) {
 - Always sign in (use any of the signIn functions from `codecrafters-frontend/tests/support/authentication-helpers`) if the test requires a user to be logged in.
 - Structure tests with clear Arrange-Act-Assert pattern
 
+## Assertions
+
+- Use page objects for DOM assertions instead of `assert.dom()`. Page objects provide a higher-level abstraction and keep selectors out of test files.
+- Use `assert.strictEqual` with page object properties for checking values (text, counts, etc.)
+- Use `assert.ok` with page object boolean properties for checking visibility/state
+
+Good:
+```js
+assert.strictEqual(coursePage.sidebar.stepListItems.length, 8);
+assert.strictEqual(coursePage.testResultsBar.autofixHintCards[0].statusText, 'Verified');
+assert.ok(coursePage.feedbackPrompt.isVisible);
+```
+
+Bad:
+```js
+assert.dom('[data-test-step-list-item]').exists({ count: 8 });
+assert.dom('[data-test-autofix-hint-card]').containsText('Verified');
+```
+
 Example:
 ```js
 test('can create concept', async function (assert) {


### PR DESCRIPTION
Add a section recommending page objects for DOM assertions instead
of direct `assert.dom()` calls. Explain usage of `assert.strictEqual`
with page object properties for value checks and `assert.ok` for
boolean states. This clarifies best practices to improve test
readability and maintainability.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change that updates testing style guidelines without affecting runtime behavior.
> 
> **Overview**
> Adds an **Assertions** section to `.cursor/rules/formatting-test-files.mdc` recommending page objects over direct `assert.dom()` selectors in tests.
> 
> Documents preferred assertion patterns (`assert.strictEqual` for value/text/count checks and `assert.ok` for boolean visibility/state) and includes good/bad examples to standardize test style.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8634a10ff5572f4bb80cb33a3cf88362071d6f1f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->