### PR TITLE
Update Vercel redirects for maintenance and 404 pages

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -2,6 +2,11 @@
   "buildCommand": "scripts/build-vercel-output.sh",
   "installCommand": "bun install --frozen-lockfile --ignore-scripts",
   "redirects": [
+    {
+      "source": "/(.*)",
+      "destination": "https://buildyourownx.com/heroku_pages/maintenance.html",
+      "permanent": false
+    },
     { "source": "/_empty.html", "destination": "/404" },
     { "source": "/_empty_notags.html", "destination": "/404" },
     { "source": "/package.json", "destination": "/404" },


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **High Risk**
> Site-wide traffic routing change that effectively takes the entire frontend offline for users until reverted; misconfiguration or wrong destination URL would block all access.
> 
> **Overview**
> Turns on **maintenance mode** for the Vercel frontend by adding a **first** redirect rule that sends **all paths** (`/(.*)`) to a static maintenance page at `https://buildyourownx.com/heroku_pages/maintenance.html` with a **temporary** (non-permanent) redirect.
> 
> Because this rule is ordered before existing redirects (404 guards, `/` → `/catalog`, backend proxy paths, etc.), **every request** should hit the maintenance page until the rule is removed—matching the repo’s maintenance-mode workflow of placing the catch-all at the top of `redirects`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a202658dad7b0464c8a07aead073ba25c16ba489. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->