### PR TITLE
Update default meta tags with clearer copy

### DIFF
--- a/config/environment.js
+++ b/config/environment.js
@@ -35,11 +35,9 @@ module.exports = function (environment) {
       defaultMetaTags: {
         type: 'website',
         siteName: 'CodeCrafters',
-        title: "The Software Pro's Best Kept Secret.",
-        description: [
-          'Real-world proficiency projects designed for experienced engineers.',
-          'Develop software craftsmanship by recreating popular devtools from scratch.',
-        ].join(' '),
+        title: 'CodeCrafters | Build Your Own Redis, Git & SQLite From Scratch',
+        description:
+          'Advanced programming challenges for experienced engineers. Rebuild real production tools like Redis, Git, and SQLite from scratch in your IDE.',
         imageUrl: 'https://codecrafters.io/images/og-index.jpg',
         twitterCard: 'summary_large_image',
         twitterSite: '@codecraftersio',


### PR DESCRIPTION
## Summary
- Replace "The Software Pro's Best Kept Secret." title with "CodeCrafters | Build Your Own Redis, Git & SQLite From Scratch"
- Replace vague description with "Advanced programming challenges for experienced engineers. Rebuild real production tools like Redis, Git, and SQLite from scratch in your IDE."
- Aligns app meta tags with the landing site messaging

## Test plan
- [ ] Share an app.codecrafters.io link in Slack/Discord and verify the preview shows the new title and description

🤖 Generated with [Claude Code](https://claude.com/claude-code)