### PR TITLE
chore: update staff Lobbyside widget ID in application.hbs

### DIFF
--- a/app/templates/application.hbs
+++ b/app/templates/application.hbs
@@ -22,9 +22,14 @@
     <HelpscoutBeacon />
   {{/if}}
 
+  {{! Lobbyside widgets — source of truth: https://lobbyside.com (CodeCrafters org dashboard).
+      The two public widgets render for everyone; the staff-audience one is gated to
+      cc staff accounts + the usernames in `staff-allowlist.ts`. If you change a UUID
+      here, the corresponding widget on the dashboard must exist AND be live, otherwise
+      it silently no-ops (the widget script renders nothing for unknown / inactive ids). }}
   <LobbysideWidget @widgetId="f6948b5a-eac2-4f92-8fce-54d4fb3bdaa4" />
   <LobbysideWidget @widgetId="b0d7150e-77e2-431c-a57c-765e080d9c72" />
-  <LobbysideWidget @widgetId="665ad94a-a863-4d0e-98e5-ff3eeac3f264" @audience="staff" />
+  <LobbysideWidget @widgetId="643b761f-d83a-4de3-a682-dfce4549607e" @audience="staff" />
 
   {{! Enable this to debug ember-animated animations }}
   {{! <AnimatedTools /> }}


### PR DESCRIPTION
Replaced the UUID for the staff audience Lobbyside widget to ensure it corresponds with the live widget on the dashboard. Added comments for clarity on widget functionality and configuration.

**Checklist**:

- [ ] I've thoroughly self-reviewed my changes
- [ ] I've added tests for my changes, unless they affect admin-only areas (or are otherwise not worth testing)
- [ ] I've verified any visual changes using Percy (add a commit with `[percy]` in the message to trigger)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only updates a staff-only widget UUID and adds explanatory comments; primary failure mode is the staff widget not rendering if the ID is wrong.
> 
> **Overview**
> Updates the staff-audience `LobbysideWidget` UUID rendered in `application.hbs` to point at the correct live widget.
> 
> Adds an inline comment documenting Lobbyside as the source of truth, the staff/allowlist gating behavior, and that invalid/inactive widget IDs silently no-op.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f658ec458f8cc834f38bea7b54c5276f71b2d254. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->