### PR TITLE
fix(modal): increase max width for tests passed modal

### DIFF
--- a/app/components/course-page/course-stage-step/tests-passed-modal/index.hbs
+++ b/app/components/course-page/course-stage-step/tests-passed-modal/index.hbs
@@ -1,6 +1,6 @@
 <ModalBody
-  {{! in-between max-w-sm and max-w-md }}
-  class="w-full max-w-102"
+  {{! just enough to fit content }}
+  class="w-full max-w-120"
   @shouldCloseOnOutsideClick={{true}}
   @shouldShowCloseButton={{true}}
   @onClose={{@onClose}}


### PR DESCRIPTION
Increase the max width of the Tests Passed Modal from 102 to 120
to better fit its content without excess space. This change improves
the visual layout and prevents unnecessary wrapping or overflow  
issues in the modal body.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, style-only change to modal layout with no behavioral or data-impacting logic changes.
> 
> **Overview**
> Increases the `Tests Passed` modal body max width from `max-w-102` to `max-w-120` (and updates the inline comment) to better fit its content and reduce wrapping/overflow.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fd753632a3f737a8838316ecc1998193d448a020. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->