### PR TITLE
test: remove feature flag fetch and user updates for CLI ping flow

### DIFF
--- a/app/components/course-page/setup-step-complete-modal.ts
+++ b/app/components/course-page/setup-step-complete-modal.ts
@@ -53,9 +53,6 @@ export default class SetupStepCompleteModalComponent extends Component<Signature
     console.log('handleDidInsert');
     // Pre-cache the workflow animation GIF to avoid flickering when it loads.
     fetch('https://codecrafters.io/images/overview/workflow-animation-3.gif', { mode: 'no-cors' });
-
-    // TODO: Remove this once can-view-cli-ping-flow feature flag is the default
-    fetch('https://codecrafters.io/images/overview/workflow-animation-2.gif', { mode: 'no-cors' });
   }
 
   @action

--- a/tests/acceptance/course-page/start-course-test.js
+++ b/tests/acceptance/course-page/start-course-test.js
@@ -49,10 +49,7 @@ module('Acceptance | course-page | start-course', function (hooks) {
 
   test('can start course', async function (assert) {
     testScenario(this.server, ['dummy']);
-    const user = signIn(this.owner, this.server);
-
-    // TODO: Change this once can-view-cli-ping-flow feature flag is the default
-    user.update({ featureFlags: { 'can-view-cli-ping-flow': 'test' } });
+    signIn(this.owner, this.server);
 
     const fakeActionCableConsumer = new FakeActionCableConsumer();
     this.owner.register('service:action-cable-consumer', fakeActionCableConsumer, { instantiate: false });
@@ -205,9 +202,6 @@ module('Acceptance | course-page | start-course', function (hooks) {
   test('can start course with workflow tutorial', async function (assert) {
     testScenario(this.server, ['dummy']);
     const user = signIn(this.owner, this.server);
-
-    // TODO: Change this once can-view-cli-ping-flow feature flag is the default
-    user.update({ featureFlags: { 'can-view-cli-ping-flow': 'test' } });
 
     const fakeActionCableConsumer = new FakeActionCableConsumer();
     this.owner.register('service:action-cable-consumer', fakeActionCableConsumer, { instantiate: false });


### PR DESCRIPTION
Remove pre-caching of deprecated workflow animation GIF tied to the
can-view-cli-ping-flow feature flag in the setup-step-complete-modal
component to simplify asset loading.

Eliminate user feature flag updates in acceptance tests since the flag
is no longer required, cleaning up test setup and improving clarity.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only and non-functional cleanup that removes deprecated flag/asset references; minimal behavior change aside from no longer prefetching the old GIF.
> 
> **Overview**
> Removes the extra workflow animation GIF prefetch in `SetupStepCompleteModal` that was guarded by the now-obsolete `can-view-cli-ping-flow` rollout.
> 
> Cleans up course-start acceptance tests by removing user feature-flag mutation for `can-view-cli-ping-flow`, relying on the default behavior for both the standard start flow and the workflow-tutorial variant.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit dbb67e3cfd74d32a65e44f7649e6fb407bea1a65. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->