### PR TITLE
Enhance TestsPassedModal to handle 'await_submission' action

### DIFF
--- a/app/components/course-page/course-stage-step/tests-passed-modal/await-submission-step.hbs
+++ b/app/components/course-page/course-stage-step/tests-passed-modal/await-submission-step.hbs
@@ -1,0 +1,46 @@
+<div
+  class="flex flex-col items-center w-full relative"
+  {{did-update this.handleLastSubmissionBecameUsable @repository.lastSubmissionCanBeUsedForStageCompletion}}
+>
+  <div class="w-20 h-20 mb-2">
+    <RiveAnimation @src="/assets/animations/checkmark_icon.riv" />
+  </div>
+
+  <div class="mb-5 font-bold text-2xl text-gray-700 dark:text-gray-100" data-test-modal-title>
+    Tests passed!
+  </div>
+
+  <div class="prose dark:prose-invert mb-3 text-center text-balance">
+    <p>
+      Run the
+
+      {{#if (gt this.selectedCommandVariant.commands.length 1)}}
+        following commands
+      {{else}}
+        <code>submit</code>
+        command
+      {{/if}}
+
+      to submit your code.
+    </p>
+  </div>
+
+  <CopyableTerminalCommandWithVariants class="mb-3" @variants={{this.commandVariants}} @onVariantSelect={{this.handleVariantSelect}} />
+
+  <div class="prose dark:prose-invert mb-5 text-center prose-sm text-balance">
+    <p class="text-xs">
+      Unable to use the
+      <a href="https://codecrafters.io/cli" target="_blank" rel="noopener noreferrer">CodeCrafters&nbsp;CLI</a>? You can use Git too.
+    </p>
+  </div>
+
+  <div class="flex items-center text-sm" ...attributes>
+    <AnimatedContainer>
+      <BlinkingDot class="mr-2" @color="yellow" />
+    </AnimatedContainer>
+
+    <span class="text-yellow-600 dark:text-yellow-500 font-medium" data-test-progress-indicator-text>
+      Waiting for command...
+    </span>
+  </div>
+</div>

--- a/app/components/course-page/course-stage-step/tests-passed-modal/await-submission-step.ts
+++ b/app/components/course-page/course-stage-step/tests-passed-modal/await-submission-step.ts
@@ -1,0 +1,56 @@
+import Component from '@glimmer/component';
+import type Owner from '@ember/owner';
+import type RepositoryModel from 'codecrafters-frontend/models/repository';
+import type { CopyableTerminalCommandVariant } from 'codecrafters-frontend/components/copyable-terminal-command-with-variants';
+import { action } from '@ember/object';
+import { tracked } from '@glimmer/tracking';
+
+interface Signature {
+  Element: HTMLDivElement;
+
+  Args: {
+    onActionButtonClick: (action: 'choose_action') => void;
+    repository: RepositoryModel;
+  };
+}
+
+export default class AwaitSubmissionStep extends Component<Signature> {
+  @tracked selectedCommandVariant: CopyableTerminalCommandVariant;
+
+  constructor(owner: Owner, args: Signature['Args']) {
+    super(owner, args);
+
+    this.selectedCommandVariant = this.commandVariants[0]!;
+  }
+
+  get commandVariants(): CopyableTerminalCommandVariant[] {
+    return [
+      {
+        label: 'codecrafters cli',
+        commands: ['codecrafters submit'],
+      },
+      {
+        label: 'git',
+        commands: ['git add .', 'git commit --allow-empty -m "[any message]"', 'git push origin master'],
+      },
+    ];
+  }
+
+  @action
+  handleLastSubmissionBecameUsable(_element: HTMLDivElement, [canUseLastSubmission]: [boolean]) {
+    if (canUseLastSubmission) {
+      this.args.onActionButtonClick('choose_action');
+    }
+  }
+
+  @action
+  handleVariantSelect(variant: CopyableTerminalCommandVariant) {
+    this.selectedCommandVariant = variant;
+  }
+}
+
+declare module '@glint/environment-ember-loose/registry' {
+  export default interface Registry {
+    'CoursePage::CourseStageStep::TestsPassedModal::AwaitSubmissionStep': typeof AwaitSubmissionStep;
+  }
+}

--- a/app/components/course-page/course-stage-step/tests-passed-modal/index.hbs
+++ b/app/components/course-page/course-stage-step/tests-passed-modal/index.hbs
@@ -9,6 +9,13 @@
 >
   <AnimatedContainer>
     <div class="flex flex-col items-center w-full">
+      {{#animated-if (eq this.action "await_submission")}}
+        <CoursePage::CourseStageStep::TestsPassedModal::AwaitSubmissionStep
+          @onActionButtonClick={{this.handleActionButtonClick}}
+          @repository={{@currentStep.repository}}
+        />
+      {{/animated-if}}
+
       {{#animated-if (eq this.action "choose_action")}}
         <CoursePage::CourseStageStep::TestsPassedModal::ChooseActionStep
           @currentStep={{@currentStep}}

--- a/app/components/course-page/course-stage-step/tests-passed-modal/index.ts
+++ b/app/components/course-page/course-stage-step/tests-passed-modal/index.ts
@@ -5,6 +5,7 @@ import { action } from '@ember/object';
 import { service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 import { waitFor } from '@ember/test-waiters';
+import type Owner from '@ember/owner';
 
 interface Signature {
   Element: HTMLDivElement;
@@ -18,7 +19,17 @@ interface Signature {
 export default class TestsPassedModal extends Component<Signature> {
   @service declare courseStageCompletion: CourseStageCompletionService;
 
-  @tracked action: 'choose_action' | 'refactor_code' | 'mark_stage_as_complete' | 'submit_code' = 'choose_action';
+  @tracked action: 'await_submission' | 'choose_action' | 'refactor_code' | 'mark_stage_as_complete' | 'submit_code' = 'choose_action';
+
+  constructor(owner: Owner, args: Signature['Args']) {
+    super(owner, args);
+
+    if (this.args.currentStep.repository.lastSubmissionCanBeUsedForStageCompletion) {
+      this.action = 'choose_action';
+    } else {
+      this.action = 'await_submission';
+    }
+  }
 
   @action
   @waitFor

--- a/tests/acceptance/course-page/complete-second-stage-test.js
+++ b/tests/acceptance/course-page/complete-second-stage-test.js
@@ -209,8 +209,7 @@ module('Acceptance | course-page | complete-second-stage', function (hooks) {
     assert.ok(coursePage.testsPassedModal.isVisible, 'Tests passed modal is visible');
     assert.strictEqual(coursePage.testsPassedModal.title, 'Tests passed!', 'Tests passed modal title is correct');
 
-    await coursePage.testsPassedModal.clickOnActionButton('Mark stage as complete');
-    assert.strictEqual(coursePage.testsPassedModal.title, 'Submit code', 'Tests passed modal title is correct');
+    assert.strictEqual(coursePage.testsPassedModal.title, 'Tests passed!', 'Tests passed modal title is correct');
 
     this.server.create('submission', 'withSuccessStatus', {
       clientType: 'git',
@@ -222,7 +221,7 @@ module('Acceptance | course-page | complete-second-stage', function (hooks) {
     await finishRender();
 
     assert.ok(coursePage.testsPassedModal.isVisible, 'Tests passed modal is visible');
-    assert.strictEqual(coursePage.testsPassedModal.title, 'Submit code', 'Tests passed modal title is correct');
+    assert.strictEqual(coursePage.testsPassedModal.title, 'Tests passed!', 'Tests passed modal title is correct');
 
     await coursePage.testsPassedModal.clickOnActionButton('Mark stage as complete');
 


### PR DESCRIPTION
Before (left): need to click "mark as complete" to find out that it isn't ready to mark as complete yet

vs 

After (Right): show the submit prompt without needing to click anything

<img width="3516" height="1408" alt="image" src="https://github.com/user-attachments/assets/e9473658-77b0-446d-ab1f-da84e729d065" />


---

Updated the action property to include 'await_submission' and modified the constructor to set the action based on the repository's last submission status. Added a new animated-if block to render the AwaitSubmissionStep component when the action is 'await_submission'.

**Checklist**:

- [x] I've thoroughly self-reviewed my changes
- [ ] I've added tests for my changes, unless they affect admin-only areas (or are otherwise not worth testing)
- [ ] I've verified any visual changes using Percy (add a commit with `[percy]` in the message to trigger)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes stage-completion UX and gating in the course flow; behavior depends on repository submission state staying in sync via ActionCable updates.
> 
> **Overview**
> After tests pass, the **Tests passed** modal now opens on a new **await submission** step when `lastSubmissionCanBeUsedForStageCompletion` is false (e.g. tests ran via CLI without a submittable push).
> 
> That step keeps the “Tests passed!” messaging, shows **codecrafters submit** / **git** copyable commands, and a “Waiting for command…” indicator. When the repository updates so the last submission becomes usable, it automatically moves to the existing **choose action** step.
> 
> The modal’s initial `action` is chosen in the constructor from the same flag, and acceptance coverage for the CLI path expects the modal title to stay **Tests passed!** until a qualifying submission exists.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9d15f3004eb593d6859693942515880416a8db63. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->