### PR TITLE
fix: update instructions and enhance command clarity in setup steps

### DIFF
--- a/app/components/course-page/course-stage-step/first-stage-your-task-card/uncomment-code-step.hbs
+++ b/app/components/course-page/course-stage-step/first-stage-your-task-card/uncomment-code-step.hbs
@@ -5,7 +5,7 @@
     </p>
     <p>
       Uncomment the relevant code in
-      <code>{{this.filename}}</code>, save your file, and submit your changes by following the steps below.
+      <code>{{this.filename}}</code>, save your file, and submit your changes by following the step below.
     </p>
   </div>
 {{else if (not @repository.language)}}

--- a/app/components/course-page/setup-step/repository-setup-card/test-cli-connection-step.ts
+++ b/app/components/course-page/setup-step/repository-setup-card/test-cli-connection-step.ts
@@ -19,12 +19,12 @@ export default class TestCliConnectionStep extends Component<Signature> {
   get commandVariants(): CopyableTerminalCommandVariant[] {
     const linuxMacOSVariant = {
       label: 'Linux / macOS',
-      commands: ['curl -fsSL https://codecrafters.io/install.sh | bash', 'codecrafters ping'],
+      commands: ['curl -fsSL https://codecrafters.io/install.sh | bash # Install CodeCrafters CLI', 'codecrafters ping'],
     };
 
     const powershellVariant = {
       label: 'PowerShell',
-      commands: ['irm https://codecrafters.io/install.ps1 | iex', 'codecrafters ping'],
+      commands: ['irm https://codecrafters.io/install.ps1 | iex # Install CodeCrafters CLI', 'codecrafters ping'],
     };
 
     if (this.userAgent.isWindows) {


### PR DESCRIPTION
- Corrected wording in the task card to refer to a single step.
- Added comments to command variants in the CLI connection setup for better understanding.

<img width="2050" height="1362" alt="image" src="https://github.com/user-attachments/assets/7039c5c7-30e1-4b92-93ae-abbd133490aa" />


<img width="3440" height="1644" alt="image" src="https://github.com/user-attachments/assets/2de4ed98-297f-4971-a382-dac67b15efb1" />

**Checklist**:

- [x] I've thoroughly self-reviewed my changes
- [ ] I've added tests for my changes, unless they affect admin-only areas (or are otherwise not worth testing)
- [ ] I've verified any visual changes using Percy (add a commit with `[percy]` in the message to trigger)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk copy-only changes to course/setup UI text and displayed terminal commands with no behavioral logic changes.
> 
> **Overview**
> Updates the first-stage task card copy to reference a single *step* instead of multiple *steps*.
> 
> Annotates the displayed CLI install commands for Linux/macOS and PowerShell with inline comments ("Install CodeCrafters CLI") while keeping the subsequent `codecrafters ping` command unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7c43581817407326d51a39a6d3f2a75fc3c47e6f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->