### PR TITLE
style: reduce right margin spacing for step progress dots

### DIFF
--- a/app/components/course-page/step-progress-indicator.hbs
+++ b/app/components/course-page/step-progress-indicator.hbs
@@ -9,9 +9,9 @@
         {{/if}}
       {{else}}
         {{#if (eq @step.progressIndicator.dotType "blinking")}}
-          <BlinkingDot class="mr-2" @color={{@step.progressIndicatorAsProgressIndicatorWithDot.dotColor}} />
+          <BlinkingDot class="mr-1.5" @color={{@step.progressIndicatorAsProgressIndicatorWithDot.dotColor}} />
         {{else}}
-          <StaticDot class="mr-2" @color={{@step.progressIndicatorAsProgressIndicatorWithDot.dotColor}} />
+          <StaticDot class="mr-1.5" @color={{@step.progressIndicatorAsProgressIndicatorWithDot.dotColor}} />
         {{/if}}
       {{/if}}
     </AnimatedContainer>


### PR DESCRIPTION
Adjust the margin-right of BlinkingDot and StaticDot components
from 0.5rem (mr-2) to 0.375rem (mr-1.5) to improve alignment and
visual consistency in the step progress indicator on the course page.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Purely a minor Tailwind class tweak affecting layout spacing; no logic, data, or security changes.
> 
> **Overview**
> Tightens the spacing in the course page step progress indicator by reducing the right margin on `BlinkingDot`/`StaticDot` from `mr-2` to `mr-1.5` to better align the dot with the accompanying text.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 98487dc6ceea5230bcd5e1dd6582f68797043c21. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->