### PR TITLE
Push custom values (signup date, subscription, stages) to Lobbyside

### DIFF
--- a/app/components/lobbyside-widget/index.hbs
+++ b/app/components/lobbyside-widget/index.hbs
@@ -16,7 +16,16 @@
   <div
     data-test-lobbyside-widget={{@widgetId}}
     {{did-insert this.insertScript}}
-    {{did-update this.syncVisitorData this.authenticator.currentUserId this.userPrimaryEmail this.userName this.userGithub}}
+    {{did-update
+      this.syncVisitorData
+      this.authenticator.currentUserId
+      this.userPrimaryEmail
+      this.userName
+      this.userGithub
+      this.customFields.stages_completed
+      this.customFields.signed_up_date
+      this.customFields.subscription_type
+    }}
     {{will-destroy this.removeScript}}
   ></div>
 {{/if}}

--- a/app/components/lobbyside-widget/index.ts
+++ b/app/components/lobbyside-widget/index.ts
@@ -8,12 +8,72 @@ import type AuthenticatorService from 'codecrafters-frontend/services/authentica
 declare global {
   interface Window {
     Lobbyside?: {
-      setVisitor(visitor: { email: string; name: string; github: string }): void;
+      setVisitor(visitor: {
+        email: string;
+        name: string;
+        github: string;
+        stages_completed: string;
+        signed_up_date: string;
+        subscription_type: string;
+      }): void;
     };
   }
 }
 
 export type LobbysideAudience = 'everyone' | 'staff';
+
+// Structural subset of UserModel so the derivation stays pure + unit-testable.
+interface VisitorSource {
+  createdAt?: Date | null;
+  isVip?: boolean;
+  activeSubscription?: { isLifetimeMembership?: boolean } | null;
+  hasActiveSubscription?: boolean;
+  teamHasActiveSubscription?: boolean;
+  courseParticipations?: { completedStageSlugs?: string[] }[];
+}
+
+export interface LobbysideCustomFields {
+  stages_completed: string;
+  signed_up_date: string;
+  subscription_type: string;
+}
+
+function subscriptionType(user: VisitorSource | null | undefined): string {
+  if (!user) {
+    return '';
+  }
+
+  if (user.activeSubscription?.isLifetimeMembership) {
+    return 'lifetime';
+  }
+
+  if (user.hasActiveSubscription) {
+    return 'individual';
+  }
+
+  if (user.teamHasActiveSubscription) {
+    return 'team';
+  }
+
+  if (user.isVip) {
+    return 'vip';
+  }
+
+  return 'free';
+}
+
+export function lobbysideCustomFields(user: VisitorSource | null | undefined): LobbysideCustomFields {
+  const stagesCompleted = (user?.courseParticipations ?? []).reduce(
+    (sum, participation) => sum + (participation.completedStageSlugs?.length ?? 0),
+    0,
+  );
+
+  return {
+    stages_completed: String(stagesCompleted),
+    signed_up_date: user?.createdAt ? user.createdAt.toISOString().slice(0, 10) : '',
+    subscription_type: subscriptionType(user),
+  };
+}
 
 export interface LobbysideWidgetSignature {
   Element: HTMLDivElement;
@@ -25,6 +85,10 @@ export interface LobbysideWidgetSignature {
 
 export default class LobbysideWidgetComponent extends Component<LobbysideWidgetSignature> {
   @service declare authenticator: AuthenticatorService;
+
+  get customFields(): LobbysideCustomFields {
+    return lobbysideCustomFields(this.authenticator.currentUser);
+  }
 
   get scriptId(): string {
     return `lobbyside-widget-${this.args.widgetId}`;
@@ -139,6 +203,7 @@ export default class LobbysideWidgetComponent extends Component<LobbysideWidgetS
       email: this.userPrimaryEmail,
       name: this.userName,
       github: this.userGithub,
+      ...this.customFields,
     });
   }
 }

--- a/app/services/authenticator.ts
+++ b/app/services/authenticator.ts
@@ -116,6 +116,8 @@ export default class AuthenticatorService extends Service {
     const includedResources = [
       'affiliate-links',
       'affiliate-links.user',
+      // Powers the `stages_completed` field the Lobbyside widget pushes via setVisitor.
+      'course-participations',
       'feature-suggestions',
       'promotional-discounts',
       'promotional-discounts.affiliate-referral',

--- a/tests/unit/components/lobbyside-widget-test.ts
+++ b/tests/unit/components/lobbyside-widget-test.ts
@@ -1,0 +1,60 @@
+import { lobbysideCustomFields } from 'codecrafters-frontend/components/lobbyside-widget';
+import { module, test } from 'qunit';
+import type UserModel from 'codecrafters-frontend/models/user';
+
+module('Unit | Component | lobbyside-widget', function () {
+  function createUser(overrides: Partial<UserModel> = {}): UserModel {
+    return {
+      createdAt: new Date('2023-04-15T10:30:00.000Z'),
+      isVip: false,
+      activeSubscription: null,
+      hasActiveSubscription: false,
+      teamHasActiveSubscription: false,
+      courseParticipations: [],
+      ...overrides,
+    } as unknown as UserModel;
+  }
+
+  test('returns empty fields for a missing user', function (assert) {
+    assert.deepEqual(lobbysideCustomFields(null), {
+      stages_completed: '0',
+      signed_up_date: '',
+      subscription_type: '',
+    });
+  });
+
+  test('formats signed_up_date as an ISO calendar date', function (assert) {
+    const user = createUser({ createdAt: new Date('2023-04-15T10:30:00.000Z') });
+
+    assert.strictEqual(lobbysideCustomFields(user).signed_up_date, '2023-04-15');
+  });
+
+  test('sums completed stage slugs across all course participations', function (assert) {
+    const user = createUser({
+      courseParticipations: [{ completedStageSlugs: ['s1', 's2', 's3'] }, { completedStageSlugs: ['s1'] }, { completedStageSlugs: [] }],
+    } as unknown as Partial<UserModel>);
+
+    assert.strictEqual(lobbysideCustomFields(user).stages_completed, '4');
+  });
+
+  test('subscription_type prefers lifetime over every other signal', function (assert) {
+    const user = createUser({
+      isVip: true,
+      hasActiveSubscription: true,
+      teamHasActiveSubscription: true,
+      activeSubscription: { isLifetimeMembership: true } as UserModel['activeSubscription'],
+    });
+
+    assert.strictEqual(lobbysideCustomFields(user).subscription_type, 'lifetime');
+  });
+
+  test('subscription_type falls back through individual, team, vip, then free', function (assert) {
+    assert.strictEqual(lobbysideCustomFields(createUser({ hasActiveSubscription: true })).subscription_type, 'individual');
+
+    assert.strictEqual(lobbysideCustomFields(createUser({ teamHasActiveSubscription: true })).subscription_type, 'team');
+
+    assert.strictEqual(lobbysideCustomFields(createUser({ isVip: true })).subscription_type, 'vip');
+
+    assert.strictEqual(lobbysideCustomFields(createUser()).subscription_type, 'free');
+  });
+});


### PR DESCRIPTION
## Summary

Surfaces host-pushed custom columns on the Lobbyside live-visitor table for CodeCrafters, validating the new custom-values feature end-to-end in prod. The widget already encrypts any non-reserved `setVisitor` key into a custom column on the dashboard; this wires three derived fields through `LobbysideWidgetComponent.syncVisitorData`:

- **`signed_up_date`** — `user.createdAt` as an ISO calendar date (`YYYY-MM-DD`).
- **`subscription_type`** — derived label with precedence `lifetime → individual → team → vip → free`.
- **`stages_completed`** — sum of `completedStageSlugs` across the user's course participations.

`stages_completed` needs `course-participations` on the current-user payload (it wasn't in the include), so it's added to `syncCurrentUser`'s `includedResources` (one flat collection, no nested expansion). The derivation is extracted into a pure, unit-tested `lobbysideCustomFields` helper, and the three fields are tracked in the `did-update` deps so a late-hydrating subscription/participation re-syncs the visitor stash.

## Test plan

- [ ] `bun run lint` is green (eslint / tsc / glint / prettier / template-lint all pass locally).
- [ ] Run the unit suite in-browser: `http://localhost:4200/tests?filter=lobbyside-widget` — covers signup-date formatting, stage-slug summing, and subscription_type precedence/fallback.
- [ ] Existing integration tests for the widget mount still pass (null-safe getters with the staff stub).
- [ ] Live check: log in on prod, open the CodeCrafters Lobbyside dashboard live table, confirm `signed_up_date`, `subscription_type`, and `stages_completed` appear as columns + in the detail drawer, and that values render decrypted/correct.

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Third-party widget enrichment and a small addition to the current-user include list; no auth or payment logic changes.
> 
> **Overview**
> **Lobbyside live-visitor sync** now sends three extra custom columns through `setVisitor`: **`signed_up_date`** (ISO date from `createdAt`), **`subscription_type`** (precedence `lifetime → individual → team → vip → free`), and **`stages_completed`** (total count of completed stage slugs across participations).
> 
> The values are computed in a new pure **`lobbysideCustomFields`** helper (with unit tests) and merged in **`syncVisitorData`**. The template **`did-update`** deps include each custom field so late-hydrating user/subscription/participation data triggers a re-sync. **`syncCurrentUser`** now includes **`course-participations`** in the current-user payload so stage counts are available when the widget runs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1b3a193243522ae221a51dcccd46b1deea4a144c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->