### PR TITLE
Remove Roadmap nav link and mark lifetime plan as sold out

### DIFF
--- a/app/components/header/index.ts
+++ b/app/components/header/index.ts
@@ -62,14 +62,12 @@ export default class Header extends Component<Signature> {
     return [
       { text: 'Catalog', route: 'catalog', type: 'route' },
       { text: 'Pricing', route: 'pay', type: 'route' },
-      { text: 'Roadmap', route: 'roadmap', type: 'route' },
     ];
   }
 
   get linksForAuthenticatedUser(): { text: string; route: string; type: 'route' | 'link'; routeParams?: string[] }[] {
     const links: { text: string; route: string; type: 'route' | 'link'; routeParams?: string[] }[] = [
       { text: 'Catalog', route: 'catalog', type: 'route' },
-      { text: 'Roadmap', route: 'roadmap', type: 'route' },
     ];
 
     links.push({

--- a/app/components/pay-page/choose-membership-plan-modal.ts
+++ b/app/components/pay-page/choose-membership-plan-modal.ts
@@ -16,12 +16,13 @@ export interface PricingPlan {
   title: string;
   priceInDollars: number;
   validityInMonths?: number; // undefined for lifetime
+  isSoldOut?: boolean;
 }
 
 export const PRICING_PLANS: PricingPlan[] = [
   { id: 'v1-3mo', frequency: 'quarterly', title: '3 months', priceInDollars: 120, validityInMonths: 3 },
   { id: 'v1-1yr', frequency: 'yearly', title: '1 year', priceInDollars: 360, validityInMonths: 12 },
-  { id: 'v1-lifetime', frequency: 'lifetime', title: 'Lifetime', priceInDollars: 1490 },
+  { id: 'v1-lifetime', frequency: 'lifetime', title: 'Lifetime', priceInDollars: 1490, isSoldOut: true },
 ];
 
 interface Signature {

--- a/app/components/pay-page/choose-membership-plan-modal/plan-card.hbs
+++ b/app/components/pay-page/choose-membership-plan-modal/plan-card.hbs
@@ -91,6 +91,8 @@
     <div class="text-gray-500 dark:text-gray-400 text-xxs shrink-0 text-right mt-0.5">
       {{#if this.amortizedMonthlyPriceInDollars}}
         Effectively ${{this.amortizedMonthlyPriceInDollars}}/mo
+      {{else if @plan.isSoldOut}}
+        Sold out
       {{else}}
         Limited spots
       {{/if}}

--- a/app/components/pay-page/choose-membership-plan-modal/plan-selection-step.hbs
+++ b/app/components/pay-page/choose-membership-plan-modal/plan-selection-step.hbs
@@ -10,7 +10,13 @@
       />
     {{/each}}
 
-    <PrimaryButton @size="large" {{on "click" @onChoosePlanButtonClick}} data-test-choose-plan-button>
+    <PrimaryButton
+      @size="large"
+      @isDisabled={{@selectedPlan.isSoldOut}}
+      disabled={{@selectedPlan.isSoldOut}}
+      {{on "click" @onChoosePlanButtonClick}}
+      data-test-choose-plan-button
+    >
       Choose
       {{@selectedPlan.title}}
       pass →


### PR DESCRIPTION
## Summary
- Remove the **Roadmap** menu option from the header for both anonymous and authenticated users (the `/roadmap` route itself is untouched).
- On the pay page's "Choose a membership plan" modal, mark the **Lifetime** plan as sold out: its small label reads **"Sold out"** instead of "Limited spots", and the bottom **Choose ... pass** button is disabled (gray) when Lifetime is selected. The lifetime card itself is still clickable/selectable.

Implemented via a new `isSoldOut?: boolean` flag on `PricingPlan`, set to `true` only on the lifetime plan.

## Test plan
- [ ] Header shows only Catalog / Pricing (anon) and Catalog / Leaderboard (authed) — no Roadmap link.
- [ ] `/roadmap` route still works when navigated to directly.
- [ ] On `/pay` → "View plans": Lifetime card shows "Sold out".
- [ ] Selecting the Lifetime card grays out the "Choose Lifetime pass" button and clicking it does nothing.
- [ ] Selecting 3 months or 1 year keeps the Choose button enabled and functional as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only changes: removes a header nav item and gates selection of one pricing plan without affecting routing or checkout logic beyond disabling the CTA.
> 
> **Overview**
> Removes the `Roadmap` link from the header navigation for both anonymous and authenticated users.
> 
> Updates the pay-page plan selection modal to support sold-out plans via a new `PricingPlan.isSoldOut` flag, marking the Lifetime plan as sold out, showing a `Sold out` label on its card, and disabling the "Choose" button when that plan is selected.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2207401191006214f6f601c70fcb387583de4fec. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->