### PR TITLE
Update pricing FAQ stage and language counts

### DIFF
--- a/app/components/pricing-page/faq-list.ts
+++ b/app/components/pricing-page/faq-list.ts
@@ -17,7 +17,7 @@ export default class FaqList extends Component<Signature> {
   faqs: Faq[] = [
     {
       query: 'How many exercises are there?',
-      answerMarkdown: `We have over 250 stages split across 10 challenges which you can attempt in 22 programming languages. Here's what you'll be building:
+      answerMarkdown: `We have over 350 stages split across 10 challenges which you can attempt in 29 programming languages. Here's what you'll be building:
 
 
 * Build Your Own Redis


### PR DESCRIPTION
## Summary
- The "How many exercises are there?" FAQ on the pricing page was outdated. Updated:
  - **Stages**: "over 250" → "over 350" (catalog currently has 390 across the 10 live courses).
  - **Languages**: "22" → "29" (matches the current `/api/v1/languages` list: 3 live + 26 beta tracks).
- Challenge list itself is unchanged — the 10 names already match the 10 live courses.

## Test plan
- [ ] Visit `/pay`, scroll to FAQ, open "How many exercises are there?" — verify the new sentence reads "over 350 stages ... 29 programming languages".

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk copy-only change in the pricing FAQ; no behavior, data handling, or pricing logic is modified.
> 
> **Overview**
> Updates the pricing page FAQ answer for "How many exercises are there?" to reflect current catalog numbers, changing the copy from **over 250 stages / 22 languages** to **over 350 stages / 29 languages**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4158f3c10972cefd6fd75aae6ab89e6133c6078d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->