### PR TITLE
Add staff-only Lobbyside widget, show public one to everyone

### DIFF
--- a/app/components/lobbyside-staff-widget/index.hbs
+++ b/app/components/lobbyside-staff-widget/index.hbs
@@ -1,0 +1,3 @@
+{{#if this.shouldShow}}
+  <div {{did-insert this.insertScript}} {{will-destroy this.removeScript}}></div>
+{{/if}}

--- a/app/components/lobbyside-staff-widget/index.ts
+++ b/app/components/lobbyside-staff-widget/index.ts
@@ -3,13 +3,20 @@ import { service } from '@ember/service';
 import { action } from '@ember/object';
 import type AuthenticatorService from 'codecrafters-frontend/services/authenticator';
 
-const LOBBYSIDE_SCRIPT_ID = 'lobbyside-widget-script';
+const ALLOWED_USERNAMES = ['vishaag', 'dronaxis'];
+const LOBBYSIDE_SCRIPT_ID = 'lobbyside-staff-widget-script';
 
-export default class LobbysideWidgetComponent extends Component {
+export default class LobbysideStaffWidgetComponent extends Component {
   @service declare authenticator: AuthenticatorService;
 
   get shouldShow(): boolean {
-    return true;
+    const user = this.authenticator.currentUser;
+
+    if (!user) {
+      return false;
+    }
+
+    return user.isStaff || ALLOWED_USERNAMES.includes(user.username);
   }
 
   @action
@@ -23,7 +30,7 @@ export default class LobbysideWidgetComponent extends Component {
     const script = document.createElement('script');
     script.id = LOBBYSIDE_SCRIPT_ID;
     script.src = 'https://lobbyside.com/widget.js';
-    script.dataset['companyId'] = 'f6948b5a-eac2-4f92-8fce-54d4fb3bdaa4';
+    script.dataset['companyId'] = '665ad94a-a863-4d0e-98e5-ff3eeac3f264';
     script.onload = () => this.syncVisitorData();
     document.body.appendChild(script);
   }

--- a/app/templates/application.hbs
+++ b/app/templates/application.hbs
@@ -23,6 +23,7 @@
   {{/if}}
 
   <LobbysideWidget />
+  <LobbysideStaffWidget />
 
   {{! Enable this to debug ember-animated animations }}
   {{! <AnimatedTools /> }}


### PR DESCRIPTION
## Summary
- Broaden the existing Lobbyside widget (`f6948b5a-eac2-4f92-8fce-54d4fb3bdaa4`) so it renders for every visitor, including signed-out ones. Visitor sync still only runs when a user is present.
- Add a second `<LobbysideStaffWidget />` bound to company ID `665ad94a-a863-4d0e-98e5-ff3eeac3f264` and gated to staff + the existing allow-listed usernames (`vishaag`, `dronaxis`). It uses a separate script element ID so both can coexist in the DOM.
- Render both widgets from `application.hbs`; staff users will see both stacked, everyone else sees only the public one. On/off toggling is handled from each company's Lobbyside dashboard.

## Test plan
- [ ] Sign out / use a non-staff account: confirm only the public widget (`f6948b5a...`) loads.
- [ ] Sign in as a staff account: confirm both widget scripts are present in the DOM (`#lobbyside-widget-script` and `#lobbyside-staff-widget-script`).
- [ ] Toggle each widget off from its respective Lobbyside dashboard and verify the corresponding UI disappears without a redeploy.