### PR TITLE
Screencasts tab references

### DIFF
--- a/app/components/course-page/course-stage-step/community-solution-card/header.hbs
+++ b/app/components/course-page/course-stage-step/community-solution-card/header.hbs
@@ -11,14 +11,14 @@
     <CoursePage::CourseStageStep::CommunitySolutionCard::HeaderLabel @solution={{@solution}} />
 
     {{#if @solution.screencast}}
-      <LinkTo @route="course.stage.screencasts" @query={{hash selectedScreencastId=@solution.screencast.id}} class="flex">
+      <a href={{@solution.screencast.originalUrl}} target="_blank" rel="noopener noreferrer" class="flex">
         <Pill @color="blue">
           {{svg-jar "play" class="w-4 h-4 mr-1 text-blue-500"}}
           Screencast
 
           <EmberTooltip @text="This solution has a linked screencast. Click to view." />
         </Pill>
-      </LinkTo>
+      </a>
     {{/if}}
   </div>
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
**Checklist**:

- [ ] I've thoroughly self-reviewed my changes
- [ ] I've added tests for my changes, unless they affect admin-only areas (or are otherwise not worth testing)
- [ ] I've verified any visual changes using Percy (add a commit with `[percy]` in the message to trigger)

This PR updates the "Screencast" pill in the community solution card header.

**Why this change?**
The internal screencasts tab/page has been removed. To ensure users can still access linked screencasts from community solutions, this change modifies the pill to directly open the screencast's `originalUrl` in a new browser tab, bypassing the deprecated internal page.

---
<p><a href="https://cursor.com/agents/bc-3b8fe21d-fad6-4b00-9e06-c7b8c9d0a99f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3b8fe21d-fad6-4b00-9e06-c7b8c9d0a99f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>


<!-- CURSOR_AGENT_PR_BODY_END -->