### PR TITLE
refactor: enhance visitor data synchronization in Lobbyside widget

### DIFF
--- a/app/components/lobbyside-widget/index.hbs
+++ b/app/components/lobbyside-widget/index.hbs
@@ -1,11 +1,21 @@
 {{#if this.shouldShow}}
-  {{! Track each visitor field in `did-update` so we re-sync whenever any of
-      them change — not just on currentUserId transitions. See the doc-comment
-      above the getters in `index.ts` for why this matters (Ember Data's two-pass
-      hydration can leave `primaryEmailAddress` empty after the first sync). }}
+  {{! Track BOTH currentUserId AND each individual visitor field in `did-update`.
+
+      - `currentUserId` catches identity transitions (login / logout / account
+        switch) even when the new user's record briefly hydrates with empty
+        fields — without this leading dep, a logout-then-login-as-different-user
+        sequence where both states coincidentally have all-empty getters would
+        not re-fire `syncVisitorData`, leaving stale visitor data in Lobbyside
+        until the new user's fields finished populating.
+      - The three field getters (`userPrimaryEmail`, `userName`, `userGithub`)
+        catch in-place mutations on the SAME user record, which is how Ember
+        Data's two-pass hydration delivers `primaryEmailAddress` (a page-level
+        sideload populates name + githubUsername first; the full /users/current
+        payload fills in the email a beat later). See the doc-comment above
+        the getters in `index.ts` for the full rationale. }}
   <div
     {{did-insert this.insertScript}}
-    {{did-update this.syncVisitorData this.userPrimaryEmail this.userName this.userGithub}}
+    {{did-update this.syncVisitorData this.authenticator.currentUserId this.userPrimaryEmail this.userName this.userGithub}}
     {{will-destroy this.removeScript}}
   ></div>
 {{/if}}

--- a/app/components/lobbyside-widget/index.hbs
+++ b/app/components/lobbyside-widget/index.hbs
@@ -1,3 +1,11 @@
 {{#if this.shouldShow}}
-  <div {{did-insert this.insertScript}} {{did-update this.syncVisitorData this.authenticator.currentUserId}} {{will-destroy this.removeScript}}></div>
+  {{! Track each visitor field in `did-update` so we re-sync whenever any of
+      them change — not just on currentUserId transitions. See the doc-comment
+      above the getters in `index.ts` for why this matters (Ember Data's two-pass
+      hydration can leave `primaryEmailAddress` empty after the first sync). }}
+  <div
+    {{did-insert this.insertScript}}
+    {{did-update this.syncVisitorData this.userPrimaryEmail this.userName this.userGithub}}
+    {{will-destroy this.removeScript}}
+  ></div>
 {{/if}}

--- a/app/components/lobbyside-widget/index.ts
+++ b/app/components/lobbyside-widget/index.ts
@@ -37,6 +37,34 @@ export default class LobbysideWidgetComponent extends Component<LobbysideWidgetS
     return true;
   }
 
+  // The next three getters mirror the fields we push to Lobbyside via
+  // `setVisitor`. They exist (and are referenced from the template's
+  // `{{did-update}}` args) so that we re-sync the visitor stash whenever any
+  // individual field's value changes — not just when `currentUserId` changes.
+  //
+  // Why this matters: Ember Data sometimes hydrates the user record in two
+  // passes. A page-level payload may sideload the current user with `name` +
+  // `githubUsername` but no `primaryEmailAddress`; the full payload from
+  // `authenticator.syncCurrentUser` arrives a beat later and fills the email
+  // in-place. Because `currentUserId` is the same string before and after
+  // that mutation, a `did-update` keyed only on `currentUserId` does NOT
+  // re-fire — and the embedder's `__LOBBYSIDE_VISITOR_DATA__.email` stays
+  // empty even though name/github were already pre-filled. Tracking each
+  // field directly forces a re-sync the moment any of them change.
+  get userGithub(): string {
+    return this.authenticator.currentUser?.githubUsername || '';
+  }
+
+  get userName(): string {
+    const user = this.authenticator.currentUser;
+
+    return user?.name || user?.githubName || '';
+  }
+
+  get userPrimaryEmail(): string {
+    return this.authenticator.currentUser?.primaryEmailAddress || '';
+  }
+
   @action
   insertScript(): void {
     if (document.getElementById(this.scriptId)) {
@@ -60,16 +88,14 @@ export default class LobbysideWidgetComponent extends Component<LobbysideWidgetS
 
   @action
   syncVisitorData(): void {
-    const user = this.authenticator.currentUser;
-
-    if (!user || !window.Lobbyside) {
+    if (!this.authenticator.currentUser || !window.Lobbyside) {
       return;
     }
 
     window.Lobbyside.setVisitor({
-      email: user.primaryEmailAddress || '',
-      name: user.name || user.githubName || '',
-      github: user.githubUsername || '',
+      email: this.userPrimaryEmail,
+      name: this.userName,
+      github: this.userGithub,
     });
   }
 }

--- a/app/components/lobbyside-widget/index.ts
+++ b/app/components/lobbyside-widget/index.ts
@@ -1,6 +1,7 @@
 import Component from '@glimmer/component';
 import { service } from '@ember/service';
 import { action } from '@ember/object';
+import config from 'codecrafters-frontend/config/environment';
 import { userIsStaffOrAllowlisted } from 'codecrafters-frontend/utils/staff-allowlist';
 import type AuthenticatorService from 'codecrafters-frontend/services/authenticator';
 
@@ -67,6 +68,18 @@ export default class LobbysideWidgetComponent extends Component<LobbysideWidgetS
 
   @action
   insertScript(): void {
+    // Skip the network fetch in test mode — the third-party widget script is
+    // not part of any test contract here, and injecting it makes acceptance
+    // tests flake: the request is fired against the public lobbyside.com CDN
+    // (no Mirage handler), and when the response arrives AFTER the test has
+    // torn down the app, our `onload → syncVisitorData → currentUser` chain
+    // calls `store.peekRecord()` on a destroyed store and the whole test
+    // run aborts with a global failure. Same pattern `UserSyncerService`
+    // uses (`app/services/user-syncer.ts`).
+    if (config.environment === 'test') {
+      return;
+    }
+
     if (document.getElementById(this.scriptId)) {
       this.syncVisitorData();
 
@@ -77,13 +90,37 @@ export default class LobbysideWidgetComponent extends Component<LobbysideWidgetS
     script.id = this.scriptId;
     script.src = 'https://lobbyside.com/widget.js';
     script.dataset['widgetId'] = this.args.widgetId;
-    script.onload = () => this.syncVisitorData();
+
+    script.onload = () => {
+      // The script is fetched async, so this callback can still fire after
+      // the component (and the Ember Data store) has been torn down — most
+      // commonly when the user navigates away mid-load. Bail in that case
+      // so `syncVisitorData → currentUser → store.peekRecord` doesn't
+      // throw against a destroyed store. Belt-and-braces with the
+      // `script.onload = null` cleanup in `removeScript` below.
+      if (this.isDestroying || this.isDestroyed) {
+        return;
+      }
+
+      this.syncVisitorData();
+    };
+
     document.body.appendChild(script);
   }
 
   @action
   removeScript(): void {
-    document.getElementById(this.scriptId)?.remove();
+    const script = document.getElementById(this.scriptId) as HTMLScriptElement | null;
+
+    if (script) {
+      // Cancel any pending onload before removing the element. The browser
+      // can still fire `onload` against a script that's already been
+      // detached from the DOM (the listener was attached to the element
+      // reference, not the DOM position), so dropping the handler here
+      // prevents a torn-down component from re-entering its own callback.
+      script.onload = null;
+      script.remove();
+    }
   }
 
   @action


### PR DESCRIPTION
Updated the Lobbyside widget to track individual visitor fields (`userPrimaryEmail`, `userName`, `userGithub`) in the `did-update` lifecycle hook. This change ensures that the visitor data is re-synced whenever any of these fields change, addressing issues with Ember Data's two-pass hydration that could leave the email field empty. Added comments for clarity on the importance of these changes.

**Checklist**:

- [ ] I've thoroughly self-reviewed my changes
- [ ] I've added tests for my changes, unless they affect admin-only areas (or are otherwise not worth testing)
- [ ] I've verified any visual changes using Percy (add a commit with `[percy]` in the message to trigger)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches third-party visitor data synchronization and async script lifecycle, so regressions could lead to stale/incorrect visitor attributes or unexpected callback timing during navigation/tests.
> 
> **Overview**
> Improves the Lobbyside widget’s visitor syncing by re-triggering `syncVisitorData` not only on `currentUserId` changes but also when the user’s `email`, `name`, or `github` fields mutate (to handle Ember Data in-place/two-pass hydration).
> 
> Hardens script injection/teardown: skips loading the external widget script in `test`, guards `onload` against firing after component destruction, and nulls `onload` before removing the script to prevent post-destroy callbacks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9666a9d769c9a0e93e37354ce1e51b4f2e1b3ace. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->