### PR TITLE
Shell stage 1 video

### DIFF
--- a/app/components/course-page/course-stage-step/first-stage-your-task-card/index.ts
+++ b/app/components/course-page/course-stage-step/first-stage-your-task-card/index.ts
@@ -86,7 +86,7 @@ export default class FirstStageYourTaskCard extends Component<Signature> {
     if (this.args.currentStep.courseStage.course.isShell) {
       return `
            <div style="left: 0; width: 100%; height: 0; position: relative; padding-bottom: 56.25%;"><iframe
-          src="https://www.loom.com/embed/63531adfeb6242eeaff9171bc1211947?hide_title=true&hideEmbedTopBar=true&hide_owner=true"
+          src="https://www.loom.com/embed/9f2942232b874ad8bbe8840837cf8995?hide_title=true&hideEmbedTopBar=true&hide_owner=true"
           style="top: 0; left: 0; width: 100%; height: 100%; position: absolute; border: 0;"
           allowfullscreen
           scrolling="no"


### PR DESCRIPTION
Update Shell Stage 1 video Loom embed URL

Updates the embedded Loom video ID for the Shell Stage 1 walkthrough to the latest version (from `63531adfeb6242eeaff9171bc1211947` to `9f2942232b874ad8bbe8840837cf8995` in `app/components/course-page/course-stage-step/first-stage-your-task-card/index.ts`).

**Checklist**:

- [x] I've thoroughly self-reviewed my changes
- [ ] I've added tests for my changes, unless they affect admin-only areas (or are otherwise not worth testing)
- [ ] I've verified any visual changes using Percy (add a commit with `[percy]` in the message to trigger)

---
[Slack Thread](https://codecrafters-io.slack.com/archives/C032VLSBFM0/p1771299099678719?thread_ts=1771299099.678719&cid=C032VLSBFM0)

<p><a href="https://cursor.com/agents/bc-efcd49aa-4d15-5ac0-89bd-4761b6040936"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-efcd49aa-4d15-5ac0-89bd-4761b6040936"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-string change to a hardcoded embed URL; impact is limited to which video is shown for Shell stage 1.
> 
> **Overview**
> Updates the Shell course stage 1 walkthrough video by changing the Loom embed URL in `FirstStageYourTaskCard`’s `videoEmbedHtml` getter to point to a new video ID.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 477326a32a83e08657ed477b915e8b477fa7c855. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->