### PR TITLE
Concepts page double completion

### DIFF
--- a/app/components/concept/continue-or-step-back.hbs
+++ b/app/components/concept/continue-or-step-back.hbs
@@ -8,7 +8,7 @@
         data-test-continue-button
         {{did-insert this.handleDidInsertContinueButtonElement}}
         {{! @glint-expect-error on-key modifier types aren't right? }}
-        {{on-key "Enter" this.handleEnterKeyPress}}
+        {{on-key "Enter" this.handleEnterKeyPress event="keyup"}}
       >
         {{or @continueButtonText "Continue"}}
       </PrimaryButton>

--- a/tests/acceptance/concepts-test.js
+++ b/tests/acceptance/concepts-test.js
@@ -7,7 +7,7 @@ import percySnapshot from '@percy/ember';
 import tcpOverview from 'codecrafters-frontend/mirage/concept-fixtures/tcp-overview';
 import testScenario from 'codecrafters-frontend/mirage/scenarios/test';
 import { assertTooltipContent } from 'ember-tooltips/test-support';
-import { currentURL } from '@ember/test-helpers';
+import { currentURL, triggerKeyEvent } from '@ember/test-helpers';
 import { module, test } from 'qunit';
 import { setupApplicationTest } from 'codecrafters-frontend/tests/helpers';
 import { setupWindowMock } from 'ember-window-mock/test-support';
@@ -262,6 +262,41 @@ module('Acceptance | concepts-test', function (hooks) {
       conceptPage.conceptCompletedModal.text.includes('Get free access to the rest of Network Primer'),
       'Modal shows correct group access message',
     );
+  });
+
+  test('pressing enter while continue button is not focused only advances one block group', async function (assert) {
+    testScenario(this.server);
+    createConcepts(this.server);
+
+    signInAsStaff(this.owner, this.server);
+
+    await conceptsPage.visit();
+    await conceptsPage.clickOnConceptCard('Network Protocols');
+
+    assert.strictEqual(conceptPage.blocks.length, 1, 'Only the first block group should be visible initially');
+    assert.true(conceptPage.focusedContinueButton.isPresent, 'Continue button is focused by default');
+
+    if (document.activeElement instanceof HTMLElement) {
+      document.activeElement.blur();
+    }
+
+    assert.false(conceptPage.focusedContinueButton.isPresent, 'Continue button is not focused');
+
+    await triggerKeyEvent(document, 'keydown', 'Enter');
+    await animationsSettled();
+
+    const keyupTarget = document.activeElement;
+
+    await triggerKeyEvent(keyupTarget || document.body, 'keyup', 'Enter');
+    await animationsSettled();
+
+    // Browsers dispatch a click on keyup if Enter is released while a button is focused.
+    if (keyupTarget instanceof HTMLButtonElement) {
+      keyupTarget.click();
+      await animationsSettled();
+    }
+
+    assert.strictEqual(conceptPage.blocks.length, 2, 'Only one additional block group should be revealed');
   });
 
   test('anonymous users can view concepts not linked to a concept group', async function (assert) {


### PR DESCRIPTION
**Checklist**:

- [ ] I've thoroughly self-reviewed my changes
- [ ] I've added tests for my changes, unless they affect admin-only areas (or are otherwise not worth testing)
- [ ] I've verified any visual changes using Percy (add a commit with `[percy]` in the message to trigger)

**Problem:**
On the concepts page, pressing the Enter key could sometimes advance two block groups instead of one, particularly when the "Continue" button was not explicitly focused.

**Root Cause:**
The `on-key "Enter"` handler in `Concept::ContinueOrStepBack` was set to trigger on `keydown`. If the "Continue" button was not focused initially, the `keydown` event would advance one block group. This action could then cause the *next* "Continue" button to become focused. Subsequently, the browser's default behavior would trigger a click on the newly focused button on `keyup`, leading to a second, unintended advance.

**Solution:**
The `on-key "Enter"` event listener in `app/components/concept/continue-or-step-back.hbs` has been changed from `keydown` to `keyup`. This ensures that the custom Enter shortcut fires at the same time as the browser's native button activation, preventing the double-advance scenario.

**Verification:**
A new acceptance test, `pressing enter while continue button is not focused only advances one block group`, has been added to `tests/acceptance/concepts-test.js` to specifically reproduce and verify this fix.

---
[Slack Thread](https://codecrafters-io.slack.com/archives/C032VLSBFM0/p1772490228396729?thread_ts=1772490228.396729&cid=C032VLSBFM0)

<p><a href="https://cursor.com/agents/bc-71259649-bc34-5f30-b92d-1372265b294f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-71259649-bc34-5f30-b92d-1372265b294f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: small change to key handling for the concept continue shortcut plus an acceptance test to lock in behavior. Potential risk is minor UX regression if other code relied on `keydown` timing for Enter on the Continue button.
> 
> **Overview**
> Fixes an issue where pressing **Enter** could advance *two* concept block groups by switching the Continue button’s `on-key "Enter"` handler from `keydown` to `keyup` in `Concept::ContinueOrStepBack`.
> 
> Adds an acceptance test that reproduces the unfocused-continue-button scenario and asserts that only one additional block group is revealed when Enter is pressed.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 09dfa8ff802d816e85d671c24453c822412dfb5f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->