### PR TITLE
Fix pricing FAQ challenge count (10 → 11)

### DIFF
--- a/app/components/pricing-page/faq-list.ts
+++ b/app/components/pricing-page/faq-list.ts
@@ -17,7 +17,7 @@ export default class FaqList extends Component<Signature> {
   faqs: Faq[] = [
     {
       query: 'How many exercises are there?',
-      answerMarkdown: `We have over 350 stages split across 10 challenges which you can attempt in 29 programming languages. Here's what you'll be building:
+      answerMarkdown: `We have over 350 stages split across 11 challenges which you can attempt in 29 programming languages. Here's what you'll be building:
 
 
 * Build Your Own Redis
@@ -30,6 +30,7 @@ export default class FaqList extends Component<Signature> {
 * Build Your Own Shell
 * Build Your Own Interpreter
 * Build Your Own Kafka
+* Build Your Own Claude Code
 
 If we launch new challenges during your membership, you get access to those too. Visit [our catalog](https://app.codecrafters.io/catalog) to check each individual challenge in detail.`,
     },


### PR DESCRIPTION
## Summary
Follow-up to #3861 — the catalog actually shows **11** challenges (10 live + Claude Code beta), not 10. Bumped the count and added Claude Code to the listed challenges.

Stage count ("over 350") and language count (29) remain accurate.

## Test plan
- [ ] Visit `/pay`, scroll to FAQ, open "How many exercises are there?" — verify it now says "over 350 stages ... 11 challenges" and lists Build Your Own Claude Code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk copy-only change to a pricing FAQ; no logic, data, or billing behavior is modified.
> 
> **Overview**
> Updates the `/pay` FAQ answer for "How many exercises are there?" to say **11 challenges** (was 10) and adds *Build Your Own Claude Code* to the listed challenges.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6c80209757b2cf337a5e1565745de9af04c83c61. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->