### PR TITLE
Disable Lobbyside widgets on staging builds

### DIFF
--- a/app/components/lobbyside-widget/index.hbs
+++ b/app/components/lobbyside-widget/index.hbs
@@ -14,6 +14,7 @@
         payload fills in the email a beat later). See the doc-comment above
         the getters in `index.ts` for the full rationale. }}
   <div
+    data-test-lobbyside-widget={{@widgetId}}
     {{did-insert this.insertScript}}
     {{did-update this.syncVisitorData this.authenticator.currentUserId this.userPrimaryEmail this.userName this.userGithub}}
     {{will-destroy this.removeScript}}

--- a/app/components/lobbyside-widget/index.ts
+++ b/app/components/lobbyside-widget/index.ts
@@ -31,6 +31,12 @@ export default class LobbysideWidgetComponent extends Component<LobbysideWidgetS
   }
 
   get shouldShow(): boolean {
+    // Widgets are registered against the prod Lobbyside dashboard; staging builds
+    // share that dashboard, so suppress them to avoid prod widgets on staging.
+    if (config.x.isStaging) {
+      return false;
+    }
+
     if ((this.args.audience ?? 'everyone') === 'staff') {
       return userIsStaffOrAllowlisted(this.authenticator.currentUser);
     }

--- a/app/config/environment.d.ts
+++ b/app/config/environment.d.ts
@@ -13,6 +13,7 @@ declare const config: {
     backendUrl: string;
     helpscoutBeaconId: string;
     isCI: boolean;
+    isStaging: boolean;
     metaTagImagesBaseURL: string;
     stripePublishableKey: string;
     vercelAnalyticsId: string;

--- a/config/environment.js
+++ b/config/environment.js
@@ -1,6 +1,8 @@
 'use strict';
 
 module.exports = function (environment) {
+  const backendUrl = process.env.BACKEND_URL || 'https://test-backend.ngrok.io';
+
   const ENV = {
     modulePrefix: 'codecrafters-frontend',
     environment,
@@ -30,7 +32,11 @@ module.exports = function (environment) {
     },
 
     x: {
-      backendUrl: process.env.BACKEND_URL || 'https://test-backend.ngrok.io',
+      backendUrl,
+
+      // No dedicated `staging` Ember env — staging is the prod build pointed at
+      // the staging backend. Used to suppress prod-only integrations (Lobbyside).
+      isStaging: backendUrl.includes('backend-staging.codecrafters.io'),
 
       defaultMetaTags: {
         type: 'website',

--- a/tests/integration/components/lobbyside-widget-test.js
+++ b/tests/integration/components/lobbyside-widget-test.js
@@ -1,0 +1,56 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'codecrafters-frontend/tests/helpers';
+import { render } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+import config from 'codecrafters-frontend/config/environment';
+import Service from '@ember/service';
+
+class StubStaffAuthenticatorService extends Service {
+  currentUser = { isStaff: true, username: 'staff-user' };
+  currentUserId = 'staff-user-id';
+}
+
+module('Integration | Component | lobbyside-widget', function (hooks) {
+  setupRenderingTest(hooks);
+
+  hooks.beforeEach(function () {
+    this.owner.unregister('service:authenticator');
+    this.owner.register('service:authenticator', StubStaffAuthenticatorService);
+  });
+
+  hooks.afterEach(function () {
+    config.x.isStaging = false;
+  });
+
+  test('renders the everyone-audience widget mount outside staging', async function (assert) {
+    config.x.isStaging = false;
+
+    await render(hbs`<LobbysideWidget @widgetId="widget-1" />`);
+
+    assert.dom('[data-test-lobbyside-widget="widget-1"]').exists();
+  });
+
+  test('renders the staff-audience widget mount for staff outside staging', async function (assert) {
+    config.x.isStaging = false;
+
+    await render(hbs`<LobbysideWidget @widgetId="widget-staff" @audience="staff" />`);
+
+    assert.dom('[data-test-lobbyside-widget="widget-staff"]').exists();
+  });
+
+  test('does not render the everyone-audience widget in staging', async function (assert) {
+    config.x.isStaging = true;
+
+    await render(hbs`<LobbysideWidget @widgetId="widget-1" />`);
+
+    assert.dom('[data-test-lobbyside-widget="widget-1"]').doesNotExist();
+  });
+
+  test('does not render the staff-audience widget in staging even for staff', async function (assert) {
+    config.x.isStaging = true;
+
+    await render(hbs`<LobbysideWidget @widgetId="widget-staff" @audience="staff" />`);
+
+    assert.dom('[data-test-lobbyside-widget="widget-staff"]').doesNotExist();
+  });
+});


### PR DESCRIPTION
## Summary

Staging deploys are the production build pointed at the staging backend (`BACKEND_URL=https://backend-staging.codecrafters.io`); there is no dedicated `staging` Ember environment, so `config.environment` is `production` on staging too. The Lobbyside widgets load the prod widget script and register against the production Lobbyside dashboard regardless of backend — so a staging deploy surfaced the live production widgets.

This derives an `isStaging` flag from `BACKEND_URL` (the one canonical signal that already defines "staging" in this repo) and gates the widget at its single chokepoint, `LobbysideWidget#shouldShow`, hiding all five instances at once.

## Changes

- `config/environment.js` — resolve `BACKEND_URL` once and expose `x.isStaging` (true when it points at `backend-staging.codecrafters.io`).
- `app/config/environment.d.ts` — type the new `x.isStaging` flag.
- `app/components/lobbyside-widget/index.ts` — `shouldShow` returns `false` in staging, mirroring the existing `config.environment === 'test'` skip pattern.
- `app/components/lobbyside-widget/index.hbs` — add `data-test-lobbyside-widget` hook for testability.
- `tests/integration/components/lobbyside-widget-test.js` — new integration tests.

## Test plan

- [x] `bun run lint:js`, `lint:hbs`, `lint:glint` — clean
- [x] `ember test --filter "lobbyside-widget"` — 4/4 pass
- [x] False-positive check: staff-audience staging test uses a stubbed staff user, so it goes red if the staging gate is removed

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Behavior is gated at one component chokepoint with integration tests; no auth or data-path changes.
> 
> **Overview**
> Staging uses the **production** Ember build with `BACKEND_URL` pointed at the staging API, so Lobbyside was still loading prod widgets against the prod dashboard. This PR adds **`config.x.isStaging`**, derived when `BACKEND_URL` contains `backend-staging.codecrafters.io`, and **`LobbysideWidget#shouldShow`** returns false when that flag is set—hiding all widget instances without a separate Ember environment.
> 
> The widget mount div gets **`data-test-lobbyside-widget`** for assertions, and new integration tests cover everyone/staff audiences on and off staging.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5c5c8eaf80da308189c87397dc64b7e4c980fd5f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->