### PR TITLE
Screencasts tab visibility

### DIFF
--- a/app/components/course-page/header/tab-list.ts
+++ b/app/components/course-page/header/tab-list.ts
@@ -119,20 +119,6 @@ export default class TabList extends Component<Signature> {
 
     if (this.args.course.visibilityIsPublic) {
       // @ts-expect-error currentStep.courseStage not typed
-      if (this.args.currentStep.courseStage && this.args.currentStep.courseStage.hasScreencasts) {
-        tabs.push({
-          icon: 'play',
-          name: 'Screencasts',
-          slug: 'screencasts',
-          internalLink: {
-            route: 'course.stage.screencasts',
-            models: this.args.currentStep.routeParams.models,
-          },
-          isActive: this.router.currentRouteName === 'course.stage.screencasts',
-        });
-      }
-
-      // @ts-expect-error currentStep.courseStage not typed
       if (this.args.currentStep.courseStage && this.args.currentStep.courseStage.course.hasConcepts) {
         tabs.push({
           icon: 'academic-cap',

--- a/app/router.ts
+++ b/app/router.ts
@@ -53,7 +53,7 @@ Router.map(function () {
       this.route('code-examples');
       this.route('concepts');
       this.route('instructions', { path: '/' });
-      this.route('screencasts');
+      this.route('screencasts'); // TODO: Remove entirely, replace with resources page
     });
 
     this.route('extension-completed', { path: '/extension-completed/:extension_slug' });

--- a/tests/acceptance/course-page/view-screencasts-test.js
+++ b/tests/acceptance/course-page/view-screencasts-test.js
@@ -1,16 +1,13 @@
-import catalogPage from 'codecrafters-frontend/tests/pages/catalog-page';
-import coursePage from 'codecrafters-frontend/tests/pages/course-page';
+import fieldComparator from 'codecrafters-frontend/utils/field-comparator';
 import screencastsPage from 'codecrafters-frontend/tests/pages/screencasts-page';
 import testScenario from 'codecrafters-frontend/mirage/scenarios/test';
+import windowMock from 'ember-window-mock';
 import { module, test } from 'qunit';
 import { setupAnimationTest } from 'ember-animated/test-support';
 import { setupApplicationTest } from 'codecrafters-frontend/tests/helpers';
 import { setupWindowMock } from 'ember-window-mock/test-support';
-import windowMock from 'ember-window-mock';
 import { signInAsStaff } from 'codecrafters-frontend/tests/support/authentication-helpers';
 import { visit } from '@ember/test-helpers';
-import courseOverviewPage from 'codecrafters-frontend/tests/pages/course-overview-page';
-import fieldComparator from 'codecrafters-frontend/utils/field-comparator';
 
 module('Acceptance | course-page | view-screencasts-test', function (hooks) {
   setupApplicationTest(hooks);
@@ -73,10 +70,7 @@ module('Acceptance | course-page | view-screencasts-test', function (hooks) {
     createScreencast(this.server, go, '2023-06-30T19:11:29.254Z', 'Go screencast #1', 500); // Older
     createScreencast(this.server, go, '2024-01-30T19:11:29.254Z', 'Go screencast #2', 5000); // Newer
 
-    await catalogPage.visit();
-    await catalogPage.clickOnCourse('Build your own Redis');
-    await courseOverviewPage.clickOnStartCourse();
-    await coursePage.clickOnHeaderTabLink('Screencasts');
+    await visit('/courses/redis/stages/rg2/screencasts');
 
     assert.strictEqual(screencastsPage.screencastPreviews.length, 3);
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
**Checklist**:

- [ ] I've thoroughly self-reviewed my changes
- [ ] I've added tests for my changes, unless they affect admin-only areas (or are otherwise not worth testing)
- [ ] I've verified any visual changes using Percy (add a commit with `[percy]` in the message to trigger)

Removes the "Screencasts" tab from the course page header. The screencasts page and its code are retained but no longer accessible via the tab.

The associated acceptance test has been updated to visit the screencasts page directly by URL. A `TODO` comment has been added to the router to indicate future plans for complete removal and replacement with a resources page.

---
<p><a href="https://cursor.com/agents/bc-baefa2a6-aa2e-49a4-b477-72b074f37c85"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-baefa2a6-aa2e-49a4-b477-72b074f37c85"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>


<!-- CURSOR_AGENT_PR_BODY_END -->