### PR TITLE
refactor(tests): remove unnecessary clickable imports and calls

### DIFF
--- a/tests/pages/components/code-mirror.ts
+++ b/tests/pages/components/code-mirror.ts
@@ -1,4 +1,4 @@
-import { blurrable, clickable, collection, create, fillable, focusable, text } from 'ember-cli-page-object';
+import { blurrable, collection, create, fillable, focusable, text } from 'ember-cli-page-object';
 import { alias } from 'ember-cli-page-object/macros';
 
 export default create({
@@ -44,18 +44,15 @@ export default create({
 
         collapsedLinesPlaceholders: collection('> .cm-cc-collapsedLines', {
           text: text(),
-          click: clickable(),
         }),
 
         lines: collection('> .cm-line', {
           text: text(),
-          click: clickable(),
           fillIn: fillable(),
         }),
 
         changedLines: collection('> .cm-changedLine', {
           text: text(),
-          click: clickable(),
           fillIn: fillable(),
         }),
 

--- a/tests/pages/components/comment-card.js
+++ b/tests/pages/components/comment-card.js
@@ -24,7 +24,6 @@ export default {
 
   hideRejectedCommentsButton: {
     scope: '[data-test-hide-rejected-comments-button]',
-    click: clickable(),
   },
 
   scope: '[data-test-comment-card]',

--- a/tests/pages/components/course-page/comment-list.js
+++ b/tests/pages/components/course-page/comment-list.js
@@ -10,7 +10,6 @@ export default {
 
   toggleRejectedCommentsButton: {
     scope: '[data-test-toggle-rejected-comments-button]',
-    click: clickable(),
   },
 
   scope: '[data-test-comment-list]',

--- a/tests/pages/components/file-contents-card.ts
+++ b/tests/pages/components/file-contents-card.ts
@@ -1,4 +1,4 @@
-import { clickable, create, text, triggerable } from 'ember-cli-page-object';
+import { create, text, triggerable } from 'ember-cli-page-object';
 import codeMirror from 'codecrafters-frontend/tests/pages/components/code-mirror';
 
 export default create({
@@ -6,18 +6,15 @@ export default create({
   codeMirror,
   header: {
     scope: '[data-test-file-contents-card-header]',
-    click: clickable(),
 
     hover: triggerable('mouseenter', '[data-test-file-contents-card-header-hover-target]'),
 
     expandButton: {
       scope: '[data-test-file-contents-card-header-expand-button]',
-      click: clickable(),
     },
 
     collapseButton: {
       scope: '[data-test-file-contents-card-header-collapse-button]',
-      click: clickable(),
     },
 
     tooltipBubble: {
@@ -29,6 +26,5 @@ export default create({
 
   collapseButton: {
     scope: '[data-test-file-contents-card-collapse-button]',
-    click: clickable(),
   },
 });

--- a/tests/pages/course-page.ts
+++ b/tests/pages/course-page.ts
@@ -194,7 +194,6 @@ export default create({
   },
 
   testsPassedPill: {
-    click: clickable(),
     proceedButton: {
       scope: '[data-test-proceed-button]',
     },

--- a/tests/pages/course/code-examples-page.ts
+++ b/tests/pages/course/code-examples-page.ts
@@ -53,9 +53,7 @@ export default createPage({
         return this.links.length > 0 && [...this.links].some((link) => link.text === linkText);
       },
 
-      links: collection('[data-test-dropdown-link]', {
-        click: clickable(),
-      }),
+      links: collection('[data-test-dropdown-link]'),
 
       resetScope: true,
       scope: '[data-test-more-dropdown-content]',

--- a/tests/pages/demo-page.ts
+++ b/tests/pages/demo-page.ts
@@ -1,4 +1,4 @@
-import { attribute, clickable, collection, create, text, visitable } from 'ember-cli-page-object';
+import { attribute, collection, create, text, visitable } from 'ember-cli-page-object';
 import CodeMirror from 'codecrafters-frontend/tests/pages/components/code-mirror';
 import DarkModeToggle from 'codecrafters-frontend/tests/pages/components/dark-mode-toggle';
 import FileContentsCard from 'codecrafters-frontend/tests/pages/components/file-contents-card';
@@ -7,9 +7,7 @@ export default create({
   tabSwitcher: {
     scope: '[data-test-demo-tab-switcher]',
 
-    tabs: collection('a', {
-      click: clickable(),
-    }),
+    tabs: collection('a'),
 
     findTabByText(text: string) {
       return this.tabs.findOneBy('text', text);
@@ -50,7 +48,6 @@ export default create({
 
         checkbox: {
           scope: 'input[type=checkbox]',
-          click: clickable(),
           isDisabled: attribute('disabled'),
         },
       }),


### PR DESCRIPTION
Remove unused clickable() actions from page object tests to simplify
interactions and prevent unintended side effects. Clean up imports by
eliminating clickable where not needed. This improves test maintainability
and reduces confusion about which elements trigger clicks during testing.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only refactor that mainly deletes redundant helpers/imports; risk is limited to potentially breaking tests that relied on the removed `click` properties.
> 
> **Overview**
> Removes unused `clickable()` actions from several Ember page-object test components (e.g., CodeMirror line/placeholder collections, FileContentsCard header buttons, comment list/card toggles, demo-page tab/checkbox collections, and code-examples dropdown links) and trims the associated `clickable` imports.
> 
> This refactor leaves element scopes/selectors in place so tests can still click via default element `.click()` where needed, reducing accidental side effects from explicit `clickable()` wiring.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0d793247d7386d2e83cac34f354791ce109a21cd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->