### PR TITLE
Revert "Push non-primary emails to Lobbyside (other_emails column)"

### DIFF
--- a/app/components/lobbyside-widget/index.hbs
+++ b/app/components/lobbyside-widget/index.hbs
@@ -25,7 +25,6 @@
       this.customFields.stages_completed
       this.customFields.signed_up_date
       this.customFields.subscription_type
-      this.customFields.other_emails
     }}
     {{will-destroy this.removeScript}}
   ></div>

--- a/app/components/lobbyside-widget/index.ts
+++ b/app/components/lobbyside-widget/index.ts
@@ -15,7 +15,6 @@ declare global {
         stages_completed: string;
         signed_up_date: string;
         subscription_type: string;
-        other_emails: string;
       }): void;
     };
   }
@@ -31,15 +30,12 @@ interface VisitorSource {
   hasActiveSubscription?: boolean;
   teamHasActiveSubscription?: boolean;
   courseParticipations?: { completedStageSlugs?: string[] }[];
-  primaryEmailAddress?: string | null;
-  emailAddresses?: { value?: string | null }[];
 }
 
 export interface LobbysideCustomFields {
   stages_completed: string;
   signed_up_date: string;
   subscription_type: string;
-  other_emails: string;
 }
 
 function subscriptionType(user: VisitorSource | null | undefined): string {
@@ -66,21 +62,6 @@ function subscriptionType(user: VisitorSource | null | undefined): string {
   return 'free';
 }
 
-function otherEmails(user: VisitorSource | null | undefined): string {
-  const primary = (user?.primaryEmailAddress ?? '').trim();
-  const seen = new Set<string>();
-
-  for (const entry of user?.emailAddresses ?? []) {
-    const value = (entry?.value ?? '').trim();
-
-    if (value && value !== primary) {
-      seen.add(value);
-    }
-  }
-
-  return Array.from(seen).join(', ');
-}
-
 export function lobbysideCustomFields(user: VisitorSource | null | undefined): LobbysideCustomFields {
   const stagesCompleted = (user?.courseParticipations ?? []).reduce(
     (sum, participation) => sum + (participation.completedStageSlugs?.length ?? 0),
@@ -91,7 +72,6 @@ export function lobbysideCustomFields(user: VisitorSource | null | undefined): L
     stages_completed: String(stagesCompleted),
     signed_up_date: user?.createdAt ? user.createdAt.toISOString().slice(0, 10) : '',
     subscription_type: subscriptionType(user),
-    other_emails: otherEmails(user),
   };
 }
 

--- a/app/services/authenticator.ts
+++ b/app/services/authenticator.ts
@@ -118,8 +118,6 @@ export default class AuthenticatorService extends Service {
       'affiliate-links.user',
       // Powers the `stages_completed` field the Lobbyside widget pushes via setVisitor.
       'course-participations',
-      // Powers the `other_emails` field the Lobbyside widget pushes via setVisitor.
-      'email-addresses',
       'feature-suggestions',
       'promotional-discounts',
       'promotional-discounts.affiliate-referral',

--- a/tests/unit/components/lobbyside-widget-test.ts
+++ b/tests/unit/components/lobbyside-widget-test.ts
@@ -20,7 +20,6 @@ module('Unit | Component | lobbyside-widget', function () {
       stages_completed: '0',
       signed_up_date: '',
       subscription_type: '',
-      other_emails: '',
     });
   });
 
@@ -57,38 +56,5 @@ module('Unit | Component | lobbyside-widget', function () {
     assert.strictEqual(lobbysideCustomFields(createUser({ isVip: true })).subscription_type, 'vip');
 
     assert.strictEqual(lobbysideCustomFields(createUser()).subscription_type, 'free');
-  });
-
-  test('other_emails joins every non-primary email, comma-separated', function (assert) {
-    const user = createUser({
-      primaryEmailAddress: 'primary@example.com',
-      emailAddresses: [{ value: 'primary@example.com' }, { value: 'work@example.com' }, { value: 'school@example.com' }],
-    } as unknown as Partial<UserModel>);
-
-    assert.strictEqual(lobbysideCustomFields(user).other_emails, 'work@example.com, school@example.com');
-  });
-
-  test('other_emails excludes the primary email and is empty when it is the only one', function (assert) {
-    const user = createUser({
-      primaryEmailAddress: 'primary@example.com',
-      emailAddresses: [{ value: 'primary@example.com' }],
-    } as unknown as Partial<UserModel>);
-
-    assert.strictEqual(lobbysideCustomFields(user).other_emails, '');
-  });
-
-  test('other_emails dedupes and drops blank values', function (assert) {
-    const user = createUser({
-      primaryEmailAddress: 'primary@example.com',
-      emailAddresses: [{ value: 'work@example.com' }, { value: '  work@example.com  ' }, { value: '' }, { value: 'alt@example.com' }],
-    } as unknown as Partial<UserModel>);
-
-    assert.strictEqual(lobbysideCustomFields(user).other_emails, 'work@example.com, alt@example.com');
-  });
-
-  test('other_emails is empty when the user has no email addresses', function (assert) {
-    const user = createUser({ primaryEmailAddress: 'primary@example.com', emailAddresses: [] } as unknown as Partial<UserModel>);
-
-    assert.strictEqual(lobbysideCustomFields(user).other_emails, '');
   });
 });


### PR DESCRIPTION
Reverts codecrafters-io/frontend#3869

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped revert of third-party visitor metadata; reduces email data sent to Lobbyside with no auth or core app logic changes.
> 
> **Overview**
> Reverts the Lobbyside integration change that sent **non-primary user emails** to the widget via an `other_emails` custom field.
> 
> The widget no longer derives or pushes `other_emails`: `lobbysideCustomFields` and `setVisitor` only include `stages_completed`, `signed_up_date`, and `subscription_type`. The template’s `{{did-update}}` deps no longer watch that field. **`authenticator.syncCurrentUser`** no longer sideloads `email-addresses`, since it was only needed for that column. Related unit tests for `other_emails` formatting are removed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4145ab88223c8184349d2433f1d5b51eaa910252. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->