### PR TITLE
Update Vercel redirects to include maintenance page and handle empty routes.

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -2,11 +2,6 @@
   "buildCommand": "scripts/build-vercel-output.sh",
   "installCommand": "bun install --frozen-lockfile --ignore-scripts",
   "redirects": [
-    {
-      "source": "/(.*)",
-      "destination": "https://buildyourownx.com/heroku_pages/maintenance.html",
-      "permanent": false
-    },
     { "source": "/_empty.html", "destination": "/404" },
     { "source": "/_empty_notags.html", "destination": "/404" },
     { "source": "/package.json", "destination": "/404" },


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Single redirect rule removal in deployment config; restores standard traffic flow with no auth or data changes.
> 
> **Overview**
> **Removes the site-wide maintenance redirect** from `vercel.json` so requests are no longer sent to the static maintenance page at `buildyourownx.com/heroku_pages/maintenance.html`.
> 
> Traffic again follows the remaining redirect rules (e.g. `/` → `/catalog`) and the existing rewrite chain, including the catch-all rewrite to `/_empty.html`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fb62f779ed876eac1a4ad09bad301293107309bf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->