### PR TITLE
Course filter spacing

### DIFF
--- a/app/templates/roadmap/course-extension-ideas.hbs
+++ b/app/templates/roadmap/course-extension-ideas.hbs
@@ -9,7 +9,7 @@
       Challenge extensions are groups of extra stages that extend challenges. Vote and help us decide which ones to build.
     </RoadmapInfoAlert>
 
-    <div class="flex items-center mb-6">
+    <div class="flex items-center">
       <CourseDropdown
         @courses={{this.orderedCourses}}
         @selectedCourse={{this.selectedCourse}}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
**Checklist**:

- [x] I've thoroughly self-reviewed my changes
- [ ] I've added tests for my changes, unless they affect admin-only areas (or are otherwise not worth testing)
- [x] I've verified any visual changes using Percy (add a commit with `[percy]` in the message to trigger)

**Problem:** The course filter dropdown on the roadmap page (`app/templates/roadmap/course-extension-ideas.hbs`) had excessive vertical spacing below it, appearing inconsistent with other elements. This was caused by a redundant `mb-6` class on the dropdown wrapper, in addition to the parent container's `gap-3`.

**Solution:** Removed the `mb-6` class from the course dropdown wrapper.

**Why:** This ensures consistent 12px spacing (from the parent's `gap-3`) between the filter and the extension idea cards, improving the visual layout and making it look less broken.

---
<p><a href="https://cursor.com/agents/bc-2558fcdf-d52f-4ef1-94ec-b10ac2cf74ac"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2558fcdf-d52f-4ef1-94ec-b10ac2cf74ac"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>


<!-- CURSOR_AGENT_PR_BODY_END -->