### PR TITLE
fix: reset staff acknowledgment status on feedback submission close

### DIFF
--- a/app/components/course-page/course-stage-step/feedback-prompt.ts
+++ b/app/components/course-page/course-stage-step/feedback-prompt.ts
@@ -102,6 +102,7 @@ export default class FeedbackPrompt extends Component<Signature> {
   @action
   handleSubmitButtonClick() {
     this.feedbackSubmission!.status = 'closed';
+    this.feedbackSubmission!.isAcknowledgedByStaff = false;
 
     // Don't fire for editing submissions
     if (!this.isEditingClosedSubmission) {


### PR DESCRIPTION
**Issue:**

Course_author_or_staff-created stage feedback are **always** acked, because every stage feedback started as acked.

https://github.com/codecrafters-io/core/blob/1937c21d26aff052eb741cf442807d9c1b68d3c9/app/controllers/api/course_stage_feedback_submissions_controller.rb#L56-L58

---

Updated the feedback submission handling to set `isAcknowledgedByStaff` to false when the submit button is clicked, ensuring proper state management for feedback submissions.

**Checklist**:

- [x] I've thoroughly self-reviewed my changes
- [ ] I've added tests for my changes, unless they affect admin-only areas (or are otherwise not worth testing)
- [ ] I've verified any visual changes using Percy (add a commit with `[percy]` in the message to trigger)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a small client-side state change that only affects the `isAcknowledgedByStaff` flag when a feedback submission is closed.
> 
> **Overview**
> When the user submits/closes a stage feedback entry, the client now explicitly resets `isAcknowledgedByStaff` to `false` before saving, preventing new/edited submissions from being treated as already acknowledged by staff.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0114dbdf62fb9471ebc03295f8120fd0d9c06b7a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->