### PR TITLE
Remove feedback prompt

### DIFF
--- a/app/components/course-page/course-stage-step/feedback-prompt.hbs
+++ b/app/components/course-page/course-stage-step/feedback-prompt.hbs
@@ -57,17 +57,6 @@
         </div>
 
         {{#if this.feedbackSubmission.hasSelectedAnswer}}
-          <div class="prose prose-sm prose-green dark:prose-invert mt-4">
-            P.S.
-            <a
-              href="https://forum.codecrafters.io/u/rohitpaulk/activity"
-              target="_blank"
-              rel="noopener noreferrer"
-              class="underline font-semibold"
-            >rohitpaulk</a>
-            reads every one of these messages! We act on most feedback within a week.
-          </div>
-
           {{! template-lint-disable require-input-label }}
           <Textarea
             @value={{this.feedbackSubmission.explanation}}


### PR DESCRIPTION
**Checklist**:

- [x] I've thoroughly self-reviewed my changes
- [ ] I've added tests for my changes, unless they affect admin-only areas (or are otherwise not worth testing)
- [ ] I've verified any visual changes using Percy (add a commit with `[percy]` in the message to trigger)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Copy-only removal in a course UI template with no logic, API, or data-handling changes.
> 
> **Overview**
> Removes the **P.S.** blurb from the course-stage **feedback prompt** that appeared after a learner picked an emoji rating. That block linked to a forum profile and said feedback is read and acted on within a week.
> 
> The flow is unchanged: emoji options, then the explanation **Textarea** and submit controls still show when an answer is selected—only the extra reassurance text is gone.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2e30edf1701c26ca42e86882aedcf602fd3713ac. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->