### PR TITLE
test(acceptance): skip flaky focus-related tests in concepts

### DIFF
--- a/tests/acceptance/concepts-test.js
+++ b/tests/acceptance/concepts-test.js
@@ -8,7 +8,7 @@ import tcpOverview from 'codecrafters-frontend/mirage/concept-fixtures/tcp-overv
 import testScenario from 'codecrafters-frontend/mirage/scenarios/test';
 import { assertTooltipContent } from 'ember-tooltips/test-support';
 import { currentURL, triggerKeyEvent } from '@ember/test-helpers';
-import { module, test } from 'qunit';
+import { module, skip, test } from 'qunit';
 import { setupApplicationTest } from 'codecrafters-frontend/tests/helpers';
 import { setupWindowMock } from 'ember-window-mock/test-support';
 import { signIn, signInAsStaff, signInAsSubscriber } from 'codecrafters-frontend/tests/support/authentication-helpers';
@@ -170,7 +170,8 @@ module('Acceptance | concepts-test', function (hooks) {
     );
   });
 
-  test('users can interact with concepts, and the expected elements are focused', async function (assert) {
+  // Flaky: focus assertions fail intermittently in CI (element not focused)
+  skip('users can interact with concepts, and the expected elements are focused', async function (assert) {
     testScenario(this.server);
     createConcepts(this.server);
 
@@ -264,7 +265,8 @@ module('Acceptance | concepts-test', function (hooks) {
     );
   });
 
-  test('pressing enter while continue button is not focused only advances one block group', async function (assert) {
+  // Flaky: focus assertions fail intermittently in CI (element not focused)
+  skip('pressing enter while continue button is not focused only advances one block group', async function (assert) {
     testScenario(this.server);
     createConcepts(this.server);
 
@@ -689,7 +691,8 @@ module('Acceptance | concepts-test', function (hooks) {
     assert.true(conceptPage.questionCards[0].hasSubmitted, 'the question has been submitted');
   });
 
-  test('can navigate using j/k and select option using enter', async function (assert) {
+  // Flaky: focusedOption element not found intermittently in CI
+  skip('can navigate using j/k and select option using enter', async function (assert) {
     testScenario(this.server);
     createConcepts(this.server);
 
@@ -724,7 +727,8 @@ module('Acceptance | concepts-test', function (hooks) {
     assert.true(conceptPage.questionCards[0].hasSubmitted, 'the question has been submitted');
   });
 
-  test('while navigating using keys, options are traversed one at a time', async function (assert) {
+  // Flaky: focusedOption element not found intermittently in CI
+  skip('while navigating using keys, options are traversed one at a time', async function (assert) {
     testScenario(this.server);
     createConcepts(this.server);
 
@@ -779,7 +783,8 @@ module('Acceptance | concepts-test', function (hooks) {
     assert.strictEqual(window.scrollY, 0, 'The page is scrolled to the top when navigating to a new concept');
   });
 
-  test('can navigate using arrow keys and select option using enter', async function (assert) {
+  // Flaky: focusedOption element not found intermittently in CI
+  skip('can navigate using arrow keys and select option using enter', async function (assert) {
     testScenario(this.server);
     createConcepts(this.server);
 
@@ -835,7 +840,8 @@ module('Acceptance | concepts-test', function (hooks) {
     assert.strictEqual(window.scrollY, currentScrollY, 'scrolling should not be triggered');
   });
 
-  test('navigating options wraps around the list for the current question card only', async function (assert) {
+  // Flaky: focusedOption element not found intermittently in CI
+  skip('navigating options wraps around the list for the current question card only', async function (assert) {
     testScenario(this.server);
     createConcepts(this.server);
 
@@ -955,7 +961,8 @@ module('Acceptance | concepts-test', function (hooks) {
     assert.ok(conceptsPage.conceptCards[3].draftLabel.isVisible, 'Draft label is visible for draft concepts');
   });
 
-  test('can use Delete and Backspace keys in the feedback popup', async function (assert) {
+  // Flaky: focusedOption element not found intermittently in CI
+  skip('can use Delete and Backspace keys in the feedback popup', async function (assert) {
     testScenario(this.server);
     createConcepts(this.server);
 


### PR DESCRIPTION
Mark several focus- and keyboard-interaction tests in concepts-test.js as 
skipped due to intermittent failures in CI. These tests frequently fail 
because expected elements are not focused or found, causing flakiness.

Skipping these tests improves CI stability while investigating the root cause.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only test suite behavior changes by skipping several flaky focus/keyboard interaction acceptance tests; no production code is modified.
> 
> **Overview**
> Reduces CI flakiness by converting several focus- and keyboard-navigation assertions in `tests/acceptance/concepts-test.js` from `test` to `skip`, with inline comments documenting intermittent failures (missing focus / missing `focusedOption`).
> 
> Updates the QUnit import to include `skip` so these acceptance tests are no longer executed until the underlying focus issues are addressed.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 75f57acf0395e19499c832a46740969f2e3c1859. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->