### PR TITLE
fix(billing): dynamically display discount percentage in badge tooltip

### DIFF
--- a/app/components/billing-status-badge/discount-timer-badge.ts
+++ b/app/components/billing-status-badge/discount-timer-badge.ts
@@ -32,7 +32,7 @@ export default class DiscountTimerBadge extends Component<Signature> {
   }
 
   get tooltipText() {
-    return `Upgrade in ${formatTimeDurationForCountdown(this.expiresAt, this.time.currentTime)} to get 40% off the annual plan. Click to view details.`;
+    return `Upgrade in ${formatTimeDurationForCountdown(this.expiresAt, this.time.currentTime)} to get ${this.args.discount.percentageOff}% off the annual plan. Click to view details.`;
   }
 }
 

--- a/app/components/pay-page/referral-discount-notice.hbs
+++ b/app/components/pay-page/referral-discount-notice.hbs
@@ -21,8 +21,8 @@
     <b>{{@discount.affiliateReferral.affiliateLink.affiliateName}}</b>'s referral offer: Subscribe in
     <span class="font-bold percy-timestamp font-mono text-lg border-b border-yellow-500 border-dashed">{{this.timeLeftText}}</span>
     to get
-    <span class="font-bold">40% off</span>
+    <span class="font-bold">{{@discount.percentageOff}}% off</span>
     the 1 year plan.
   </div>
-  <EmberTooltip @text="The 1 year plan is usually $360, but you can get it for $216 with this offer." @side="bottom" />
+  <EmberTooltip @text={{this.tooltipText}} @side="bottom" />
 </div>

--- a/app/components/pay-page/referral-discount-notice.ts
+++ b/app/components/pay-page/referral-discount-notice.ts
@@ -18,8 +18,16 @@ export default class ReferralDiscountNotice extends Component<Signature> {
 
   @service declare time: TimeService;
 
+  get discountedPrice() {
+    return this.args.discount.computeDiscountedPrice(360);
+  }
+
   get timeLeftText() {
     return formatTimeDurationForCountdown(this.args.discount.expiresAt, this.time.currentTime);
+  }
+
+  get tooltipText() {
+    return `The 1 year plan is usually $360, but you can get it for $${this.discountedPrice} with this offer.`;
   }
 }
 

--- a/app/components/pay-page/signup-discount-notice.hbs
+++ b/app/components/pay-page/signup-discount-notice.hbs
@@ -11,8 +11,8 @@
     New user offer: Subscribe in
     <span class="font-bold percy-timestamp font-mono text-lg border-b border-yellow-500 border-dashed">{{this.timeLeftText}}</span>
     to get
-    <span class="font-bold">40% off</span>
+    <span class="font-bold">{{@discount.percentageOff}}% off</span>
     the annual plan.
   </div>
-  <EmberTooltip @text="The 1 year plan is usually $360, but you can get it for $216 with this offer." @side="bottom" />
+  <EmberTooltip @text={{this.tooltipText}} @side="bottom" />
 </div>

--- a/app/components/pay-page/signup-discount-notice.ts
+++ b/app/components/pay-page/signup-discount-notice.ts
@@ -17,8 +17,16 @@ export default class SignupDiscountNotice extends Component<Signature> {
 
   @service declare time: TimeService;
 
+  get discountedPrice() {
+    return this.args.discount.computeDiscountedPrice(360);
+  }
+
   get timeLeftText() {
     return formatTimeDurationForCountdown(this.args.discount.expiresAt, this.time.currentTime);
+  }
+
+  get tooltipText() {
+    return `The 1 year plan is usually $360, but you can get it for $${this.discountedPrice} with this offer.`;
   }
 }
 


### PR DESCRIPTION
Update discount-timer-badge to show the actual discount percentage
from args instead of a hardcoded value. This makes the tooltip text
accurate and adaptable to different discount values.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Text-only UI changes that pull existing discount data (`percentageOff`) and compute a display price; low blast radius but minor risk of formatting/rounding mismatches in user-facing copy.
> 
> **Overview**
> Updates discount-related UI copy to **stop hardcoding 40%** and instead render `@discount.percentageOff` in the billing status badge tooltip and the pay-page signup/referral notices.
> 
> Pay-page discount notices also replace the fixed tooltip price ($216) with a dynamically computed value via `discount.computeDiscountedPrice(360)` and a new `tooltipText` getter, keeping tooltip messaging consistent with the active discount.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit dde824d1f77712205cf54774c2b0ec6aee2526a1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->