### PR TITLE
Dummy hint tracking

### DIFF
--- a/app/components/course-page/test-results-bar/autofix-request-card.ts
+++ b/app/components/course-page/test-results-bar/autofix-request-card.ts
@@ -31,6 +31,10 @@ export default class AutofixRequestCard extends Component<Signature> {
     };
   }
 
+  get hasRealHints(): boolean {
+    return (this.args.autofixRequest.hintsJson?.length ?? 0) > 0;
+  }
+
   @action
   handleHideSolutionButtonClick() {
     this.solutionIsBlurred = true;
@@ -38,20 +42,24 @@ export default class AutofixRequestCard extends Component<Signature> {
 
   @action
   handleHintCollapse(hintIndex: number): void {
-    this.analyticsEventTracker.track('collapsed_autofix_hint', {
-      autofix_request_id: this.args.autofixRequest.id,
-      hint_index: hintIndex,
-    });
+    if (this.hasRealHints) {
+      this.analyticsEventTracker.track('collapsed_autofix_hint', {
+        autofix_request_id: this.args.autofixRequest.id,
+        hint_index: hintIndex,
+      });
+    }
 
     this.expandedHintIndex = null;
   }
 
   @action
   handleHintExpand(hintIndex: number): void {
-    this.analyticsEventTracker.track('expanded_autofix_hint', {
-      autofix_request_id: this.args.autofixRequest.id,
-      hint_index: hintIndex,
-    });
+    if (this.hasRealHints) {
+      this.analyticsEventTracker.track('expanded_autofix_hint', {
+        autofix_request_id: this.args.autofixRequest.id,
+        hint_index: hintIndex,
+      });
+    }
 
     this.expandedHintIndex = hintIndex;
     this.solutionIsBlurred = true;


### PR DESCRIPTION
**Checklist**:

- [ ] I've thoroughly self-reviewed my changes
- [ ] I've added tests for my changes, unless they affect admin-only areas (or are otherwise not worth testing)
- [ ] I've verified any visual changes using Percy (add a commit with `[percy]` in the message to trigger)

Prevents analytics events (`expanded_autofix_hint`, `collapsed_autofix_hint`) from being tracked when a user expands or collapses the "dummy" autofix hint (the "Generating hint..." placeholder).

Analytics should only fire for interactions with actual, generated autofix hints, not the temporary placeholder.

---
<p><a href="https://cursor.com/background-agent?bcId=bc-e3d6a7e9-e91c-4518-ad60-f07907d1d001"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-e3d6a7e9-e91c-4518-ad60-f07907d1d001"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, UI-local conditional around analytics tracking with no data mutations or security impact.
> 
> **Overview**
> Prevents `expanded_autofix_hint` and `collapsed_autofix_hint` analytics events from firing when the only displayed hint is the placeholder “Generating hint...”.
> 
> Adds a `hasRealHints` guard (based on `autofixRequest.hintsJson` length) so expand/collapse tracking only occurs once actual autofix hints exist; UI state changes (expanded index / blur) still apply as before.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4a7d64dedb00be1fbf9b5f5be169dd3deeb1b3c3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->