### PR TITLE
Pre-fill visitor data in Lobbyside widget

### DIFF
--- a/app/components/lobbyside-widget/index.ts
+++ b/app/components/lobbyside-widget/index.ts
@@ -22,6 +22,8 @@ export default class LobbysideWidgetComponent extends Component {
   @action
   insertScript(): void {
     if (document.getElementById(LOBBYSIDE_SCRIPT_ID)) {
+      this.syncVisitorData();
+
       return;
     }
 
@@ -29,7 +31,25 @@ export default class LobbysideWidgetComponent extends Component {
     script.id = LOBBYSIDE_SCRIPT_ID;
     script.src = 'https://lobbyside.com/widget.js';
     script.dataset['companyId'] = 'f6948b5a-eac2-4f92-8fce-54d4fb3bdaa4';
+    script.onload = () => this.syncVisitorData();
     document.body.appendChild(script);
+  }
+
+  private syncVisitorData(): void {
+    const user = this.authenticator.currentUser;
+
+    if (!user || !(window as Record<string, unknown>)['Lobbyside']) {
+      return;
+    }
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const lobbyside = (window as any).Lobbyside;
+
+    lobbyside.setVisitor({
+      email: user.primaryEmailAddress || '',
+      name: user.name || '',
+      github: user.githubUsername || '',
+    });
   }
 
   @action


### PR DESCRIPTION
## Summary
- Calls `Lobbyside.setVisitor()` with the current user's email, name, and GitHub username after the widget script loads
- When a user clicks "Join" on the Lobbyside widget, their info is pre-filled in the lobby form so they don't have to type it again
- Also syncs data if the script was already loaded (e.g., navigating back to a page with the widget)

## Test plan
- [ ] Log in as a staff user, visit a page with the Lobbyside widget
- [ ] Click "Join" on the widget card
- [ ] Verify the lobby form has email, name, and GitHub handle pre-filled
- [ ] Verify fields are still editable

🤖 Generated with [Claude Code](https://claude.com/claude-code)